### PR TITLE
use `float('-inf')` instead of `math.inf` (py3+ support only)

### DIFF
--- a/onmt/modules/GlobalAttention.py
+++ b/onmt/modules/GlobalAttention.py
@@ -47,7 +47,7 @@ class GlobalAttention(nn.Module):
         # Get attention
         attn = torch.bmm(context, targetT).squeeze(2)  # batch x sourceL
         if self.mask is not None:
-            attn.data.masked_fill_(self.mask, -math.inf)
+            attn.data.masked_fill_(self.mask, float('-inf'))
         attn = self.sm(attn)
         attn3 = attn.view(attn.size(0), 1, attn.size(1))  # batch x 1 x sourceL
 

--- a/translate.py
+++ b/translate.py
@@ -94,7 +94,7 @@ def main():
                 if opt.n_best > 1:
                     print('\nBEST HYP:')
                     for n in range(opt.n_best):
-                        print("[%.4f] %s" % (predScore[b][n], " ".join(predBatch[b][0])))
+                        print("[%.4f] %s" % (predScore[b][n], " ".join(predBatch[b][n])))
 
                 print('')
 


### PR DESCRIPTION
It is better to use `float('-inf')` instead of `math.inf` since `math.inf` is only supported in python 3+.

Python 2.7 throws the error `AttributeError: 'module' object has no attribute 'inf'` at `attn.data.masked_fill_(self.mask, -math.inf)` line. 

Also in `translate.py` file `predBatch[b][0]` should be `predBatch[b][n]` instead to print the nth best sequence.