### PR TITLE
Update Translator.py

### DIFF
--- a/onmt/Translator.py
+++ b/onmt/Translator.py
@@ -189,8 +189,7 @@ class Translator(object):
         #  (1) convert words to indexes
         dataset = self.buildData(srcBatch, goldBatch)
         batch = dataset[0]
-        batch = [x.transpose(0, 1) for x in batch]
-
+        batch = [x.transpose(0, 1) if x is not None else None for x in batch]
         #  (2) translate
         pred, predScore, attn, goldScore = self.translateBatch(batch)
 


### PR DESCRIPTION
fix bug occurs if tgt argument not specify in translating.

The bug looks like this:

```
Traceback (most recent call last):
  File "translate.py", line 116, in <module>
    main()
  File "translate.py", line 77, in main
    predBatch, predScore, goldScore = translator.translate(srcBatch, tgtBatch)
  File "/Users/wangqian/OpenNMT-py/onmt/Translator.py", line 192, in translate
    batch = [x.transpose(0, 1) for x in batch]
  File "/Users/wangqian/OpenNMT-py/onmt/Translator.py", line 192, in <listcomp>
    batch = [x.transpose(0, 1) for x in batch]
AttributeError: 'NoneType' object has no attribute 'transpose'
```