### PR TITLE
Fix a bug of missing arg type

### DIFF
--- a/translate.py
+++ b/translate.py
@@ -20,7 +20,7 @@ parser.add_argument('-beam_size',  type=int, default=5,
                     help='Beam size')
 parser.add_argument('-batch_size', type=int, default=30,
                     help='Batch size')
-parser.add_argument('-max_sent_length', default=100,
+parser.add_argument('-max_sent_length', type=int, default=100,
                     help='Maximum sentence length.')
 parser.add_argument('-replace_unk', action="store_true",
                     help="""Replace the generated UNK tokens with the source


### PR DESCRIPTION
Hi, 
When I tried running `translate.py` with a specified `-max_sent_length` parameter,
I found that it fails because the argument type is not specified (and considered as str).

E.g., 

```
$ python translate.py ...(other parameters)... -max_sent_length 30 ...
Traceback (most recent call last):
  File "translate.py", line 135, in <module>
    main()
  File "translate.py", line 89, in main
    predBatch, predScore, goldScore = translator.translate(srcBatch, tgtBatch)
  File "/Users/sotetsuk/github/OpenNMT-py/onmt/Translator.py", line 197, in translate
    pred, predScore, attn, goldScore = self.translateBatch(src, tgt)
  File "/Users/sotetsuk/github/OpenNMT-py/onmt/Translator.py", line 117, in translateBatch
    for i in range(self.opt.max_sent_length):
TypeError: 'str' object cannot be interpreted as an integer
```