### PR TITLE
Fix DataParallel with variable lengths

### DIFF
--- a/onmt/Dataset.py
+++ b/onmt/Dataset.py
@@ -68,6 +68,10 @@ class Dataset(object):
             b = Variable(b, volatile=self.volatile)
             return b
 
+        # wrap lengths in a Variable to properly split it in DataParallel
+        lengths = torch.LongTensor(lengths).view(1, -1)
+        lengths = Variable(lengths, volatile=self.volatile)
+
         return (wrap(srcBatch), lengths), wrap(tgtBatch), indices
 
     def __len__(self):

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -30,7 +30,8 @@ class Encoder(nn.Module):
 
     def forward(self, input, hidden=None):
         if isinstance(input, tuple):
-            emb = pack(self.word_lut(input[0]), input[1])
+            lengths = input[1].data.view(-1).tolist() # lengths data is wrapped inside a Variable
+            emb = pack(self.word_lut(input[0]), lengths)
         else:
             emb = self.word_lut(input)
         outputs, hidden_t = self.rnn(emb, hidden)

--- a/train.py
+++ b/train.py
@@ -209,7 +209,7 @@ def trainModel(model, trainData, validData, dataset, optim):
             report_loss += loss
             report_num_correct += num_correct
             report_tgt_words += num_words
-            report_src_words += sum(batch[0][1])
+            report_src_words += batch[0][1].data.sum()
             total_loss += loss
             total_num_correct += num_correct
             total_words += num_words


### PR DESCRIPTION
`DataParallel` splits input `Variable`s alongside the second dimension but the lengths metadata was a plain Python list, thus throwing an error. This PR temporarily make the lengths array a 2D `Variable`, like the actual input.

Fixes #34 and #28.