### PR TITLE
ignore empty lines in preprocess.py

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -105,17 +105,15 @@ def makeData(srcFile, tgtFile, srcDicts, tgtDicts):
         sline = srcF.readline().strip()
         tline = tgtF.readline().strip()
 
+        if sline == "" and tline == "":
+            break
+
         if sline == "" or tline == "":
             print('WARNING: ignoring an empty line')
             continue
 
-        srcWords = srcF.readline().split()
-        tgtWords = tgtF.readline().split()
-
-        if not srcWords or not tgtWords:
-            if srcWords and not tgtWords or not srcWords and tgtWords:
-                print('WARNING: source and target do not have the same number of sentences')
-            break
+        srcWords = sline.split()
+        tgtWords = tline.split()
 
         if len(srcWords) <= opt.seq_length and len(tgtWords) <= opt.seq_length:
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -102,6 +102,13 @@ def makeData(srcFile, tgtFile, srcDicts, tgtDicts):
     tgtF = open(tgtFile)
 
     while True:
+        sline = srcF.readline().strip()
+        tline = tgtF.readline().strip()
+
+        if sline == "" or tline == "":
+            print('WARNING: ignoring an empty line')
+            continue
+
         srcWords = srcF.readline().split()
         tgtWords = tgtF.readline().split()
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -105,9 +105,11 @@ def makeData(srcFile, tgtFile, srcDicts, tgtDicts):
         sline = srcF.readline()
         tline = tgtF.readline()
 
+        # normal end of file
         if sline == "" and tline == "":
             break
 
+        # source or target does not have same number of lines
         if sline == "" or tline == "":
             print('WARNING: source and target do not have the same number of sentences')
             break
@@ -115,8 +117,9 @@ def makeData(srcFile, tgtFile, srcDicts, tgtDicts):
         sline = sline.strip()
         tline = tline.strip()
 
+        # source and/or target are empty
         if sline == "" or tline == "":
-            print('WARNING: ignoring an empty line ('+str(count)+')')
+            print('WARNING: ignoring an empty line ('+str(count+1)+')')
             continue
 
         srcWords = sline.split()

--- a/preprocess.py
+++ b/preprocess.py
@@ -102,14 +102,21 @@ def makeData(srcFile, tgtFile, srcDicts, tgtDicts):
     tgtF = open(tgtFile)
 
     while True:
-        sline = srcF.readline().strip()
-        tline = tgtF.readline().strip()
+        sline = srcF.readline()
+        tline = tgtF.readline()
 
         if sline == "" and tline == "":
             break
 
         if sline == "" or tline == "":
-            print('WARNING: ignoring an empty line')
+            print('WARNING: source and target do not have the same number of sentences')
+            break
+
+        sline = sline.strip()
+        tline = tline.strip()
+
+        if sline == "" or tline == "":
+            print('WARNING: ignoring an empty line ('+str(count)+')')
             continue
 
         srcWords = sline.split()


### PR DESCRIPTION
when there's an empty line on either side of the parallel corpus, preprocess.py ignores any line from thereon with only a warning message. this pr makes preprocess.py effectively ignore any line in which either source or target side is empty.