### PR TITLE
optim function expects perplexity

### DIFF
--- a/train.py
+++ b/train.py
@@ -243,7 +243,7 @@ def trainModel(model, trainData, validData, dataset, optim):
         print('Validation accuracy: %g' % (valid_acc*100))
 
         #  (3) update the learning rate
-        optim.updateLearningRate(valid_loss, epoch)
+        optim.updateLearningRate(valid_ppl, epoch)
 
         model_state_dict = model.module.state_dict() if len(opt.gpus) > 1 else model.state_dict()
         model_state_dict = {k: v for k, v in model_state_dict.items() if 'generator' not in k}


### PR DESCRIPTION
it's a trivial thing but the optimiser function appears to be documented around using perplexity instead of loss and the input in this line is loss and not perplexity