### PR TITLE
attempt to fix #86

### DIFF
--- a/onmt/modules/StackedRNN.py
+++ b/onmt/modules/StackedRNN.py
@@ -47,14 +47,18 @@ class StackedGRU(nn.Module):
             input_size = rnn_size
 
     def forward(self, input, hidden):
+        h_0 = hidden[0]
         h_1 = []
         for i, layer in enumerate(self.layers):
-            h_1_i = layer(input, hidden[i])
+            if len(h_0.size()) == 3:
+                h_0_i = h_0[i]
+            else:
+                h_0_i = h_0
+            h_1_i = layer(input, h_0_i)
             input = h_1_i
             if i + 1 != self.num_layers:
                 input = self.dropout(input)
             h_1 += [h_1_i]
 
         h_1 = torch.stack(h_1)
-
         return input, h_1


### PR DESCRIPTION
@mattiadg can you test this?

i got the similar error and and the following patch seems fix the problem.

```bash

	$ python train.py -log_interval 100 -context_gate both -optim adam -learning_rate 0.0001 -data data/demo.train.pt -epochs=1 -rnn_size 100 -word_vec_size 100 -optim adam -learning_rate 0.00001 -brnn -rnn_type GRU

	Namespace(batch_size=64, brnn=True, brnn_merge='concat', context_gate='both', copy_attn=False, coverage_attn=False, curriculum=False, data='data/demo.train.pt', decay_method='', decoder_layer='rnn', dropout=0.3, encoder_layer='rnn', encoder_type='text', epochs=1, experiment_name='', extra_shuffle=False, feature_vec_size=100, gpus=[], input_feed=1, lambda_coverage=1, layers=2, learning_rate=1e-05, learning_rate_decay=0.5, log_interval=100, log_server='', max_generator_batches=32, max_grad_norm=5, optim='adam', param_init=0.1, position_encoding=False, pre_word_vecs_dec=None, pre_word_vecs_enc=None, rnn_size=100, rnn_type='GRU', save_model='model', seed=-1, share_decoder_embeddings=False, start_checkpoint_at=0, start_decay_at=8, start_epoch=1, train_from='', train_from_state_dict='', truncated_decoder=0, warmup_steps=4000, word_vec_size=100)
	Loading data from 'data/demo.train.pt'
	 * vocabulary size. source = 24999; target = 35820
	 * number of training sentences. 10000
	 * maximum batch size. 64
	Building model...
	Intializing params
	* number of parameters: 10062520

	Traceback (most recent call last):
	  File "train.py", line 436, in <module>
	    main()
	  File "train.py", line 432, in main
	    trainModel(model, trainData, validData, dataset, optim)
	  File "train.py", line 270, in trainModel
	    train_stats = trainEpoch(epoch)
	  File "train.py", line 242, in trainEpoch
	    dec_state)
	  File "/Users/geovedi/anaconda3/lib/python3.6/site-packages/torch/nn/modules/module.py", line 206, in __call__
	    result = self.forward(*input, **kwargs)
	  File "/Users/geovedi/Documents/Others/github.com/OpenNMT/OpenNMT-py/onmt/Models.py", line 379, in forward
	    else dec_state)
	  File "/Users/geovedi/anaconda3/lib/python3.6/site-packages/torch/nn/modules/module.py", line 206, in __call__
	    result = self.forward(*input, **kwargs)
	  File "/Users/geovedi/Documents/Others/github.com/OpenNMT/OpenNMT-py/onmt/Models.py", line 302, in forward
	    rnn_output, hidden = self.rnn(emb_t, hidden)
	  File "/Users/geovedi/anaconda3/lib/python3.6/site-packages/torch/nn/modules/module.py", line 206, in __call__
	    result = self.forward(*input, **kwargs)
	  File "/Users/geovedi/Documents/Others/github.com/OpenNMT/OpenNMT-py/onmt/modules/StackedRNN.py", line 52, in forward
	    h_1_i = layer(input, hidden[i])
	  File "/Users/geovedi/anaconda3/lib/python3.6/site-packages/torch/nn/modules/module.py", line 206, in __call__
	    result = self.forward(*input, **kwargs)
	  File "/Users/geovedi/anaconda3/lib/python3.6/site-packages/torch/nn/modules/rnn.py", line 568, in forward
	    self.bias_ih, self.bias_hh,
	  File "/Users/geovedi/anaconda3/lib/python3.6/site-packages/torch/nn/_functions/rnn.py", line 54, in GRUCell
	    gh = F.linear(hidden, w_hh, b_hh)
	  File "/Users/geovedi/anaconda3/lib/python3.6/site-packages/torch/nn/functional.py", line 449, in linear
	    return state(input, weight) if bias is None else state(input, weight, bias)
	  File "/Users/geovedi/anaconda3/lib/python3.6/site-packages/torch/nn/_functions/linear.py", line 10, in forward
	    output.addmm_(0, 1, input, weight.t())
	RuntimeError: matrices expected, got 3D, 2D tensors at /Users/soumith/miniconda2/conda-bld/pytorch_1493757603856/work/torch/lib/TH/generic/THTensorMath.c:1232
```