### PR TITLE
Fix a bug in attention dimension with MLP attention

### DIFF
--- a/translate.py
+++ b/translate.py
@@ -116,9 +116,14 @@ def main():
 
         for b in range(len(predBatch)):
             count += 1
-            #outF.write(" ".join([i.decode('utf-8')
-            #                     for i in predBatch[b][0]]) + '\n')
-            outF.write(" ".join(predBatch[b][0]) + '\n') # can't do .decode on a str object
+            # a temporary fix at least
+            try:
+                # python2
+                outF.write(" ".join([i.decode('utf-8')
+                                 for i in predBatch[b][0]]) + '\n')
+            except AttributeError:
+                # python3: can't do .decode on a str object
+                outF.write(" ".join(predBatch[b][0]) + '\n')
             outF.flush()
 
             if opt.verbose:

--- a/translate.py
+++ b/translate.py
@@ -116,8 +116,9 @@ def main():
 
         for b in range(len(predBatch)):
             count += 1
-            outF.write(" ".join([i.decode('utf-8')
-                                 for i in predBatch[b][0]]) + '\n')
+            #outF.write(" ".join([i.decode('utf-8')
+            #                     for i in predBatch[b][0]]) + '\n')
+            outF.write(" ".join(predBatch[b][0]) + '\n') # can't do .decode on a str object
             outF.flush()
 
             if opt.verbose:


### PR DESCRIPTION
The BottleLinear transformation applied in MLP attention adds an extra singleton dimension that should be removed. The previous solution was to squeeze the resulting tensor. However, this squeezing will also remove the source length dimension if the the source length was 1; therefore, I changed squeeze to only remove the dimension 2, which I believe is the intended behavior.

I also added a fix for the string-decoding thing in translate.py that broke translation for python3 users. This is not a permanent fix as I am not aware of all the encoding issues facing python2 folks; I just wanted it to stop crashing when I was using it in python3.