### PR TITLE
Add distinct options for general and dotprod attention

### DIFF
--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -28,7 +28,7 @@ class Embeddings(nn.Module):
         self.dropout = nn.Dropout(p=opt.dropout)
         self.feature_dicts = feature_dicts
         # Feature embeddings.
-        if self.feature_dicts is not None:
+        if self.feature_dicts:
             self.feature_luts = nn.ModuleList([
                 nn.Embedding(feature_dict.size(),
                              opt.feature_vec_size,
@@ -69,7 +69,7 @@ class Embeddings(nn.Module):
         """
         word = self.word_lut(src_input[:, :, 0])
         emb = word
-        if self.feature_dicts is not None:
+        if self.feature_dicts:
             features = [feature_lut(src_input[:, :, j+1])
                         for j, feature_lut in enumerate(self.feature_luts)]
 

--- a/onmt/modules/GlobalAttention.py
+++ b/onmt/modules/GlobalAttention.py
@@ -118,7 +118,7 @@ class GlobalAttention(nn.Module):
         a_t = self.score(input, context)
         
         if self.mask is not None:
-            attention_scores.data.masked_fill_(self.mask, -float('inf'))
+            a_t.data.masked_fill_(self.mask, -float('inf'))
             
         # Softmax to normalize attention weights 
         align_vector = self.sm(a_t)

--- a/onmt/modules/GlobalAttention.py
+++ b/onmt/modules/GlobalAttention.py
@@ -38,7 +38,7 @@ class GlobalAttention(nn.Module):
     $$a_j = softmax(v_a^T \tanh(W_a q + U_a h_j) )$$.
 
     """
-    def __init__(self, dim, coverage=False, attn_type="dotprod"):
+    def __init__(self, dim, coverage=False, attn_type="dot"):
         super(GlobalAttention, self).__init__()
 
         self.dim = dim

--- a/onmt/modules/GlobalAttention.py
+++ b/onmt/modules/GlobalAttention.py
@@ -80,7 +80,7 @@ class GlobalAttention(nn.Module):
             aeq(batch, batch_)
             aeq(sourceL, sourceL_)
 
-        if self.mask:
+        if self.mask is not None:
             beam_, batch_, sourceL_ = self.mask.size()
             aeq(batch, batch_*beam_)
             aeq(sourceL, sourceL_)

--- a/onmt/modules/GlobalAttention.py
+++ b/onmt/modules/GlobalAttention.py
@@ -39,36 +39,60 @@ class GlobalAttention(nn.Module):
 
         self.dim = dim
         self.attn_type = attn_type
-        assert (self.attn_type in ["dotprod", "mlp"]), (
+        assert (self.attn_type in ["dotprod", "general", "mlp"]), (
                 "Please select a valid attention type.")
-
-        if self.attn_type == "dotprod":
+                
+        if self.attn_type == "general":
             self.linear_in = nn.Linear(dim, dim, bias=False)
-            self.linear_out = nn.Linear(dim*2, dim, bias=False)
-        elif self.attn_type == "mlp":
+        elif self.attn_type == 'mlp':
             self.linear_context = BottleLinear(dim, dim, bias=False)
             self.linear_query = nn.Linear(dim, dim, bias=True)
-            self.mlp_tanh = nn.Tanh()
             self.v = BottleLinear(dim, 1, bias=False)
-            self.linear_out = nn.Linear(dim*2, dim, bias=True)
+        out_bias = self.attn_type == 'mlp' # mlp wants it with bias
+        self.linear_out = nn.Linear(dim*2, dim, bias=out_bias)
 
         self.sm = nn.Softmax()
         self.tanh = nn.Tanh()
         self.mask = None
-
+                                
         if coverage:
             self.linear_cover = nn.Linear(1, dim, bias=False)
 
     def applyMask(self, mask):
         self.mask = mask
+        
+    def score(self, h_t, h_s):
+        """
+        h_t (FloatTensor): batch x dim
+        h_s (FloatTensor): batch x src_len x dim
+        returns scores (FloatTensor): batch x src_len:
+            raw attention scores for each src index
+        """
+        
+        if self.attn_type in ["general", "dotprod"]:
+            if self.attn_type == "general":
+                h_t = self.linear_in(h_t)
+            return torch.bmm(h_s, h_t.unsqueeze(2)).squeeze(2)
+        else:
+            # MLP
+            # batch x 1 x dim
+            wq = self.linear_query(h_t).unsqueeze(1)
+            # batch x src_len x dim
+            uh = self.linear_context(h_s.contiguous())
+            # batch x src_len x dim
+            wquh = uh + wq.expand_as(uh)
+            # batch x src_len x dim
+            wquh = self.tanh(wquh)
+            # batch x src_len
+            return self.v(wquh.contiguous()).squeeze(2)
 
     def forward(self, input, context, coverage=None):
         """
-        input (FloatTensor): batch x dim
-        context (FloatTensor): batch x sourceL x dim
-        coverage (FloatTensor): batch x sourceL
+        input (FloatTensor): batch x dim: decoder's rnn's output.
+        context (FloatTensor): batch x src_len x dim: src hidden states
+        coverage (FloatTensor): batch x src_len
         """
-
+        
         # Check input sizes
         batch, sourceL, dim = context.size()
         batch_, dim_ = input.size()
@@ -84,54 +108,36 @@ class GlobalAttention(nn.Module):
             beam_, batch_, sourceL_ = self.mask.size()
             aeq(batch, batch_*beam_)
             aeq(sourceL, sourceL_)
-
+            
         if coverage is not None:
-            context += self.linear_cover(coverage.view(-1).unsqueeze(1)) \
-                           .view_as(context)
+            cover = coverage.view(-1).unsqueeze(1)
+            context += self.linear_cover(cover).view_as(context)
             context = self.tanh(context)
-
-        # Alignment/Attention Function
-        if self.attn_type == "dotprod":
-            # batch x dim x 1
-            targetT = self.linear_in(input).unsqueeze(2)
-            # batch x sourceL
-            attn = torch.bmm(context, targetT).squeeze(2)
-        elif self.attn_type == "mlp":
-            # batch x 1 x dim
-            wq = self.linear_query(input).unsqueeze(1)
-            # batch x sourceL x dim
-            uh = self.linear_context(context.contiguous())
-            # batch x sourceL x dim
-            wquh = uh + wq.expand_as(uh)
-            # batch x sourceL x dim
-            wquh = self.mlp_tanh(wquh)
-            # batch x sourceL
-            attn = self.v(wquh.contiguous()).squeeze(2)
-
+        
+        # compute attention scores, as in Luong et al.
+        a_t = self.score(input, context)
+        
         if self.mask is not None:
-            attn.data.masked_fill_(self.mask, -float('inf'))
-
-        # SoftMax
-        attn = self.sm(attn)
-
-        # Compute context weighted by attention.
-        # batch x 1 x sourceL
-        attn3 = attn.view(attn.size(0), 1, attn.size(1))
-        # batch x dim
-        weightedContext = torch.bmm(attn3, context).squeeze(1)
-
-        # Concatenate the input to context (Luong only)
-        weightedContext = torch.cat((weightedContext, input), 1)
-        weightedContext = self.linear_out(weightedContext)
-        if self.attn_type == "dotprod":
-            weightedContext = self.tanh(weightedContext)
+            attention_scores.data.masked_fill_(self.mask, -float('inf'))
+            
+        # Softmax to normalize attention weights 
+        align_vector = self.sm(a_t)
+        
+        # the context vector c_t is the weighted average
+        # over all the source hidden states
+        c_t = torch.bmm(align_vector.unsqueeze(1), context).squeeze(1)
+        
+        # concatenate 
+        attn_h_t = self.linear_out(torch.cat([c_t, input], 1))
+        if self.attn_type in ["general", "dotprod"]:
+            attn_h_t = self.tanh(attn_h_t)
 
         # Check output sizes
-        batch_, sourceL_ = attn.size()
+        batch_, sourceL_ = align_vector.size()
         aeq(batch, batch_)
         aeq(sourceL, sourceL_)
-        batch_, dim_ = weightedContext.size()
+        batch_, dim_ = attn_h_t.size()
         aeq(batch, batch_)
         aeq(dim, dim_)
 
-        return weightedContext, attn
+        return attn_h_t, align_vector

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -47,8 +47,8 @@ parser.add_argument('-context_gate', type=str, default=None,
                     choices=['source', 'target', 'both'],
                     help="""Type of context gate to use [source|target|both].
                     Do not select for no context gate.""")
-parser.add_argument('-attention_type', type=str, default='dotprod',
-                    choices=['dotprod', 'mlp'],
+parser.add_argument('-attention_type', type=str, default='dot',
+                    choices=['dot', 'general', 'mlp'],
                     help="""The attention type to use:
                     dotprot (Luong) or MLP (Bahdanau)""")
 

--- a/train.py
+++ b/train.py
@@ -69,7 +69,7 @@ parser.add_argument('-context_gate', type=str, default=None,
                     help="""Type of context gate to use [source|target|both].
                     Do not select for no context gate.""")
 parser.add_argument('-attention_type', type=str, default='general',
-                    choices=['dotprod', 'general', 'mlp'],
+                    choices=['dot', 'general', 'mlp'],
                     help="""The attention type to use:
                     dotprot or general (Luong) or MLP (Bahdanau)""")
 
@@ -432,6 +432,17 @@ def main():
 
     nParams = sum([p.nelement() for p in model.parameters()])
     print('* number of parameters: %d' % nParams)
+    enc = 0
+    dec = 0
+    for name, param in model.named_parameters():
+        if 'encoder' in name:
+            enc += param.nelement()
+        elif 'decoder' in name:
+            dec += param.nelement()
+        else:
+            print(name, param.nelement())
+    print('encoder: ', enc)
+    print('decoder: ', dec)
 
     trainModel(model, trainData, validData, dataset, optim)
 

--- a/train.py
+++ b/train.py
@@ -68,10 +68,10 @@ parser.add_argument('-context_gate', type=str, default=None,
                     choices=['source', 'target', 'both'],
                     help="""Type of context gate to use [source|target|both].
                     Do not select for no context gate.""")
-parser.add_argument('-attention_type', type=str, default='dotprod',
-                    choices=['dotprod', 'mlp'],
+parser.add_argument('-attention_type', type=str, default='general',
+                    choices=['dotprod', 'general', 'mlp'],
                     help="""The attention type to use:
-                    dotprot (Luong) or MLP (Bahdanau)""")
+                    dotprot or general (Luong) or MLP (Bahdanau)""")
 
 # Optimization options
 parser.add_argument('-encoder_type', default='text',

--- a/train.py
+++ b/train.py
@@ -369,7 +369,7 @@ def main():
             nn.Linear(opt.rnn_size, dicts['tgt'].size()),
             nn.LogSoftmax())
         if opt.share_decoder_embeddings:
-            generator[0].weight = decoder.word_lut.weight
+            generator[0].weight = decoder.embeddings.word_lut.weight
 
     model = onmt.Models.NMTModel(encoder, decoder, len(opt.gpus) > 1)
 

--- a/translate.py
+++ b/translate.py
@@ -9,7 +9,7 @@ import argparse
 import math
 import codecs
 import os
-
+from itertools import zip_longest, repeat
 
 parser = argparse.ArgumentParser(description='translate.py')
 onmt.Markdown.add_md_help_argument(parser)
@@ -21,6 +21,7 @@ parser.add_argument('-src',   required=True,
 parser.add_argument('-src_img_dir',   default="",
                     help='Source image directory')
 parser.add_argument('-tgt',
+                    default=None,
                     help='True target sequence (optional)')
 parser.add_argument('-output', default='pred.txt',
                     help="""Path to output the predictions (each line will
@@ -62,12 +63,22 @@ def reportScore(name, scoreTotal, wordsTotal):
         name, scoreTotal / wordsTotal,
         name, math.exp(-scoreTotal/wordsTotal)))
 
-
-def addone(f):
-    for line in f:
-        yield line
-    yield None
-
+def batchify(lines, batch_size):
+    """
+    cf. https://docs.python.org/3/library/itertools.html#itertools-recipes
+    lines is an iterable, such as the src.test lines
+    """
+    args = [iter(lines)] * batch_size
+    for raw_batch in zip_longest(*args):
+        yield tuple(line for line in raw_batch if line is not None)
+        
+def target_file_or_none(target):
+    """
+    so as to not have to check all the time if the target file exists
+    """
+    if target:
+        return codecs.open(target, 'r', 'utf-8')
+    return repeat(None)
 
 def main():
     opt = parser.parse_args()
@@ -77,11 +88,7 @@ def main():
 
     translator = onmt.Translator(opt)
 
-    outF = codecs.open(opt.output, 'w', 'utf-8')
-
     predScoreTotal, predWordsTotal, goldScoreTotal, goldWordsTotal = 0, 0, 0, 0
-
-    srcBatch, tgtBatch = [], []
 
     count = 0
 
@@ -90,76 +97,66 @@ def main():
     if opt.dump_beam != "":
         import json
         translator.initBeamAccum()
-
-    for line in addone(codecs.open(opt.src, 'r', 'utf-8')):
-        if line is not None:
-            srcTokens = line.split()
-            srcBatch += [srcTokens]
-            if tgtF:
-                tgtTokens = tgtF.readline().split() if tgtF else None
-                tgtBatch += [tgtTokens]
-
-            if len(srcBatch) < opt.batch_size:
-                continue
-        else:
-            # at the end of file, check last batch
-            if len(srcBatch) == 0:
-                break
-
-        predBatch, predScore, goldScore, attn, src \
-            = translator.translate(srcBatch, tgtBatch)
-        predScoreTotal += sum(score[0] for score in predScore)
-        predWordsTotal += sum(len(x[0]) for x in predBatch)
-        if tgtF is not None:
-            goldScoreTotal += sum(goldScore)
-            goldWordsTotal += sum(len(x) for x in tgtBatch)
-
-        for b in range(len(predBatch)):
-            count += 1
-            # a temporary fix at least
-            try:
-                # python2
-                outF.write(" ".join([i.decode('utf-8')
-                                 for i in predBatch[b][0]]) + '\n')
-            except AttributeError:
-                # python3: can't do .decode on a str object
-                outF.write(" ".join(predBatch[b][0]) + '\n')
-            outF.flush()
-
-            if opt.verbose:
-                srcSent = ' '.join(srcBatch[b])
-                if translator.tgt_dict.lower:
-                    srcSent = srcSent.lower()
-                os.write(1, bytes('SENT %d: %s\n' % (count, srcSent), 'UTF-8'))
-                os.write(1, bytes('PRED %d: %s\n' %
-                                  (count, " ".join(predBatch[b][0])), 'UTF-8'))
-                print("PRED SCORE: %.4f" % predScore[b][0])
-
-                if tgtF is not None:
-                    tgtSent = ' '.join(tgtBatch[b])
+        
+    with codecs.open(opt.src, 'r', 'utf-8') as src_test, \
+        codecs.open(opt.output, 'w', 'utf-8') as predicted_out:
+        count = 1
+        for src_batch in batchify(src_test, opt.batch_size):
+            src_batch = [line.split() for line in src_batch]
+            predicted_batch, predicted_scores, gold_scores, attn, src \
+            = translator.translate(src_batch, None)
+            # sort of weird that predicted batch is a list of lists of lists
+            # also sort of weird that predScore is a tuple of singleton Tensors
+            predScoreTotal += sum(score[0] for score in predicted_scores)
+            predWordsTotal += sum(len(x[0]) for x in predicted_batch)
+            # targets: no need right now: simplicity!
+            '''
+            if tgtF is not None:
+                goldScoreTotal += sum(gold_scores)
+                goldWordsTotal += sum(len(x) for x in tgtBatch)
+            '''
+            # 1) print the predicted lines to the outfile
+            # 2) maybe do some extra things if verbose
+            for src_sent, pred_sent, pred_score, gold_score in zip(src_batch, predicted_batch, predicted_scores, gold_scores):
+                pred_sent = pred_sent[0]
+                pred_line = " ".join(pred_sent) # breaking python2 compatibility, maybe
+                predicted_out.write(pred_line + '\n')
+                
+                if opt.verbose:
+                    src_line = " ".join(src_sent)
                     if translator.tgt_dict.lower:
-                        tgtSent = tgtSent.lower()
-                    os.write(1, bytes('GOLD %d: %s\n' %
-                             (count, tgtSent), 'UTF-8'))
-                    print("GOLD SCORE: %.4f" % goldScore[b])
+                        src_line = src_line.lower()
+                    os.write(1, bytes('SENT %d: %s\n' % (count, src_line), 'UTF-8'))
+                    os.write(1, bytes('PRED %d: %s\n' %
+                                      (count, " ".join(pred_sent)), 'UTF-8'))
+                    print("PRED SCORE: %.4f" % pred_score[0])
+                    """
+                    if tgtF is not None:
+                        tgtSent = ' '.join(tgtBatch[b])
+                        if translator.tgt_dict.lower:
+                            tgtSent = tgtSent.lower()
+                        os.write(1, bytes('GOLD %d: %s\n' %
+                                 (count, tgtSent), 'UTF-8'))
+                        print("GOLD SCORE: %.4f" % goldScore[b])
 
-                if opt.n_best > 1:
-                    print('\nBEST HYP:')
-                    for n in range(opt.n_best):
-                        os.write(1, bytes("[%.4f] %s\n" % (predScore[b][n],
-                                 " ".join(predBatch[b][n])),
-                            'UTF-8'))
+                    if opt.n_best > 1:
+                        print('\nBEST HYP:')
+                        for n in range(opt.n_best):
+                            os.write(1, bytes("[%.4f] %s\n" % (predScore[b][n],
+                                     " ".join(pred_batch[n])),
+                                'UTF-8'))
 
-                if opt.attn_debug:
-                    print('')
-                    for i, w in enumerate(predBatch[b][0]):
-                        print(w)
-                        _, ids = attn[b][0][i].sort(0, descending=True)
-                        for j in ids[:5].tolist():
-                            print("\t%s\t%d\t%3f" % (srcTokens[j], j,
-                                                     attn[b][0][i][j]))
-
-        srcBatch, tgtBatch = [], []
+                    if opt.attn_debug:
+                        print('')
+                        for i, w in enumerate(batch[0]):
+                            print(w)
+                            _, ids = attn[b][0][i].sort(0, descending=True)
+                            for j in ids[:5].tolist():
+                                print("\t%s\t%d\t%3f" % (srcTokens[j], j,
+                                                         attn[b][0][i][j]))
+                    """
+                count += 1
+            
 
     reportScore('PRED', predScoreTotal, predWordsTotal)
     if tgtF:

--- a/translate.py
+++ b/translate.py
@@ -173,4 +173,4 @@ def main():
 
 
 if __name__ == "__main__":
-main()
+    main()


### PR DESCRIPTION
The option for dotprod attention in GlobalAttention in fact matched Luong et al.'s specification of general attention. I fixed the naming of these options and added an attention option that corresponds to the dot product method of scoring in the Luong paper. 

I refactored the attention-scoring a little bit so now the batch x source length attention score tensor can be created by a helper score function. If the GlobalAttention class were only concerned with the mechanisms from Luong et al.'s paper, it would be possible to handle all of their attention types simply by subclassing the thing and defining a new score function and layers as necessary. However, the process for MLP has a few different steps later on in forward().