### PR TITLE
Fix batch not matching and alignment in translator

### DIFF
--- a/onmt/Translator.py
+++ b/onmt/Translator.py
@@ -180,10 +180,10 @@ class Translator(object):
                              .contiguous()
                 attn_copy = attn["copy"].view(beamSize, batchSize, -1) \
                                         .transpose(0, 1).contiguous()
-                #attn_copy: batchSize x beamSize x src_len
+                # attn_copy: batchSize x beamSize x src_len
                 out, c_attn_t \
                     = self.model.generator.forward(
-                        decOut, attn_copy.transpose(0, 1).contiguous() \
+                        decOut, attn_copy.transpose(0, 1).contiguous()
                         .view(-1, batch_src.size(0)))
 
                 for b in range(out.size(0)):

--- a/onmt/Translator.py
+++ b/onmt/Translator.py
@@ -188,7 +188,7 @@ class Translator(object):
 
                 for b in range(out.size(0)):
                     for c in range(c_attn_t.size(1)):
-                        v = self.align[words[b // batchSize, c].data[0]]
+                        v = self.align[words[b % batchSize, c].data[0]]
                         if v != onmt.Constants.PAD:
                             out[b, v] += c_attn_t[b, c]
                 out = out.log()


### PR DESCRIPTION
In generator.forward:
decOut: (beamSize*batchSize) x rnn_size 
attn_copy.view(-1, batch_src.size(0)): (batchSize*beamSize) x src_len
