### PR TITLE
Add concatenative feature embeddings

### DIFF
--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -148,7 +148,6 @@ class Encoder(nn.Module):
         self.embeddings = Embeddings(opt, dicts, feature_dicts)
 
         input_size = self.embeddings.embedding_size
-        print(input_size)
 
         # The Encoder RNN.
         self.encoder_layer = opt.encoder_layer

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -34,8 +34,8 @@ class Embeddings(nn.Module):
                 # When concatenating, derive the size of each feature's
                 # embedding from the number of values the embedding
                 # takes
-                feat_sizes = (int(feat_dict.size() ** feat_exp
-                              for feat_dict in feature_dicts))
+                feat_sizes = (int(feat_dict.size() ** feat_exp)
+                              for feat_dict in feature_dicts)
             else:
                 # sum feature merge (for now, the same as the old option
                 # for merging features in OpenNMT-py)

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -16,9 +16,16 @@ parser.add_argument('-rnn_size', type=int, default=500,
                     help='Size of LSTM hidden states')
 parser.add_argument('-word_vec_size', type=int, default=500,
                     help='Word embedding sizes')
-parser.add_argument('-feature_vec_size', type=int, default=100,
+parser.add_argument('-feat_vec_size', type=int, default=100,
                     help='Feature vec sizes')
-
+parser.add_argument('-feat_merge', type=str, default='concat',
+                    choices=['concat', 'sum'],
+                    help='Merge action for the features embeddings')
+parser.add_argument('-feat_vec_exponent', type=float, default=0.7,
+                    help="""When features embedding sizes are not set and
+                    using -feat_merge concat, their dimension will be set
+                    to N^feat_vec_exponent where N is the number of values
+                    the feature takes""")
 parser.add_argument('-input_feed', type=int, default=1,
                     help="""Feed the context vector at each time step as
                     additional input (via concatenation with the word

--- a/train.py
+++ b/train.py
@@ -383,7 +383,7 @@ def main():
             nn.Linear(opt.rnn_size, dicts['tgt'].size()),
             nn.LogSoftmax())
         if opt.share_decoder_embeddings:
-            generator[0].weight = decoder.embeddings.word_lut.weight
+            generator[0].weight = decoder.embeddings.emb_lut[0].weight
 
     model = onmt.Models.NMTModel(encoder, decoder, len(opt.gpus) > 1)
 

--- a/train.py
+++ b/train.py
@@ -39,7 +39,14 @@ parser.add_argument('-word_vec_size', type=int, default=500,
                     help='Word embedding sizes')
 parser.add_argument('-feature_vec_size', type=int, default=100,
                     help='Feature vec sizes')
-
+parser.add_argument('-feat_merge', type=str, default='concat',
+                    choices=['concat', 'sum'],
+                    help='Merge action for the features embeddings')
+parser.add_argument('-feat_vec_exponent', type=float, default=0.7,
+                    help="""When features embedding sizes are not set and
+                    using -feat_merge concat, their dimension will be set
+                    to N^feat_vec_exponent where N is the number of values
+                    the feature takes""")
 parser.add_argument('-input_feed', type=int, default=1,
                     help="""Feed the context vector at each time step as
                     additional input (via concatenation with the word

--- a/train.py
+++ b/train.py
@@ -37,7 +37,7 @@ parser.add_argument('-rnn_size', type=int, default=500,
                     help='Size of LSTM hidden states')
 parser.add_argument('-word_vec_size', type=int, default=500,
                     help='Word embedding sizes')
-parser.add_argument('-feature_vec_size', type=int, default=100,
+parser.add_argument('-feat_vec_size', type=int, default=20,
                     help='Feature vec sizes')
 parser.add_argument('-feat_merge', type=str, default='concat',
                     choices=['concat', 'sum'],
@@ -383,7 +383,7 @@ def main():
             nn.Linear(opt.rnn_size, dicts['tgt'].size()),
             nn.LogSoftmax())
         if opt.share_decoder_embeddings:
-            generator[0].weight = decoder.embeddings.emb_lut[0].weight
+            generator[0].weight = decoder.embeddings.word_lut.weight
 
     model = onmt.Models.NMTModel(encoder, decoder, len(opt.gpus) > 1)
 


### PR DESCRIPTION
This pull request adds support for concatenation of word and feature embeddings. Namely, if you have an x-dimension word embedding and a y-dimensional feature embedding, then these will be concatenated into an (x+y)-dimensional embedding for the encoder. This is the default setting for using features in Lua.

I believe the previous behavior of the embeddings class corresponds to the sum behavior, so I preserved it with the sum option.

 The goal is for the interface to be the same is in Lua OpenNMT. Consequently, the command line interface has been changed slightly to match Lua.

`-feat_merge` accepts concat and sum; the default is concat
`-feat_vec_exponent` defaults to 0.7; it is used to compute size of feature embeddings when using concat
`-feature_vec_size` is now `-feat_vec_size` and its default is 20

While I was at it, I changed the implementation of `make_positional_encodings()` to one with vectorized tensor operations instead of for loops and the built-in math class. It is faster now.