### PR TITLE
Allowing to provide value 0 for no pruning of src and target vocabulary

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -95,7 +95,7 @@ def makeVocabulary(filename, size):
     originalSize = vocab.size()
     if size != 0:
         vocab = vocab.prune(size)
-        print('Created dictionary of size %d (pruned from %d)' % 
+        print('Created dictionary of size %d (pruned from %d)' %
               (vocab.size(), originalSize))
     else:
         print('Created dictionary of size %d' % (vocab.size()))

--- a/preprocess.py
+++ b/preprocess.py
@@ -94,11 +94,11 @@ def makeVocabulary(filename, size):
 
     originalSize = vocab.size()
     if size!=0:
-    	vocab = vocab.prune(size)
-    	print('Created dictionary of size %d (pruned from %d)' %
-          (vocab.size(), originalSize))
+        vocab = vocab.prune(size)
+        print('Created dictionary of size %d (pruned from %d)' %
+            (vocab.size(), originalSize))
     else:
-	print('Created dictionary of size %d' % (vocab.size()))
+        print('Created dictionary of size %d' % (vocab.size()))
 
     return vocab, featuresVocabs
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -98,7 +98,7 @@ def makeVocabulary(filename, size):
     	print('Created dictionary of size %d (pruned from %d)' %
           (vocab.size(), originalSize))
     else:
-	print('Created dictionary of size %d' % (vocab.size())
+	print('Created dictionary of size %d' % (vocab.size()))
 
     return vocab, featuresVocabs
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -93,9 +93,12 @@ def makeVocabulary(filename, size):
                     featuresVocabs[j].add(features[j][i])
 
     originalSize = vocab.size()
-    vocab = vocab.prune(size)
-    print('Created dictionary of size %d (pruned from %d)' %
+    if size!=0:
+    	vocab = vocab.prune(size)
+    	print('Created dictionary of size %d (pruned from %d)' %
           (vocab.size(), originalSize))
+    else:
+	print('Created dictionary of size %d' % (vocab.size())
 
     return vocab, featuresVocabs
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -93,10 +93,10 @@ def makeVocabulary(filename, size):
                     featuresVocabs[j].add(features[j][i])
 
     originalSize = vocab.size()
-    if size!=0:
+    if size != 0:
         vocab = vocab.prune(size)
-        print('Created dictionary of size %d (pruned from %d)' %
-            (vocab.size(), originalSize))
+        print('Created dictionary of size %d (pruned from %d)' % 
+              (vocab.size(), originalSize))
     else:
         print('Created dictionary of size %d' % (vocab.size()))
 


### PR DESCRIPTION
Hi,

I am requesting this PR for allowing values 0 for attributes src_vocab_size, tgt_vocab_size. This would allow no pruning of the vocabulary.

Currently, we can either use default 50000 or manually find out the vocab size to disallow pruning. 