### PR TITLE
Add sum feature embeddings

### DIFF
--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -356,7 +356,9 @@ class Decoder(nn.Module):
 
                 # COVERAGE
                 if self._coverage:
-                    coverage = (coverage + attn) if coverage else attn
+                    coverage = attn
+                    if coverage is not None:
+                        coverage += attn
                     attns["coverage"] += [coverage]
 
                 # COPY

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -356,9 +356,7 @@ class Decoder(nn.Module):
 
                 # COVERAGE
                 if self._coverage:
-                    coverage = attn
-                    if coverage is not None:
-                        coverage += attn
+                    coverage = (coverage + attn) if coverage else attn
                     attns["coverage"] += [coverage]
 
                 # COPY

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -57,6 +57,10 @@ class Embeddings(nn.Module):
 
     @property
     def embedding_size(self):
+        """
+        Returns sum of all feature dimensions if the merge action is concat.
+        Otherwise, returns word vector size.
+        """
         if self.feat_merge == 'concat':
             return sum(emb_lut.embedding_dim
                        for emb_lut in self.emb_luts.children())
@@ -86,17 +90,11 @@ class Embeddings(nn.Module):
 
     def forward(self, src_input):
         """
-        Embed the words or utilize features and MLP.
-
+        Return the embeddings for words, and features if there are any.
         Args:
             src_input (LongTensor): len x batch x nfeat
-
         Return:
-            emb (FloatTensor): len x batch x emb_size
-                                emb_size is word_vec_size if there are no
-                                features or the merge action is sum.
-                                It is the sum of all feature dimensions
-                                if the merge action is concatenate.
+            emb (FloatTensor): len x batch x self.embedding_size
         """
         in_length, in_batch, nfeat = src_input.size()
         aeq(nfeat, len(self.emb_luts))

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -19,7 +19,7 @@ parser.add_argument('-word_vec_size', type=int, default=500,
 parser.add_argument('-feat_vec_size', type=int, default=100,
                     help='Feature vec sizes')
 parser.add_argument('-feat_merge', type=str, default='concat',
-                    choices=['concat', 'sum'],
+                    choices=['concat', 'sum', 'mlp'],
                     help='Merge action for the features embeddings')
 parser.add_argument('-feat_vec_exponent', type=float, default=0.7,
                     help="""When features embedding sizes are not set and

--- a/train.py
+++ b/train.py
@@ -40,7 +40,7 @@ parser.add_argument('-word_vec_size', type=int, default=500,
 parser.add_argument('-feat_vec_size', type=int, default=20,
                     help='Feature vec sizes')
 parser.add_argument('-feat_merge', type=str, default='concat',
-                    choices=['concat', 'sum'],
+                    choices=['concat', 'sum', 'mlp'],
                     help='Merge action for the features embeddings')
 parser.add_argument('-feat_vec_exponent', type=float, default=0.7,
                     help="""When features embedding sizes are not set and

--- a/train.py
+++ b/train.py
@@ -38,15 +38,15 @@ parser.add_argument('-rnn_size', type=int, default=500,
 parser.add_argument('-word_vec_size', type=int, default=500,
                     help='Word embedding sizes')
 parser.add_argument('-feat_vec_size', type=int, default=20,
-                    help='Feature vec sizes')
+                    help="""When using -feat_merge mlp, feature embedding
+                    sizes will be set to this.""")
 parser.add_argument('-feat_merge', type=str, default='concat',
                     choices=['concat', 'sum', 'mlp'],
                     help='Merge action for the features embeddings')
 parser.add_argument('-feat_vec_exponent', type=float, default=0.7,
-                    help="""When features embedding sizes are not set and
-                    using -feat_merge concat, their dimension will be set
-                    to N^feat_vec_exponent where N is the number of values
-                    the feature takes""")
+                    help="""When using -feat_merge concat, feature embedding
+                    sizes will be set to N^feat_vec_exponent where N is the
+                    number of values the feature takes.""")
 parser.add_argument('-input_feed', type=int, default=1,
                     help="""Feed the context vector at each time step as
                     additional input (via concatenation with the word


### PR DESCRIPTION
In my previous PR, I referred to the feature merging strategy that used MLP as "sum". As Guillaume Klein pointed out, this is not correct. Therefore, I have revised the code to include a legitimate sum option. I added an extra feature merging option in train.py, `-feat_merge mlp`, for the MLP case. There are still some bits that might need to change regarding the sizes of features. Current behavior is that if merge is` concat`, the `feat_vec_exponent` is used for determining sizes. If the merge is `mlp`, `feat_vec_size` is used. And if the merge is `sum`, `word_vec_size` is used.