### PR TITLE
Fix issue #158

### DIFF
--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -358,7 +358,9 @@ class Decoder(nn.Module):
 
                 # COVERAGE
                 if self._coverage:
-                    coverage = (coverage + attn) if coverage else attn
+                    coverage = attn
++                    if coverage is not None:
++                        coverage += attn
                     attns["coverage"] += [coverage]
 
                 # COPY

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -359,8 +359,8 @@ class Decoder(nn.Module):
                 # COVERAGE
                 if self._coverage:
                     coverage = attn
-+                    if coverage is not None:
-+                        coverage += attn
+                    if coverage is not None:
+                        coverage += attn
                     attns["coverage"] += [coverage]
 
                 # COPY

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -358,9 +358,7 @@ class Decoder(nn.Module):
 
                 # COVERAGE
                 if self._coverage:
-                    coverage = attn
-                    if coverage is not None:
-                        coverage += attn
+                    coverage = (coverage + attn) if coverage else attn
                     attns["coverage"] += [coverage]
 
                 # COPY

--- a/train.py
+++ b/train.py
@@ -325,7 +325,6 @@ def check_model_path():
     model_dirname = os.path.dirname(save_model_path)
     if not os.path.exists(model_dirname):
         os.makedirs(model_dirname)
-    assert os.path.isdir(model_dirname), "%s not a directory" % opt.save_model
 
 
 def main():

--- a/train.py
+++ b/train.py
@@ -215,11 +215,6 @@ def eval(model, criterion, data):
 def trainModel(model, trainData, validData, dataset, optim):
     model.train()
 
-    model_dirname = os.path.dirname(opt.save_model)
-    if not os.path.exists(model_dirname):
-        os.mkdir(model_dirname)
-    assert os.path.isdir(model_dirname), "%s not a directory" % opt.save_model
-
     # Define criterion of each GPU.
     if not opt.copy_attn:
         criterion = onmt.Loss.NMTCriterion(dataset['dicts']['tgt'].size(), opt)
@@ -323,6 +318,14 @@ def trainModel(model, trainData, validData, dataset, optim):
                        '%s_acc_%.2f_ppl_%.2f_e%d.pt'
                        % (opt.save_model, valid_stats.accuracy(),
                           valid_stats.ppl(), epoch))
+
+
+def check_model_path():
+    save_model_path = os.path.abspath(opt.save_model)
+    model_dirname = os.path.dirname(save_model_path)
+    if not os.path.exists(model_dirname):
+        os.makedirs(model_dirname)
+    assert os.path.isdir(model_dirname), "%s not a directory" % opt.save_model
 
 
 def main():
@@ -457,6 +460,8 @@ def main():
             print(name, param.nelement())
     print('encoder: ', enc)
     print('decoder: ', dec)
+
+    check_model_path()
 
     trainModel(model, trainData, validData, dataset, optim)
 


### PR DESCRIPTION
train.py currently does not work if the string passed to -save_model does not contain a directory because of the changes made in pull request #143 . I changed so that training is possible if -save_model contains a string with no directory-separating characters. For example, with the command 

`python train.py -data data/demo.train.pt -save_model demo-model`

the model .pt file will be located inside the OpenNMT-py directory. I believe this was the behavior before #143 .

In the event that -save_model contains multiple directories, i.e. `foo/bar/baz/model_name`, intermediate directories will also be made to make sure that the path exists.