### PR TITLE
Fix coverage attention

### DIFF
--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -358,7 +358,8 @@ class Decoder(nn.Module):
 
                 # COVERAGE
                 if self._coverage:
-                    coverage = (coverage + attn) if coverage else attn
+                    coverage = coverage + attn \
+                               if coverage is not None else attn
                     attns["coverage"] += [coverage]
 
                 # COPY


### PR DESCRIPTION
The previous way of doing coverage attention breaks Models.py because boolean tests cannot be done on tensors. This PR provides a minimal fix.