### PR TITLE
speed improvement when input_feed = 0

### DIFF
--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -384,7 +384,7 @@ class Decoder(nn.Module):
             assert isinstance(state, RNNDecoderState)
             assert emb.dim() == 3
 
-            #TODO: context_gate, coverage and copy
+            # TODO: context_gate, coverage and copy
             assert self.context_gate is None
             assert not self._coverage
             assert not self._copy

--- a/onmt/modules/GlobalAttention.py
+++ b/onmt/modules/GlobalAttention.py
@@ -94,7 +94,7 @@ class GlobalAttention(nn.Module):
             wq = self.linear_query(h_t.view(-1, dim))
             wq = wq.view(tgt_batch, tgt_len, 1, dim)
 
-            uh = self.linear_context(h_s.view(-1, dim))
+            uh = self.linear_context(h_s.contiguous().view(-1, dim))
             uh = uh.view(src_batch, 1, src_len, dim)
 
             # (batch, t_len, s_len, d)

--- a/onmt/modules/GlobalAttention.py
+++ b/onmt/modules/GlobalAttention.py
@@ -90,6 +90,7 @@ class GlobalAttention(nn.Module):
             # (batch, t_len, d) x (batch, d, s_len) --> (batch, t_len, s_len)
             return torch.bmm(h_t, h_s_)
         else:
+            dim = self.dim
             wq = self.linear_query(h_t.view(-1, dim))
             wq = wq.view(tgt_batch, tgt_len, 1, dim)
 

--- a/onmt/modules/GlobalAttention.py
+++ b/onmt/modules/GlobalAttention.py
@@ -174,12 +174,12 @@ class GlobalAttention(nn.Module):
             if self.attn_type == "general":
                 h_t_ = h_t.view(tgt_batch*tgt_len, tgt_dim)
                 h_t_ = self.linear_in(h_t_)
-                h_t  = h_t_.view(tgt_batch, tgt_len, tgt_dim)
+                h_t = h_t_.view(tgt_batch, tgt_len, tgt_dim)
             h_s_ = h_s.transpose(1, 2)
-            # (batch, tgt_len, dim) x (batch, dim, src_len) --> (batch, tgt_len, src_len)
+            # (batch, t_len, d) x (batch, d, s_len) --> (batch, t_len, s_len)
             return torch.bmm(h_t, h_s_)
         else:
-            #TODO: MLP
+            # TODO: MLP
             raise Exception("mlp not supported yet.")
 
     def forward_all(self, input, context, coverage=None):
@@ -201,7 +201,7 @@ class GlobalAttention(nn.Module):
             aeq(batch, batch_*beam_)
             aeq(sourceL, sourceL_)
 
-        #TODO: coverage
+        # TODO: coverage
         if coverage is not None:
             raise Exception("coverage not supported yet.")
 
@@ -209,11 +209,12 @@ class GlobalAttention(nn.Module):
         align = self.score_all(input, context)
 
         if self.mask is not None:
-            mask_ = self.mask.view(batch, 1, sourceL)   # making it broardcastable
+            mask_ = self.mask.view(batch, 1, sourceL) # make it broardcastable
             align.data.masked_fill_(mask_, -float('inf'))
 
         # Softmax to normalize attention weights
-        align_vectors = self.sm(align.view(batch*targetL, sourceL)).view(batch, targetL, sourceL)
+        align_vectors = self.sm(align.view(batch*targetL, sourceL))
+        align_vectors = align_vectors.view(batch, targetL, sourceL)
 
         # each context vector c_t is the weighted average
         # over all the source hidden states
@@ -239,5 +240,3 @@ class GlobalAttention(nn.Module):
         aeq(sourceL, sourceL_)
 
         return attn_h, align_vectors
-
-

--- a/onmt/modules/GlobalAttention.py
+++ b/onmt/modules/GlobalAttention.py
@@ -93,14 +93,16 @@ class GlobalAttention(nn.Module):
             dim = self.dim
             wq = self.linear_query(h_t.view(-1, dim))
             wq = wq.view(tgt_batch, tgt_len, 1, dim)
+            wq = wq.expand(tgt_batch, tgt_len, src_len, dim)
 
             uh = self.linear_context(h_s.contiguous().view(-1, dim))
             uh = uh.view(src_batch, 1, src_len, dim)
+            uh = uh.expand(src_batch, tgt_len, src_len, dim)
 
             # (batch, t_len, s_len, d)
             wquh = self.tanh(wq + uh)
 
-            return self.v(wquh.view(-1, dim)).squeeze(3)
+            return self.v(wquh.view(-1, dim)).view(tgt_batch, tgt_len, src_len)
 
     def forward(self, input, context, coverage=None):
         """

--- a/onmt/modules/GlobalAttention.py
+++ b/onmt/modules/GlobalAttention.py
@@ -209,7 +209,7 @@ class GlobalAttention(nn.Module):
         align = self.score_all(input, context)
 
         if self.mask is not None:
-            mask_ = self.mask.view(batch, 1, sourceL) # make it broardcastable
+            mask_ = self.mask.view(batch, 1, sourceL)  # make it broardcastable
             align.data.masked_fill_(mask_, -float('inf'))
 
         # Softmax to normalize attention weights


### PR DESCRIPTION
RNN decoder processes one token at a time during training. 

When `-input_feed` is disabled, RNN forward and attentions can be computed in parallel at sequence level instead of token level.

This gives a  > 2x speed-up, tested on a GTX 1080 card:
  **before:**  ~4,000 tokens / sec
  **after:**  ~10,000 tokens / sec

