### PR TITLE
Refactor Encoder class constructor to take needed options explicitly. 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,8 +2,9 @@ PyOpenNMT is a community developed project and we love developer contributions.
 
 When sending a PR we will check the following: 
 
-- Please unsure that there are no style issues. We run an automatic check that calls `flake8`. If that fails we cannot accept the PR.
-- To run unittests, call `python -m unittest discover`
+- Please ensure that there are no style issues. We run an automatic check that calls `flake8`. If that fails we cannot accept the PR.
+- Please ensure that unittest is passed before sending PR. To run unittests, call `python -m unittest discover`.
+- When modifying class constructor, please make the arguments as same naming style as its superclass in pytorch.
 - There is also a basic model trained in using continuous integration. See `.travis.yml` for details.   
 - If your change is based on a paper, please include a clear comment and reference in the code. 
 - If your function takes/returns tensor arguments, please include assertions to document the sizes. See `GlobalAttention.py` for examples. 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,10 +1,11 @@
-PyOpenNMT is a community developed project and we love developer contributions. 
+OpenNMT-py is a community developed project and we love developer contributions.
 
-When sending a PR we will check the following: 
+Before sending a PR, please do this checklist first:
 
-- Please ensure that there are no style issues. We run an automatic check that calls `flake8`. If that fails we cannot accept the PR.
-- Please ensure that unittest is passed before sending PR. To run unittests, call `python -m unittest discover`.
-- When modifying class constructor, please make the arguments as same naming style as its superclass in pytorch.
-- There is also a basic model trained in using continuous integration. See `.travis.yml` for details.   
+- Please run `tools/pull_request_chk.sh` and fix any errors. When adding new functionality, also add tests to this script. Included checks:
+    1. flake8 check for coding style;
+    2. unittest;
+    3. continuous integration tests listed in `.travis.yml`.
+- When adding/modifying class constructor, please make the arguments as same naming style as its superclass in pytorch.
 - If your change is based on a paper, please include a clear comment and reference in the code. 
 - If your function takes/returns tensor arguments, please include assertions to document the sizes. See `GlobalAttention.py` for examples. 

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -236,6 +236,18 @@ class ONMTDataset(torchtext.data.Dataset):
         return feats
 
     @staticmethod
+    def collect_feature_dicts(fields):
+        feature_dicts = []
+        j = 0
+        while True:
+            key = "src_feat_" + str(j)
+            if key not in fields:
+                break
+            feature_dicts.append(fields[key].vocab)
+            j += 1
+        return feature_dicts
+
+    @staticmethod
     def get_fields(nFeatures=0):
         fields = {}
         fields["src"] = torchtext.data.Field(

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -26,22 +26,19 @@ class Embeddings(nn.Module):
         feat_embedding_dim (int): embedding dimension for features when using
                     '-feat_merge mlp'
         dropout (float): dropout probablity.
-        cuda (bool): use GPU?
         padding_idx (int): padding index in the embedding dictionary.
         num_word_embeddings (int): size of dictionary of embeddings for words.
         num_feat_embeddings ([int], optional): list of size of dictionary
                                     of embeddings for each feature.
     """
     def __init__(self, embedding_dim, position_encoding, feat_merge,
-                 feat_dim_exponent, feat_embedding_dim, dropout, cuda,
+                 feat_dim_exponent, feat_embedding_dim, dropout,
                  padding_idx,
                  num_word_embeddings, num_feat_embeddings=None):
         super(Embeddings, self).__init__()
         self.positional_encoding = position_encoding
         if self.positional_encoding:
             self.pe = self.make_positional_encodings(embedding_dim, 5000)
-            if cuda:
-                self.pe.cuda()
             self.dropout = nn.Dropout(p=dropout)
 
         self.padding_idx = padding_idx
@@ -164,14 +161,12 @@ def build_embeddings(opt, padding_idx, num_word_embeddings,
         embedding_dim = opt.src_word_vec_size
     else:
         embedding_dim = opt.tgt_word_vec_size
-    cuda = (len(opt.gpuid) >= 1)
     return Embeddings(embedding_dim,
                       opt.position_encoding,
                       opt.feat_merge,
                       opt.feat_vec_exponent,
                       opt.feat_vec_size,
                       opt.dropout,
-                      cuda,
                       padding_idx,
                       num_word_embeddings,
                       num_feat_embeddings)

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -156,7 +156,8 @@ class Encoder(nn.Module):
 
         if self.encoder_type == "transformer":
             self.transformer = nn.ModuleList(
-                [onmt.modules.TransformerEncoder(self.hidden_size, opt, pad_id)
+                [onmt.modules.TransformerEncoder(
+                        self.hidden_size, opt.dropout, pad_id)
                  for i in range(opt.enc_layers)])
         else:
             self.rnn = getattr(nn, opt.rnn_type)(

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -4,6 +4,7 @@ import torch.nn as nn
 from torch.autograd import Variable
 import onmt
 import onmt.modules
+from onmt.IO import ONMTDataset
 from onmt.modules import aeq
 from onmt.modules.Gate import ContextGateFactory
 from torch.nn.utils.rnn import pad_packed_sequence as unpack
@@ -11,54 +12,77 @@ from torch.nn.utils.rnn import pack_padded_sequence as pack
 
 
 class Embeddings(nn.Module):
-    def __init__(self, dropout, cuda, dicts, feature_dicts=None, **emb_opts):
+    """
+    Words embeddings dictionary for Encoder/Decoder.
+
+    Args:
+        embedding_dim (int): size of the dictionary of embeddings.
+        position_encoding (bool): use a sin to mark relative words positions.
+        feat_merge (string): merge action for the features embeddings:
+                    concat, sum or mlp.
+        feat_dim_exponent (float): when using '-feat_merge concat', feature
+                    embedding size is N^feat_dim_exponent, where N is the
+                    number of values of feature takes.
+        feat_embedding_dim (int): embedding dimension for features when using
+                    '-feat_merge mlp'
+        dropout (float): dropout probablity.
+        cuda (bool): use GPU?
+        padding_idx (int): padding index in the embedding dictionary.
+        num_word_embeddings (int): size of dictionary of embeddings for words.
+        num_feat_embeddings ([int], optional): list of size of dictionary
+                                    of embeddings for each feature.
+    """
+    def __init__(self, embedding_dim, position_encoding, feat_merge,
+                 feat_dim_exponent, feat_embedding_dim, dropout, cuda,
+                 padding_idx,
+                 num_word_embeddings, num_feat_embeddings=None):
         super(Embeddings, self).__init__()
-        vec_size = emb_opts['src_word_vec_size']
-        self.positional_encoding = emb_opts['position_encoding']
+        self.positional_encoding = position_encoding
         if self.positional_encoding:
-            self.pe = self.make_positional_encodings(vec_size, 5000)
+            self.pe = self.make_positional_encodings(embedding_dim, 5000)
             if cuda:
                 self.pe.cuda()
             self.dropout = nn.Dropout(p=dropout)
 
-        self.feat_merge = emb_opts['feat_merge']
+        self.padding_idx = padding_idx
+        self.feat_merge = feat_merge
 
-        feat_exp = emb_opts['feat_vec_exponent']
-
-        # vocab_sizes: sequence of vocab sizes for words and each feature
-        vocab_sizes = [len(dicts)]
-        # emb_sizes
-        emb_sizes = [vec_size]
-        if feature_dicts:
-            vocab_sizes.extend(len(feat_dict) for feat_dict in feature_dicts)
-            if emb_opts['feat_merge'] == 'concat':
-                # Derive embedding sizes from each feature's vocab size
-                emb_sizes.extend([int(len(feat_dict) ** feat_exp)
-                                  for feat_dict in feature_dicts])
-            elif emb_opts['feat_merge'] == 'sum':
+        # num_embeddings: list of size of dictionary of embeddings
+        #                 for words and each feature.
+        num_embeddings = [num_word_embeddings]
+        # embedding_dims: list of dimension of each embedding vector
+        #                 for words and each feature.
+        embedding_dims = [embedding_dim]
+        if num_feat_embeddings:
+            num_embeddings.extend(num_feat for num_feat in num_feat_embeddings)
+            if feat_merge == 'concat':
+                # Derive embedding dims from each feature's vocab size
+                embedding_dims.extend([int(num_feat ** feat_dim_exponent)
+                                      for num_feat in num_feat_embeddings])
+            elif feat_merge == 'sum':
                 # All embeddings to be summed must be the same size
-                emb_sizes.extend([vec_size] * len(feature_dicts))
+                embedding_dims.extend([embedding_dim] *
+                                      len(num_feat_embeddings))
             else:
                 # mlp feature merge
-                emb_sizes.extend([emb_opts['feat_vec_size']]
-                                 * len(feature_dicts))
+                embedding_dims.extend([feat_embedding_dim]
+                                      * len(num_feat_embeddings))
                 # apply a layer of mlp to get it down to the correct dim
                 self.mlp = nn.Sequential(onmt.modules.BottleLinear(
-                                        sum(emb_sizes),
-                                        vec_size),
+                                        sum(embedding_dims),
+                                        embedding_dim),
                                         nn.ReLU())
         self.emb_luts = \
             nn.ModuleList([
-                nn.Embedding(vocab, dim,
-                             padding_idx=dicts.stoi[onmt.IO.PAD_WORD])
-                for vocab, dim in zip(vocab_sizes, emb_sizes)])
+                nn.Embedding(num_emb, emb_dim, padding_idx=padding_idx)
+                for num_emb, emb_dim in zip(num_embeddings, embedding_dims)])
 
     @property
     def word_lut(self):
         return self.emb_luts[0]
 
     @property
-    def embedding_size(self):
+    def embedding_dim(self):
         """
         Returns sum of all feature dimensions if the merge action is concat.
         Otherwise, returns word vector size.
@@ -96,7 +120,7 @@ class Embeddings(nn.Module):
         Args:
             src_input (LongTensor): len x batch x nfeat
         Return:
-            emb (FloatTensor): len x batch x self.embedding_size
+            emb (FloatTensor): len x batch x self.embedding_dim
         """
         in_length, in_batch, nfeat = src_input.size()
         aeq(nfeat, len(self.emb_luts))
@@ -115,72 +139,87 @@ class Embeddings(nn.Module):
                                  .expand_as(emb))
             emb = self.dropout(emb)
 
-        out_length, out_batch, emb_size = emb.size()
+        out_length, out_batch, emb_dim = emb.size()
         aeq(in_length, out_length)
         aeq(in_length, out_length)
-        aeq(emb_size, self.embedding_size)
+        aeq(emb_dim, self.embedding_dim)
 
         return emb
+
+
+def build_embeddings(opt, padding_idx, num_word_embeddings,
+                     for_encoder, num_feat_embeddings=None):
+    """
+    Create an Embeddings instance.
+    Args:
+        opt: command-line options.
+        padding_idx(int): padding index in the embedding dictionary.
+        num_word_embeddings(int): size of dictionary
+                                 of embedding for words.
+        for_encoder(bool): make Embeddings for Encoder or Decoder?
+        num_feat_embeddings([int]): list of size of dictionary
+                                    of embedding for each feature.
+    """
+    if for_encoder:
+        embedding_dim = opt.src_word_vec_size
+    else:
+        embedding_dim = opt.tgt_word_vec_size
+    cuda = (len(opt.gpuid) >= 1)
+    return Embeddings(embedding_dim,
+                      opt.position_encoding,
+                      opt.feat_merge,
+                      opt.feat_vec_exponent,
+                      opt.feat_vec_size,
+                      opt.dropout,
+                      cuda,
+                      padding_idx,
+                      num_word_embeddings,
+                      num_feat_embeddings)
 
 
 class Encoder(nn.Module):
     """
     Encoder recurrent neural network.
-
-    Attributes:
-        encdoer_type: rnn, brnn, mean, or transformer.
-        transformer: the transformer list for transformer encdoer_type.
-        rnn: the rnn for ther other encdoer_type.
-        num_directions: number of direction for this Encoder(2 if brnn).
-        num_layers: number of Encoder layers.
-        hidden_size: size of hidden states of a rnn.
-        embedding: Embeddings instance for this Encoder.
     """
-    def __init__(self, encoder_type, brnn, rnn_type,
+    def __init__(self, encoder_type, bidirectional, rnn_type,
                  num_layers, rnn_size, dropout, cuda,
-                 dicts, feature_dicts=None, **emb_opts):
+                 embeddings):
         """
         Args:
-            encdoer_type: rnn, brnn, mean, or transformer.
-            brnn: brnn Encoder. Deprecated, use encdoer_type.
-            rnn_type: LSTM or GRU.
-            num_layers: number of Encoder layers.
-            rnn_size: size of hidden states of a rnn.
-            dropout: dropout probablity.
-            cuda: use GPU?
-            dicts (`Dict`): The src dictionary.
-            features_dicts (`[Dict]`): List of src feature dictionaries.
-            emb_opts: a dicctionary passed for Embeddings constructor.
+            encoder_type (string): rnn, brnn, mean, or transformer.
+            bidirectional (bool): bidirectional Encoder.
+            rnn_type (string): LSTM or GRU.
+            num_layers (int): number of Encoder layers.
+            rnn_size (int): size of hidden states of a rnn.
+            dropout (float): dropout probablity.
+            cuda (bool): use GPU?
+            embeddings (Embeddings): vocab embeddings for this Encoder.
         """
-        # Basic attributes.
-        self.encoder_type = encoder_type
-
-        self.num_directions = 2 if brnn else 1
-        assert rnn_size % self.num_directions == 0
-
-        self.num_layers = num_layers
-        self.hidden_size = rnn_size // self.num_directions
-
+        # Call nn.Module.__init().
         super(Encoder, self).__init__()
 
-        # Create a word embedding instance for this Encoder.
-        self.embeddings = Embeddings(dropout, cuda, dicts, feature_dicts,
-                                     **emb_opts)
+        # Basic attributes.
+        self.encoder_type = encoder_type
+        self.num_directions = 2 if bidirectional else 1
+        assert rnn_size % self.num_directions == 0
+        self.num_layers = num_layers
+        self.hidden_size = rnn_size // self.num_directions
+        self.embeddings = embeddings
 
         # Build the Encoder RNN.
         if self.encoder_type == "transformer":
-            pad_id = dicts.stoi[onmt.IO.PAD_WORD]
+            pad_id = embeddings.padding_idx
             self.transformer = nn.ModuleList(
                 [onmt.modules.TransformerEncoder(
                         self.hidden_size, dropout, pad_id)
                  for i in range(self.num_layers)])
         else:
             self.rnn = getattr(nn, rnn_type)(
-                 input_size=self.embeddings.embedding_size,
+                 input_size=self.embeddings.embedding_dim,
                  hidden_size=self.hidden_size,
                  num_layers=self.num_layers,
                  dropout=dropout,
-                 bidirectional=brnn)
+                 bidirectional=bidirectional)
 
     def forward(self, input, lengths=None, hidden=None):
         """
@@ -202,12 +241,12 @@ class Encoder(nn.Module):
         # END CHECKS
 
         emb = self.embeddings(input)
-        s_len, n_batch, vec_size = emb.size()
+        s_len, n_batch, emb_dim = emb.size()
 
         if self.encoder_type == "mean":
             # No RNN, just take mean as final state.
             mean = emb.mean(0) \
-                   .expand(self.num_layers, n_batch, vec_size)
+                   .expand(self.num_layers, n_batch, emb_dim)
             return (mean, mean), emb
 
         elif self.encoder_type == "transformer":
@@ -234,7 +273,7 @@ class Decoder(nn.Module):
     Decoder + Attention recurrent neural network.
     """
 
-    def __init__(self, opt, cuda, dicts, **emb_opts):
+    def __init__(self, opt, cuda, embeddings):
         """
         Args:
             opt: model options
@@ -250,10 +289,9 @@ class Decoder(nn.Module):
             input_size += opt.rnn_size
 
         super(Decoder, self).__init__()
-        self.embeddings = Embeddings(opt.dropout, cuda,
-                                     dicts, None, **emb_opts)
+        self.embeddings = embeddings
 
-        pad_id = dicts.stoi[onmt.IO.PAD_WORD]
+        pad_id = embeddings.padding_idx
         if self.decoder_type == "transformer":
             self.transformer = nn.ModuleList(
                 [onmt.modules.TransformerDecoder(self.hidden_size, opt, pad_id)
@@ -559,35 +597,38 @@ class TransformerDecoderState(DecoderState):
 
 
 def make_base_model(opt, model_opt, fields, cuda, checkpoint=None):
-    # HACK: collect source feature vocabs.
-    feature_vocabs = []
-    for j in range(100):
-        key = "src_feat_" + str(j)
-        if key not in fields:
-            break
-        feature_vocabs.append(fields[key].vocab)
 
-    emb_opts = {'src_word_vec_size': model_opt.src_word_vec_size,
-                'position_encoding': model_opt.position_encoding,
-                'feat_merge': model_opt.feat_merge,
-                'feat_vec_exponent': model_opt.feat_vec_exponent,
-                'feat_vec_size': model_opt.feat_vec_size}
+    # Make Encoder.
+    src_vocab = fields["src"].vocab
+    num_feat_embeddings = [len(feat_dict) for feat_dict in
+                           ONMTDataset.collect_feature_dicts(fields)]
+    embeddings = build_embeddings(
+                model_opt, src_vocab.stoi[onmt.IO.PAD_WORD],
+                len(src_vocab), for_encoder=True,
+                num_feat_embeddings=num_feat_embeddings)
 
     if model_opt.model_type == "text":
         encoder = Encoder(model_opt.encoder_type, model_opt.brnn,
                           model_opt.rnn_type, model_opt.enc_layers,
                           model_opt.rnn_size, model_opt.dropout, cuda,
-                          fields["src"].vocab, feature_vocabs, **emb_opts)
+                          embeddings)
     elif model_opt.model_type == "img":
         encoder = onmt.modules.ImageEncoder(model_opt)
     else:
         assert False, ("Unsupported model type %s"
                        % (model_opt.model_type))
 
-    decoder = onmt.Models.Decoder(
-            model_opt, cuda, fields["tgt"].vocab, **emb_opts)
+    # Make Decoder.
+    tgt_vocab = fields["tgt"].vocab
+    embeddings = build_embeddings(
+                    model_opt, tgt_vocab.stoi[onmt.IO.PAD_WORD],
+                    len(tgt_vocab), for_encoder=False)
+    decoder = onmt.Models.Decoder(model_opt, cuda, embeddings)
+
+    # Make NMTModel(= Encoder + Decoder).
     model = onmt.Models.NMTModel(encoder, decoder)
 
+    # Make Generator.
     if not model_opt.copy_attn:
         generator = nn.Sequential(
             nn.Linear(model_opt.rnn_size, len(fields["tgt"].vocab)),

--- a/onmt/Translator.py
+++ b/onmt/Translator.py
@@ -23,7 +23,7 @@ class Translator(object):
         self.copy_attn = model_opt.copy_attn
 
         self.model = onmt.Models.make_base_model(opt, model_opt, self.fields,
-                                                 opt.cuda, checkpoint)
+                                                 checkpoint)
         self.model.eval()
         self.model.generator.eval()
 

--- a/onmt/modules/Transformer.py
+++ b/onmt/modules/Transformer.py
@@ -46,7 +46,7 @@ class PositionwiseFeedForward(nn.Module):
 
 
 class TransformerEncoder(nn.Module):
-    def __init__(self, hidden_size, dropout, pad,
+    def __init__(self, hidden_size, dropout, padding_idx,
                  n_head=8, d_inner=2048):
         super(TransformerEncoder, self).__init__()
 
@@ -55,7 +55,7 @@ class TransformerEncoder(nn.Module):
         self.feed_forward = PositionwiseFeedForward(hidden_size,
                                                     d_inner,
                                                     dropout)
-        self.pad = pad
+        self.padding_idx = padding_idx
 
     def forward(self, input, words):
         # CHECKS
@@ -65,7 +65,7 @@ class TransformerEncoder(nn.Module):
         aeq(s_len, s_len_)
         # END CHECKS
 
-        mask = get_attn_padding_mask(words, words, self.pad)
+        mask = get_attn_padding_mask(words, words, self.padding_idx)
         mid, _ = self.self_attn(input, input, input, mask=mask)
         out = self.feed_forward(mid)
         return out

--- a/onmt/modules/Transformer.py
+++ b/onmt/modules/Transformer.py
@@ -46,15 +46,15 @@ class PositionwiseFeedForward(nn.Module):
 
 
 class TransformerEncoder(nn.Module):
-    def __init__(self, hidden_size, opt, pad,
+    def __init__(self, hidden_size, dropout, pad,
                  n_head=8, d_inner=2048):
         super(TransformerEncoder, self).__init__()
 
         self.self_attn = onmt.modules.MultiHeadedAttention(
-            n_head, hidden_size, p=opt.dropout)
+            n_head, hidden_size, p=dropout)
         self.feed_forward = PositionwiseFeedForward(hidden_size,
                                                     d_inner,
-                                                    opt.dropout)
+                                                    dropout)
         self.pad = pad
 
     def forward(self, input, words):

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -81,7 +81,10 @@ class TestModel(unittest.TestCase):
                     'feat_vec_exponent': opt.feat_vec_exponent,
                     'feat_vec_size': opt.feat_vec_size}
         cuda = (len(opt.gpuid) >= 1)
-        enc = onmt.Models.Encoder(opt, cuda, vocab, None, **emb_opts)
+        enc = onmt.Models.Encoder(opt.encoder_type, opt.brnn,
+                                  opt.rnn_type, opt.enc_layers,
+                                  opt.rnn_size, opt.dropout, cuda,
+                                  vocab, None, **emb_opts)
 
         test_src, test_tgt, test_length = self.get_batch(sourceL=sourceL,
                                                          bsize=bsize)
@@ -117,7 +120,10 @@ class TestModel(unittest.TestCase):
                     'feat_vec_exponent': opt.feat_vec_exponent,
                     'feat_vec_size': opt.feat_vec_size}
         cuda = (len(opt.gpuid) >= 1)
-        enc = onmt.Models.Encoder(opt, cuda, vocab, None, **emb_opts)
+        enc = onmt.Models.Encoder(opt.encoder_type, opt.brnn,
+                                  opt.rnn_type, opt.enc_layers,
+                                  opt.rnn_size, opt.dropout, cuda,
+                                  vocab, None, **emb_opts)
         dec = onmt.Models.Decoder(opt, cuda, vocab, **emb_opts)
         model = onmt.Models.NMTModel(enc, dec)
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -45,14 +45,8 @@ class TestModel(unittest.TestCase):
             bsize: Batchsize of generated input
         '''
         vocab = self.get_vocab()
-        emb_opts = {'src_word_vec_size': opt.src_word_vec_size,
-                    'position_encoding': opt.position_encoding,
-                    'feat_merge': opt.feat_merge,
-                    'feat_vec_exponent': opt.feat_vec_exponent,
-                    'feat_vec_size': opt.feat_vec_size}
-        cuda = (len(opt.gpuid) >= 1)
-        emb = onmt.Models.Embeddings(opt.dropout, cuda, vocab,
-                                     None, **emb_opts)
+        emb = onmt.Models.build_embeddings(opt, vocab.stoi[onmt.IO.PAD_WORD],
+                                           len(vocab), for_encoder=True)
         test_src, _, __ = self.get_batch(sourceL=sourceL,
                                          bsize=bsize)
         if opt.decoder_type == 'transformer':
@@ -75,16 +69,14 @@ class TestModel(unittest.TestCase):
             bsize: Batchsize of generated input
         '''
         vocab = self.get_vocab()
-        emb_opts = {'src_word_vec_size': opt.src_word_vec_size,
-                    'position_encoding': opt.position_encoding,
-                    'feat_merge': opt.feat_merge,
-                    'feat_vec_exponent': opt.feat_vec_exponent,
-                    'feat_vec_size': opt.feat_vec_size}
         cuda = (len(opt.gpuid) >= 1)
+        embeddings = onmt.Models.build_embeddings(
+                                    opt, vocab.stoi[onmt.IO.PAD_WORD],
+                                    len(vocab), for_encoder=True)
         enc = onmt.Models.Encoder(opt.encoder_type, opt.brnn,
                                   opt.rnn_type, opt.enc_layers,
                                   opt.rnn_size, opt.dropout, cuda,
-                                  vocab, None, **emb_opts)
+                                  embeddings)
 
         test_src, test_tgt, test_length = self.get_batch(sourceL=sourceL,
                                                          bsize=bsize)
@@ -114,17 +106,17 @@ class TestModel(unittest.TestCase):
             bsize: batchsize
         """
         vocab = self.get_vocab()
-        emb_opts = {'src_word_vec_size': opt.src_word_vec_size,
-                    'position_encoding': opt.position_encoding,
-                    'feat_merge': opt.feat_merge,
-                    'feat_vec_exponent': opt.feat_vec_exponent,
-                    'feat_vec_size': opt.feat_vec_size}
         cuda = (len(opt.gpuid) >= 1)
+        padding_idx = vocab.stoi[onmt.IO.PAD_WORD]
+        embeddings = onmt.Models.build_embeddings(opt, padding_idx, len(vocab),
+                                               for_encoder=True)
         enc = onmt.Models.Encoder(opt.encoder_type, opt.brnn,
                                   opt.rnn_type, opt.enc_layers,
                                   opt.rnn_size, opt.dropout, cuda,
-                                  vocab, None, **emb_opts)
-        dec = onmt.Models.Decoder(opt, cuda, vocab, **emb_opts)
+                                  embeddings)
+        embeddings = onmt.Models.build_embeddings(opt, padding_idx, len(vocab),
+                                               for_encoder=False)
+        dec = onmt.Models.Decoder(opt, cuda, embeddings)
         model = onmt.Models.NMTModel(enc, dec)
 
         test_src, test_tgt, test_length = self.get_batch(sourceL=sourceL,

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -45,7 +45,14 @@ class TestModel(unittest.TestCase):
             bsize: Batchsize of generated input
         '''
         vocab = self.get_vocab()
-        emb = onmt.Models.Embeddings(opt.src_word_vec_size, opt, vocab)
+        emb_opts = {'src_word_vec_size': opt.src_word_vec_size,
+                    'position_encoding': opt.position_encoding,
+                    'feat_merge': opt.feat_merge,
+                    'feat_vec_exponent': opt.feat_vec_exponent,
+                    'feat_vec_size': opt.feat_vec_size}
+        cuda = (len(opt.gpuid) >= 1)
+        emb = onmt.Models.Embeddings(opt.dropout, cuda, vocab,
+                                     None, **emb_opts)
         test_src, _, __ = self.get_batch(sourceL=sourceL,
                                          bsize=bsize)
         if opt.decoder_type == 'transformer':
@@ -68,7 +75,13 @@ class TestModel(unittest.TestCase):
             bsize: Batchsize of generated input
         '''
         vocab = self.get_vocab()
-        enc = onmt.Models.Encoder(opt, vocab)
+        emb_opts = {'src_word_vec_size': opt.src_word_vec_size,
+                    'position_encoding': opt.position_encoding,
+                    'feat_merge': opt.feat_merge,
+                    'feat_vec_exponent': opt.feat_vec_exponent,
+                    'feat_vec_size': opt.feat_vec_size}
+        cuda = (len(opt.gpuid) >= 1)
+        enc = onmt.Models.Encoder(opt, cuda, vocab, None, **emb_opts)
 
         test_src, test_tgt, test_length = self.get_batch(sourceL=sourceL,
                                                          bsize=bsize)
@@ -98,8 +111,14 @@ class TestModel(unittest.TestCase):
             bsize: batchsize
         """
         vocab = self.get_vocab()
-        enc = onmt.Models.Encoder(opt, vocab)
-        dec = onmt.Models.Decoder(opt, vocab)
+        emb_opts = {'src_word_vec_size': opt.src_word_vec_size,
+                    'position_encoding': opt.position_encoding,
+                    'feat_merge': opt.feat_merge,
+                    'feat_vec_exponent': opt.feat_vec_exponent,
+                    'feat_vec_size': opt.feat_vec_size}
+        cuda = (len(opt.gpuid) >= 1)
+        enc = onmt.Models.Encoder(opt, cuda, vocab, None, **emb_opts)
+        dec = onmt.Models.Decoder(opt, cuda, vocab, **emb_opts)
         model = onmt.Models.NMTModel(enc, dec)
 
         test_src, test_tgt, test_length = self.get_batch(sourceL=sourceL,

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -106,7 +106,7 @@ class TestModel(unittest.TestCase):
         vocab = self.get_vocab()
         padding_idx = vocab.stoi[onmt.IO.PAD_WORD]
         embeddings = onmt.Models.build_embeddings(opt, padding_idx, len(vocab),
-                                               for_encoder=True)
+                                                  for_encoder=True)
         enc = onmt.Models.Encoder(opt.encoder_type, opt.brnn,
                                   opt.rnn_type, opt.enc_layers,
                                   opt.rnn_size, opt.dropout,

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -69,14 +69,12 @@ class TestModel(unittest.TestCase):
             bsize: Batchsize of generated input
         '''
         vocab = self.get_vocab()
-        cuda = (len(opt.gpuid) >= 1)
         embeddings = onmt.Models.build_embeddings(
                                     opt, vocab.stoi[onmt.IO.PAD_WORD],
                                     len(vocab), for_encoder=True)
         enc = onmt.Models.Encoder(opt.encoder_type, opt.brnn,
                                   opt.rnn_type, opt.enc_layers,
-                                  opt.rnn_size, opt.dropout, cuda,
-                                  embeddings)
+                                  opt.rnn_size, opt.dropout, embeddings)
 
         test_src, test_tgt, test_length = self.get_batch(sourceL=sourceL,
                                                          bsize=bsize)
@@ -106,17 +104,16 @@ class TestModel(unittest.TestCase):
             bsize: batchsize
         """
         vocab = self.get_vocab()
-        cuda = (len(opt.gpuid) >= 1)
         padding_idx = vocab.stoi[onmt.IO.PAD_WORD]
         embeddings = onmt.Models.build_embeddings(opt, padding_idx, len(vocab),
                                                for_encoder=True)
         enc = onmt.Models.Encoder(opt.encoder_type, opt.brnn,
                                   opt.rnn_type, opt.enc_layers,
-                                  opt.rnn_size, opt.dropout, cuda,
+                                  opt.rnn_size, opt.dropout,
                                   embeddings)
         embeddings = onmt.Models.build_embeddings(opt, padding_idx, len(vocab),
-                                               for_encoder=False)
-        dec = onmt.Models.Decoder(opt, cuda, embeddings)
+                                                  for_encoder=False)
+        dec = onmt.Models.Decoder(opt, embeddings)
         model = onmt.Models.NMTModel(enc, dec)
 
         test_src, test_tgt, test_length = self.get_batch(sourceL=sourceL,

--- a/tools/extract_embeddings.py
+++ b/tools/extract_embeddings.py
@@ -36,8 +36,14 @@ def main():
     src_dict = checkpoint['dicts']['src']
     tgt_dict = checkpoint['dicts']['tgt']
 
-    encoder = onmt.Models.Encoder(model_opt, src_dict)
-    decoder = onmt.Models.Decoder(model_opt, tgt_dict)
+    emb_opts = {'src_word_vec_size': model_opt.src_word_vec_size,
+                'position_encoding': model_opt.position_encoding,
+                'feat_merge': model_opt.feat_merge,
+                'feat_vec_exponent': model_opt.feat_vec_exponent,
+                'feat_vec_size': model_opt.feat_vec_size}
+    cuda = (len(model_opt.gpuid) > 0)
+    encoder = onmt.Models.Encoder(model_opt, cuda, src_dict, None, **emb_opts)
+    decoder = onmt.Models.Decoder(model_opt, cuda, tgt_dict, **emb_opts)
     encoder_embeddings = encoder.word_lut.weight.data.tolist()
     decoder_embeddings = decoder.word_lut.weight.data.tolist()
 

--- a/tools/extract_embeddings.py
+++ b/tools/extract_embeddings.py
@@ -36,18 +36,17 @@ def main():
     src_dict = checkpoint['dicts']['src']
     tgt_dict = checkpoint['dicts']['tgt']
 
-    cuda = (len(model_opt.gpuid) > 0)
     embeddings = onmt.Models.build_embeddings(
                 model_opt, src_dict.stoi[onmt.IO.PAD_WORD],
                 len(src_dict), for_encoder=True)
     encoder = onmt.Models.Encoder(model_opt.encoder_type, model_opt.brnn,
                                   model_opt.rnn_type, model_opt.enc_layers,
                                   model_opt.rnn_size, model_opt.dropout,
-                                  cuda, embeddings)
+                                  embeddings)
     embeddings = onmt.Models.build_embeddings(
                 model_opt, tgt_dict.stoi[onmt.IO.PAD_WORD],
                 len(tgt_dict), for_encoder=False)
-    decoder = onmt.Models.Decoder(model_opt, cuda, embeddings)
+    decoder = onmt.Models.Decoder(model_opt, embeddings)
     encoder_embeddings = encoder.word_lut.weight.data.tolist()
     decoder_embeddings = decoder.word_lut.weight.data.tolist()
 

--- a/tools/extract_embeddings.py
+++ b/tools/extract_embeddings.py
@@ -36,17 +36,18 @@ def main():
     src_dict = checkpoint['dicts']['src']
     tgt_dict = checkpoint['dicts']['tgt']
 
-    emb_opts = {'src_word_vec_size': model_opt.src_word_vec_size,
-                'position_encoding': model_opt.position_encoding,
-                'feat_merge': model_opt.feat_merge,
-                'feat_vec_exponent': model_opt.feat_vec_exponent,
-                'feat_vec_size': model_opt.feat_vec_size}
     cuda = (len(model_opt.gpuid) > 0)
+    embeddings = onmt.Models.build_embeddings(
+                model_opt, src_dict.stoi[onmt.IO.PAD_WORD],
+                len(src_dict), for_encoder=True)
     encoder = onmt.Models.Encoder(model_opt.encoder_type, model_opt.brnn,
                                   model_opt.rnn_type, model_opt.enc_layers,
                                   model_opt.rnn_size, model_opt.dropout,
-                                  cuda, src_dict, None, **emb_opts)
-    decoder = onmt.Models.Decoder(model_opt, cuda, tgt_dict, **emb_opts)
+                                  cuda, embeddings)
+    embeddings = onmt.Models.build_embeddings(
+                model_opt, tgt_dict.stoi[onmt.IO.PAD_WORD],
+                len(tgt_dict), for_encoder=False)
+    decoder = onmt.Models.Decoder(model_opt, cuda, embeddings)
     encoder_embeddings = encoder.word_lut.weight.data.tolist()
     decoder_embeddings = decoder.word_lut.weight.data.tolist()
 

--- a/tools/extract_embeddings.py
+++ b/tools/extract_embeddings.py
@@ -42,7 +42,10 @@ def main():
                 'feat_vec_exponent': model_opt.feat_vec_exponent,
                 'feat_vec_size': model_opt.feat_vec_size}
     cuda = (len(model_opt.gpuid) > 0)
-    encoder = onmt.Models.Encoder(model_opt, cuda, src_dict, None, **emb_opts)
+    encoder = onmt.Models.Encoder(model_opt.encoder_type, model_opt.brnn,
+                                  model_opt.rnn_type, model_opt.enc_layers,
+                                  model_opt.rnn_size, model_opt.dropout,
+                                  cuda, src_dict, None, **emb_opts)
     decoder = onmt.Models.Decoder(model_opt, cuda, tgt_dict, **emb_opts)
     encoder_embeddings = encoder.word_lut.weight.data.tolist()
     decoder_embeddings = decoder.word_lut.weight.data.tolist()

--- a/tools/pull_request_chk.sh
+++ b/tools/pull_request_chk.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Run this script and fix *any* error before sending PR.
+
+LOG_FILE=/tmp/$$_pull_request_chk.log
+echo > ${LOG_FILE} # Empty the log file.
+
+PROJECT_ROOT=`dirname "$0"`"/.."
+DATA_DIR="$PROJECT_ROOT/data"
+
+clean_up()
+{
+    rm ${LOG_FILE}
+}
+trap clean_up SIGINT SIGQUIT SIGKILL
+
+error_exit()
+{
+    echo "Failed !" | tee -a ${LOG_FILE}
+    echo "[!] Check ${LOG_FILE} for detail."
+    exit 1
+}
+
+
+# flake8 check
+echo -n "[+] Doing flake8 check..."
+python -m flake8 >> ${LOG_FILE} 2>&1
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
+
+
+# unittest
+echo -n "[+] Doing unittest test..."
+python -m unittest discover >> ${LOG_FILE} 2>&1
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
+
+
+# Preprocess test
+echo -n "[+] Doing preprocess test..."
+python preprocess.py -train_src ${DATA_DIR}/src-train.txt \
+		     -train_tgt ${DATA_DIR}/tgt-train.txt \
+		     -valid_src ${DATA_DIR}/src-val.txt \
+		     -valid_tgt ${DATA_DIR}/tgt-val.txt \
+		     -save_data /tmp/data \
+		     -src_vocab_size 1000 \
+		     -tgt_vocab_size 1000  >> ${LOG_FILE} 2>&1
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
+
+
+# Translation test
+echo -n "[+] Doing translation test..."
+head ${DATA_DIR}/src-test.txt > /tmp/src-test.txt
+python translate.py -model ${DATA_DIR}/test_model.pt -src /tmp/src-test.txt -verbose >> ${LOG_FILE} 2>&1
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
+
+
+# Train + Translation test
+echo -n "[+] Doing preprocess + train + translation test..."
+head ${DATA_DIR}/src-val.txt > /tmp/src-val.txt
+head ${DATA_DIR}/tgt-val.txt > /tmp/tgt-val.txt
+python preprocess.py -train_src /tmp/src-val.txt \
+		     -train_tgt /tmp/tgt-val.txt \
+		     -valid_src /tmp/src-val.txt \
+		     -valid_tgt /tmp/tgt-val.txt \
+		     -save_data /tmp/q           \
+		     -src_vocab_size 1000        \
+		     -tgt_vocab_size 1000        >> ${LOG_FILE} 2>&1
+python train.py -data /tmp/q -rnn_size 2 -batch_size 10 \
+		-word_vec_size 5 -report_every 5        \
+		-rnn_size 10 -epochs 1                 >> ${LOG_FILE} 2>&1
+python translate.py -model ${DATA_DIR}/test_model2.pt  \
+		    -src ${DATA_DIR}/test_model2.src   \
+		    -verbose -batch_size 10     \
+		    -beam_size 10               \
+		    -tgt ${DATA_DIR}/test_model2.tgt   \
+		    -out /tmp/trans             >> ${LOG_FILE} 2>&1
+diff ${DATA_DIR}/test_model2.tgt /tmp/trans
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
+
+clean_up

--- a/train.py
+++ b/train.py
@@ -246,9 +246,7 @@ def main():
     print(' * maximum batch size. %d' % opt.batch_size)
 
     print('Building model...')
-    cuda = (len(opt.gpuid) >= 1)
-    model = onmt.Models.make_base_model(opt, model_opt,
-                                        fields, cuda, checkpoint)
+    model = onmt.Models.make_base_model(opt, model_opt, fields, checkpoint)
     print(model)
 
     if opt.train_from:


### PR DESCRIPTION
#  **V1** 

This is the first patch series, addressing Issue https://github.com/OpenNMT/OpenNMT-py/issues/196.

This patch series refactors the `Encoder` class.

To do this, I chose a bottom-up way, that is refactoring the class used in `Encoder` class first, which are
`Embeddings` class and `TransformerEncoder` class, then refactor the `Encoder` class itself.

For the `Embeddings` class, since it is also used by `Decoder` class, which I will refactor in later series,
 I collect its needed options into a dictionary. So the `Encoder` class constructor would not be too cluttered.

To ease review, I split the patches into 4 parts incrementally:

patch 76fcdda2c5a2:  just a arg tidy-up.
patch 576d9cb560ac:  prep patch, refactored the `Embeddings` class
patch 49143d84ae20:  prep patch, refactored the `TransformerEncoder` class
patch dcf2a92882fa:  refactored the `Encoder` class

P.S. Every patch has been tested(flake8'ed, unittest'ed, run) successfully before applying the next one. 

P.P.S. These constructors might not be the final versions, but currently we just expose their needed options first, after these refactorization works are all finished, we could optimize them further if needed
(for example, the `cuda` option is used by many classes, so we can consider making it a gloal variable and not passing it).
