### PR TITLE
torchtext.data.iterator have add reverse

### DIFF
--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -89,7 +89,7 @@ class ONMTDataset(torchtext.data.Dataset):
     @staticmethod
     def sort_key(ex):
         "Sort in reverse size order"
-        return -len(ex.src)
+        return len(ex.src)
 
     def __init__(self, src_path, tgt_path, fields, opt,
                  src_img_dir=None, **kwargs):


### PR DESCRIPTION
For a new starter, the latest torchtext have added reverse operation, then it  will cause error "lengths argument in Encoder.forward() is not sorted by decreasing order" in rnn.
So there may need update the sign of self.sort_key()