### PR TITLE
minor fix in translator to make it work with tgt and gpu

### DIFF
--- a/onmt/Translator.py
+++ b/onmt/Translator.py
@@ -67,7 +67,8 @@ class Translator(object):
 
         #  (2) if a target is specified, compute the 'goldScore'
         #  (i.e. log likelihood) of the target under the model
-        goldScores = torch.FloatTensor(batch.batch_size).fill_(0)
+        tt = torch.cuda if self.opt.cuda else torch
+        goldScores = tt.FloatTensor(batch.batch_size).fill_(0)
         decOut, decStates, attn = self.model.decoder(
             batch.tgt[:-1], src, context, decStates)
 


### PR DESCRIPTION
Thanks for fixing #188 . When I run translate.py with --tgt and --gpu 1 I get the following stack trace, which should be fixed by the pull request.

```
  File "translate.py", line 151, in <module>
    main()
  File "translate.py", line 94, in main
    = translator.translate(batch, data)
  File "/home/marcotcr/OpenNMT-py/onmt/Translator.py", line 188, in translate
    pred, predScore, attn, goldScore = self.translateBatch(batch, data)
  File "/home/marcotcr/OpenNMT-py/onmt/Translator.py", line 163, in translateBatch
    allGold = self._runTarget(batch, dataset)
  File "/home/marcotcr/OpenNMT-py/onmt/Translator.py", line 83, in _runTarget
    goldScores += scores
  File "/home/marcotcr/.local/lib/python2.7/site-packages/torch/tensor.py", line 297, in __iadd__
    return self.add_(other)
TypeError: add_ received an invalid combination of arguments - got (torch.cuda.FloatTensor), but expected one of:
 * (float value)
      didn't match because some of the arguments have invalid types: (torch.cuda.FloatTensor)
 * (torch.FloatTensor other)
      didn't match because some of the arguments have invalid types: (torch.cuda.FloatTensor)
 * (torch.SparseFloatTensor other)
      didn't match because some of the arguments have invalid types: (torch.cuda.FloatTensor)
 * (float value, torch.FloatTensor other)
 * (float value, torch.SparseFloatTensor other)
```