### PR TITLE
Fix bug that dynamic_dict cannot be used with pickle

### DIFF
--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -11,6 +11,13 @@ BOS_WORD = '<s>'
 EOS_WORD = '</s>'
 
 
+def __getstate__(self):
+    return dict(self.__dict__, stoi=dict(self.stoi))
+
+
+torchtext.vocab.Vocab.__getstate__ = __getstate__
+
+
 def extractFeatures(tokens):
     "Given a list of token separate out words and features (if any)."
     words = []
@@ -82,7 +89,6 @@ class OrderedIterator(torchtext.data.Iterator):
                                           self.batch_size_fn):
                 self.batches.append(sorted(b, key=self.sort_key))
 
-
 class ONMTDataset(torchtext.data.Dataset):
     """Defines a dataset for machine translation."""
 
@@ -132,7 +138,7 @@ class ONMTDataset(torchtext.data.Dataset):
 
                         self.src_vocabs.append(src_vocab)
                         examples[i]["src_map"] = src_map
-
+                        
                 else:
                     # TODO finish this.
                     if not transforms:
@@ -155,12 +161,13 @@ class ONMTDataset(torchtext.data.Dataset):
                     examples[i]["tgt"] = tgt
 
                     if opt is None or opt.dynamic_dict:
-                        src_vocab = self.src_vocabs[i]
-                        # Map target tokens to indices in the dynamic dict
-                        mask = torch.LongTensor(len(tgt)+2).fill_(0)
-                        for j in range(len(tgt)):
-                            mask[j+1] = src_vocab.stoi[tgt[j]]
-                        examples[i]["alignment"] = mask
+                        pass
+                        # src_vocab = self.src_vocabs[i]
+                        # # Map target tokens to indices in the dynamic dict
+                        # mask = torch.LongTensor(len(tgt)+2).fill_(0)
+                        # for j in range(len(tgt)):
+                        #     mask[j+1] = src_vocab.stoi[tgt[j]]
+                        # examples[i]["alignment"] = mask
                 assert i + 1 == len(examples), "Len src and tgt do not match"
         keys = examples[0].keys()
         fields = [(k, fields[k]) for k in keys]

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -89,6 +89,7 @@ class OrderedIterator(torchtext.data.Iterator):
                                           self.batch_size_fn):
                 self.batches.append(sorted(b, key=self.sort_key))
 
+
 class ONMTDataset(torchtext.data.Dataset):
     """Defines a dataset for machine translation."""
 
@@ -138,7 +139,7 @@ class ONMTDataset(torchtext.data.Dataset):
 
                         self.src_vocabs.append(src_vocab)
                         examples[i]["src_map"] = src_map
-                        
+
                 else:
                     # TODO finish this.
                     if not transforms:
@@ -161,13 +162,12 @@ class ONMTDataset(torchtext.data.Dataset):
                     examples[i]["tgt"] = tgt
 
                     if opt is None or opt.dynamic_dict:
-                        pass
-                        # src_vocab = self.src_vocabs[i]
-                        # # Map target tokens to indices in the dynamic dict
-                        # mask = torch.LongTensor(len(tgt)+2).fill_(0)
-                        # for j in range(len(tgt)):
-                        #     mask[j+1] = src_vocab.stoi[tgt[j]]
-                        # examples[i]["alignment"] = mask
+                        src_vocab = self.src_vocabs[i]
+                        # Map target tokens to indices in the dynamic dict
+                        mask = torch.LongTensor(len(tgt)+2).fill_(0)
+                        for j in range(len(tgt)):
+                            mask[j+1] = src_vocab.stoi[tgt[j]]
+                        examples[i]["alignment"] = mask
                 assert i + 1 == len(examples), "Len src and tgt do not match"
         keys = examples[0].keys()
         fields = [(k, fields[k]) for k in keys]


### PR DESCRIPTION
There is a bug right now that prevents preprocessing with the `dynamic_dict` option. This is due to stoi in torchtext.vocab.Vocab using a defaultdict with a lambda function. These functions are not pickleable without using dill. 
Since we got rid of dill, we need a change to torchtext itself. For now, I built a workaround but we should ping the guys to change the stoi defaultdict to a named function or to return a normal dict in `__getstate__`

