### PR TITLE
ImageEncoder: Modify its constuctor for accepting options explicitly

### DIFF
--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -612,7 +612,10 @@ def make_base_model(opt, model_opt, fields, checkpoint=None):
                           model_opt.rnn_size, model_opt.dropout,
                           embeddings)
     elif model_opt.model_type == "img":
-        encoder = onmt.modules.ImageEncoder(model_opt)
+        encoder = onmt.modules.ImageEncoder(model_opt.layers,
+                                            model_opt.brnn,
+                                            model_opt.rnn_size,
+                                            model_opt.dropout)
     else:
         assert False, ("Unsupported model type %s"
                        % (model_opt.model_type))

--- a/onmt/modules/ImageEncoder.py
+++ b/onmt/modules/ImageEncoder.py
@@ -6,11 +6,21 @@ from torch.autograd import Variable
 
 
 class ImageEncoder(nn.Module):
-    def __init__(self, opt):
+    """
+    Encoder recurrent neural network for Images.
+    """
+    def __init__(self, num_layers, bidirectional, rnn_size, dropout):
+        """
+        Args:
+            num_layers (int): number of Encoder layers.
+            bidirectional (bool): bidirectional Encoder.
+            rnn_size (int): size of hidden states of the rnn.
+            dropout (float): dropout probablity.
+        """
         super(ImageEncoder, self).__init__()
-        self.layers = opt.layers
-        self.num_directions = 2 if opt.brnn else 1
-        self.hidden_size = opt.rnn_size
+        self.num_layers = num_layers
+        self.num_directions = 2 if bidirectional else 1
+        self.hidden_size = rnn_size
 
         self.layer1 = nn.Conv2d(3,   64, kernel_size=(3, 3),
                                 padding=(1, 1), stride=(1, 1))
@@ -30,13 +40,14 @@ class ImageEncoder(nn.Module):
         self.batch_norm3 = nn.BatchNorm2d(512)
 
         input_size = 512
-        self.rnn = nn.LSTM(input_size, opt.rnn_size,
-                           num_layers=opt.layers,
-                           dropout=opt.dropout,
-                           bidirectional=opt.brnn)
+        self.rnn = nn.LSTM(input_size, rnn_size,
+                           num_layers=num_layers,
+                           dropout=dropout,
+                           bidirectional=bidirectional)
         self.pos_lut = nn.Embedding(1000, input_size)
 
     def load_pretrained_vectors(self, opt):
+        # Pass in needed options only when modify function definition.
         pass
 
     def forward(self, input, lengths=None):


### PR DESCRIPTION
This pull request has only one patch:

e7c1acb:  ImageEncoder: Modify its constuctor for accepting options explicitly

It would have been part of the `Encoder` refactorization series, but since it is quite independent from other parts, thus it warrants a standalone patch.

