### PR TITLE
Refactor IO.ONMTDataset

### DIFF
--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -50,14 +50,7 @@ def merge_vocabs(vocabs, vocab_size=None):
     Return:
         `torchtext.vocab.Vocab`
     """
-    merged = Counter()
-    # take the counts of the disjoint union of all the vocabs
-    for vocab in vocabs:
-        # XXX note that `vocab.freqs` does not contain special symbols
-        for word, count in vocab.freqs.most_common():
-            if word not in merged:
-                merged[word] = 0
-            merged[word] += count
+    merged = Counter(chain(*[vocab.freqs for vocab in vocabs]))
     return torchtext.vocab.Vocab(merged,
                                  specials=[PAD_WORD, BOS_WORD, EOS_WORD],
                                  max_size=vocab_size)

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -298,7 +298,7 @@ class ONMTDataset(torchtext.data.Dataset):
         def make_src(data, _):
             src_size = max([t.size(0) for t in data])
             src_vocab_size = max([t.max() for t in data]) + 1
-            alignment = torch.zeros(src_size, len(data), src_vocab_size)
+            alignment = torch.zeros(src_size, len(data), src_vocab_size).long()
             for i in range(len(data)):
                 for j, t in enumerate(data[i]):
                     alignment[j, i, t] = 1
@@ -310,7 +310,7 @@ class ONMTDataset(torchtext.data.Dataset):
 
         def make_tgt(data, _):
             tgt_size = max([t.size(0) for t in data])
-            alignment = torch.zeros(tgt_size, len(data))
+            alignment = torch.zeros(tgt_size, len(data)).long()
             for i in range(len(data)):
                 alignment[:data[i].size(0), i] = data[i]
             return alignment

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -305,7 +305,7 @@ class ONMTDataset(torchtext.data.Dataset):
             return alignment
 
         fields["src_map"] = torchtext.data.Field(
-            use_vocab=False, tensor_type=torch.FloatTensor,
+            use_vocab=False, tensor_type=torch.LongTensor,
             postprocessing=make_src, sequential=False)
 
         def make_tgt(data, _):

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -114,8 +114,8 @@ class ONMTDataset(torchtext.data.Dataset):
         if self.type_ == "text":
             self.src_vocabs = []
             src_truncate = 0 if opt is None else opt.src_seq_length_trunc
-            src_data = self.read_corpus_file(src_path, src_truncate)
-            src_examples = self.construct_examples(src_data, "src")
+            src_data = self._read_corpus_file(src_path, src_truncate)
+            src_examples = self._construct_examples(src_data, "src")
             self.nfeatures = src_data[0][2]
         else:
             # TODO finish this.
@@ -124,10 +124,10 @@ class ONMTDataset(torchtext.data.Dataset):
 
         if tgt_path:
             tgt_truncate = 0 if opt is None else opt.tgt_seq_length_trunc
-            tgt_data = self.read_corpus_file(tgt_path, tgt_truncate)
+            tgt_data = self._read_corpus_file(tgt_path, tgt_truncate)
             assert len(src_data) == len(tgt_data), \
                 "Len src and tgt do not match"
-            tgt_examples = self.construct_examples(tgt_data, "tgt")
+            tgt_examples = self._construct_examples(tgt_data, "tgt")
         else:
             tgt_examples = None
 

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -26,28 +26,16 @@ torchtext.vocab.Vocab.__setstate__ = __setstate__
 
 def extractFeatures(tokens):
     "Given a list of token separate out words and features (if any)."
-    words = []
-    features = []
-    numFeatures = None
 
-    for t in range(len(tokens)):
-        field = tokens[t].split(u"￨")
-        word = field[0]
-        if len(word) > 0:
-            words.append(word)
-            if numFeatures is None:
-                numFeatures = len(field) - 1
-            else:
-                assert (len(field) - 1 == numFeatures), \
-                    "all words must have the same number of features"
-
-            if len(field) > 1:
-                for i in range(1, len(field)):
-                    if len(features) <= i-1:
-                        features.append([])
-                    features[i - 1].append(field[i])
-                    assert (len(features[i - 1]) == len(words))
-    return words, features, numFeatures if numFeatures else 0
+    split_tokens = [token.split(u"￨") for token in tokens]
+    split_tokens = [token for token in split_tokens if token[0]]
+    token_size = len(split_tokens[0])
+    assert all(len(token) == token_size for token in split_tokens), \
+        "all words must have the same number of features"
+    words_and_features = list(zip(*split_tokens))
+    words = words_and_features[0]
+    features = words_and_features[1:]
+    return words, features, token_size - 1
 
 
 def merge_vocabs(vocabs, vocab_size=None):

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -174,7 +174,7 @@ class ONMTDataset(torchtext.data.Dataset):
                                           filter_pred if opt is not None
                                           else None)
 
-    def read_corpus_file(self, path, truncate):
+    def _read_corpus_file(self, path, truncate):
         """
         path: location of a src or tgt file
         truncate: maximum sequence length (0 for unlimited)
@@ -187,7 +187,7 @@ class ONMTDataset(torchtext.data.Dataset):
                 lines = (line[:truncate] for line in lines)
             return [extract_features(line) for line in lines]
 
-    def construct_examples(self, lines, side):
+    def _construct_examples(self, lines, side):
         assert side in ["src", "tgt"]
         examples = []
         for line in lines:

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -149,18 +149,15 @@ class ONMTDataset(torchtext.data.Dataset):
                 src_vocab = torchtext.vocab.Vocab(Counter(src))
                 self.src_vocabs.append(src_vocab)
                 # mapping source tokens to indices in the dynamic dict
-                src_map = torch.zeros(len(src)).long()
-                for j, w in enumerate(src):
-                    src_map[j] = src_vocab.stoi[w]
+                src_map = torch.LongTensor([src_vocab.stoi[w] for w in src])
 
                 self.src_vocabs.append(src_vocab)
                 example["src_map"] = src_map
 
                 if "tgt" in example:
                     tgt = example["tgt"]
-                    mask = torch.zeros(len(tgt) + 2).long()
-                    for j, word in enumerate(tgt, 1):
-                        mask[j] = src_vocab.stoi[word]
+                    mask = torch.LongTensor(
+                            [0] + [src_vocab.stoi[w] for w in tgt] + [0])
                     example["alignment"] = mask
 
         keys = examples[0].keys()
@@ -213,7 +210,7 @@ class ONMTDataset(torchtext.data.Dataset):
         "This is a hack. Something is broken with torch pickle."
         return super(ONMTDataset, self).__reduce_ex__()
 
-    def collapseCopyScores(self, scores, batch, tgt_vocab):
+    def collapse_copy_scores(self, scores, batch, tgt_vocab):
         """Given scores from an expanded dictionary
         corresponeding to a batch, sums together copies,
         with a dictionary word when it is ambigious.

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -298,14 +298,14 @@ class ONMTDataset(torchtext.data.Dataset):
         def make_src(data, _):
             src_size = max([t.size(0) for t in data])
             src_vocab_size = max([t.max() for t in data]) + 1
-            alignment = torch.zeros(src_size, len(data), src_vocab_size).long()
+            alignment = torch.zeros(src_size, len(data), src_vocab_size)
             for i in range(len(data)):
                 for j, t in enumerate(data[i]):
                     alignment[j, i, t] = 1
             return alignment
 
         fields["src_map"] = torchtext.data.Field(
-            use_vocab=False, tensor_type=torch.LongTensor,
+            use_vocab=False, tensor_type=torch.FloatTensor,
             postprocessing=make_src, sequential=False)
 
         def make_tgt(data, _):

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -289,8 +289,8 @@ class ONMTDataset(torchtext.data.Dataset):
             src_size = max([t.size(0) for t in data])
             src_vocab_size = max([t.max() for t in data]) + 1
             alignment = torch.zeros(src_size, len(data), src_vocab_size)
-            for i in range(len(data)):
-                for j, t in enumerate(data[i]):
+            for i, sent in enumerate(data):
+                for j, t in enumerate(sent):
                     alignment[j, i, t] = 1
             return alignment
 
@@ -301,8 +301,8 @@ class ONMTDataset(torchtext.data.Dataset):
         def make_tgt(data, _):
             tgt_size = max([t.size(0) for t in data])
             alignment = torch.zeros(tgt_size, len(data)).long()
-            for i in range(len(data)):
-                alignment[:data[i].size(0), i] = data[i]
+            for i, sent in enumerate(data):
+                alignment[:sent.size(0), i] = sent
             return alignment
 
         fields["alignment"] = torchtext.data.Field(

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -25,7 +25,7 @@ torchtext.vocab.Vocab.__getstate__ = __getstate__
 torchtext.vocab.Vocab.__setstate__ = __setstate__
 
 
-def extractFeatures(tokens):
+def extract_features(tokens):
     "Given a list of token separate out words and features (if any)."
 
     split_tokens = [token.split(u"￨") for token in tokens]
@@ -188,7 +188,7 @@ class ONMTDataset(torchtext.data.Dataset):
             lines = (line.split() for line in corpus_file)
             if truncate:
                 lines = (line[:truncate] for line in lines)
-            return [extractFeatures(line) for line in lines]
+            return [extract_features(line) for line in lines]
 
     def construct_examples(self, lines, side):
         assert side in ["src", "tgt"]

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -120,7 +120,7 @@ class ONMTDataset(torchtext.data.Dataset):
         else:
             # TODO finish this.
             if not transforms:
-                loadImageLibs()
+                load_image_libs()
 
         if tgt_path:
             tgt_truncate = 0 if opt is None else opt.tgt_seq_length_trunc
@@ -338,7 +338,7 @@ class ONMTDataset(torchtext.data.Dataset):
             fields["tgt"].vocab = merged_vocab
 
 
-def loadImageLibs():
+def load_image_libs():
     "Conditional import of torch image libs."
     global Image, transforms
     from PIL import Image

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -4,7 +4,7 @@ import codecs
 import torchtext.data
 import torchtext.vocab
 from collections import Counter, defaultdict
-from itertools import chain
+from itertools import chain, count
 
 PAD_WORD = '<blank>'
 UNK = 0
@@ -74,7 +74,7 @@ def make_features(batch, fields):
 def join_dicts(*args):
     """
     args: dictionaries with disjoint keys
-    returns: a single dictionary that is the union of these keys
+    returns: a single dictionary that has the union of these keys
     """
     return dict(chain(*[d.items() for d in args]))
 
@@ -260,25 +260,21 @@ class ONMTDataset(torchtext.data.Dataset):
     @staticmethod
     def collect_features(fields):
         feats = []
-        j = 0
-        while True:
+        for j in count():
             key = "src_feat_" + str(j)
             if key not in fields:
                 break
             feats.append(key)
-            j += 1
         return feats
 
     @staticmethod
     def collect_feature_dicts(fields):
         feature_dicts = []
-        j = 0
-        while True:
+        for j in count():
             key = "src_feat_" + str(j)
             if key not in fields:
                 break
             feature_dicts.append(fields[key].vocab)
-            j += 1
         return feature_dicts
 
     @staticmethod
@@ -302,8 +298,7 @@ class ONMTDataset(torchtext.data.Dataset):
         def make_src(data, _):
             src_size = max([t.size(0) for t in data])
             src_vocab_size = max([t.max() for t in data]) + 1
-            alignment = torch.FloatTensor(src_size, len(data),
-                                          src_vocab_size).fill_(0)
+            alignment = torch.zeros(src_size, len(data), src_vocab_size)
             for i in range(len(data)):
                 for j, t in enumerate(data[i]):
                     alignment[j, i, t] = 1
@@ -315,7 +310,7 @@ class ONMTDataset(torchtext.data.Dataset):
 
         def make_tgt(data, _):
             tgt_size = max([t.size(0) for t in data])
-            alignment = torch.LongTensor(tgt_size, len(data)).fill_(0)
+            alignment = torch.zeros(tgt_size, len(data))
             for i in range(len(data)):
                 alignment[:data[i].size(0), i] = data[i]
             return alignment

--- a/onmt/Loss.py
+++ b/onmt/Loss.py
@@ -171,7 +171,7 @@ class LossCompute:
             scores = self.generator(bottle(out), bottle(attn), batch.src_map)
             loss = self.crit(scores, align, target)
             scores_data = scores.data.clone()
-            scores_data = self.dataset.collapseCopyScores(
+            scores_data = self.dataset.collapse_copy_scores(
                 unbottle(scores_data), batch, self.tgt_vocab)
             scores_data = bottle(scores_data)
 

--- a/onmt/Translator.py
+++ b/onmt/Translator.py
@@ -148,7 +148,7 @@ class Translator(object):
                                                    attn["copy"].squeeze(0),
                                                    srcMap)
                 # beam x (tgt_vocab + extra_vocab)
-                out = dataset.collapseCopyScores(
+                out = dataset.collapse_copy_scores(
                     unbottle(out.data),
                     batch, self.fields["tgt"].vocab)
                 # beam x tgt_vocab

--- a/preprocess.py
+++ b/preprocess.py
@@ -52,7 +52,7 @@ def main():
     print('Preparing training ...')
     with codecs.open(opt.train_src, "r", "utf-8") as src_file:
         src_line = src_file.readline().strip().split()
-        _, _, nFeatures = onmt.IO.extractFeatures(src_line)
+        _, _, nFeatures = onmt.IO.extract_features(src_line)
 
     fields = onmt.IO.ONMTDataset.get_fields(nFeatures)
     print("Building Training...")


### PR DESCRIPTION
The goal of this pull request is to simplify the process by which source and target files are read in and converted into ONMTDataset objects. The contributions can be divided into three parts:

1) I shortened `extractFeatures` so that the reader of code no longer needs to keep track of indexing logic, but merely a sequence of comprehensions with descriptive names. This also allows the assertion requiring all words to have the same number of features to be expressed in a clearer way. The `zip(*split_tokens)` trick is not always completely intuitive to the reader, but it is well-documented on the internet as a way to unzip a zipped sequence.

2) I rewrote the `ONMTDataset` constructor. Its previous iteration had two large loops, one for the source file and the other for the target file. I abstracted out the logic for reading and tokenizing a source/target file and put it in the `read_corpus_file` method. As well as separating file I/O from the distinct task of building the examples list for torchtext, this also makes the assertion that the source and target files be the same length much clearer. I also wrote a `construct_examples` method for creating the examples dictionaries for either the source or target sides separately. The source and target dictionaries can then easily be merged. This limits the duplication of similar/identical code for processing the source and target sides, and should make it easier to extend OpenNMT-py to allow target features. 

3) I made miscellaneous small changes to the code elsewhere, such as using the `torch.zeros().long()` constructor instead of making an empty `LongTensor` and filling it with zeros, as I believe that is slightly more efficient. I replaced `while True` loops with `count()` (although the fact that we have to do either of these things just to get the features dicts is a little frustrating).

This is just a first attempt; I think more refactoring should be possible.