### PR TITLE
Give decoder input an nfeat dimension

### DIFF
--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -56,12 +56,20 @@ def merge_vocabs(vocabs, vocab_size=None):
                                  max_size=vocab_size)
 
 
-def make_features(batch, fields):
-    # TODO: This is bit hacky, add to batch somehow.
-    f = ONMTDataset.collect_features(fields)
-    cat = [batch.src[0]] + [batch.__dict__[k] for k in f]
-    cat = [c.unsqueeze(2) for c in cat]
-    return torch.cat(cat, 2)
+def make_features(batch, side):
+    """
+    data (Variable): a batch of source or target data
+    """
+    assert side in ['src', 'tgt']
+    if isinstance(batch.__dict__[side], tuple):
+        data = batch.__dict__[side][0]
+    else:
+        data = batch.__dict__[side]
+    feat_start = side + "_feat_"
+    features = sorted(batch.__dict__[k]
+                      for k in batch.__dict__ if feat_start in k)
+    levels = [data] + features
+    return torch.cat([level.unsqueeze(2) for level in levels], 2)
 
 
 def join_dicts(*args):

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -58,7 +58,7 @@ def merge_vocabs(vocabs, vocab_size=None):
 
 def make_features(batch, side):
     """
-    data (Variable): a batch of source or target data
+    batch (Variable): a batch of source or target data
     """
     assert side in ['src', 'tgt']
     if isinstance(batch.__dict__[side], tuple):

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -62,8 +62,8 @@ class Embeddings(nn.Module):
                                       len(num_feat_embeddings))
             else:
                 # mlp feature merge
-                embedding_dims.extend([feat_embedding_dim]
-                                      * len(num_feat_embeddings))
+                embedding_dims.extend([feat_embedding_dim] *
+                                      len(num_feat_embeddings))
                 # apply a layer of mlp to get it down to the correct dim
                 self.mlp = nn.Sequential(onmt.modules.BottleLinear(
                                         sum(embedding_dims),

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -375,7 +375,7 @@ class Decoder(nn.Module):
                 output, attn \
                     = self.transformer[i](output, src_context,
                                           src[:, :, 0].transpose(0, 1),
-                                          input.transpose(0, 1))
+                                          input[:, :, 0].transpose(0, 1))
             outputs = output.transpose(0, 1).contiguous()
             if state.previous_input:
                 outputs = outputs[state.previous_input.size(0):]

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -331,7 +331,7 @@ class Decoder(nn.Module):
         Forward through the decoder.
 
         Args:
-            input (LongTensor):  (len x batch) -- Input tokens
+            input (LongTensor):  (len x batch x nfeats) -- Input tokens
             src (LongTensor)
             context:  (src_len x batch x rnn_size)  -- Memory bank
             state: an object initializing the decoder.
@@ -342,7 +342,7 @@ class Decoder(nn.Module):
             attns: Dictionary of (src_len x batch)
         """
         # CHECKS
-        t_len, n_batch = input.size()
+        t_len, n_batch, _ = input.size()
         s_len, n_batch_, _ = src.size()
         s_len_, n_batch__, _ = context.size()
         aeq(n_batch, n_batch_, n_batch__)
@@ -350,9 +350,9 @@ class Decoder(nn.Module):
         # END CHECKS
         if self.decoder_type == "transformer":
             if state.previous_input:
-                input = torch.cat([state.previous_input.squeeze(2), input], 0)
+                input = torch.cat([state.previous_input, input], 0)
 
-        emb = self.embeddings(input.unsqueeze(2))
+        emb = self.embeddings(input)
 
         # n.b. you can increase performance if you compute W_ih * x for all
         # iterations in parallel, but that's only possible if

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -384,7 +384,7 @@ class Decoder(nn.Module):
             attns["std"] = attn
             if self._copy:
                 attns["copy"] = attn
-            state = TransformerDecoderState(input.unsqueeze(2))
+            state = TransformerDecoderState(input)
         elif self.input_feed:
             assert isinstance(state, RNNDecoderState)
             output = state.input_feed.squeeze(0)

--- a/onmt/Translator.py
+++ b/onmt/Translator.py
@@ -60,6 +60,7 @@ class Translator(object):
 
         _, src_lengths = batch.src
         src = onmt.IO.make_features(batch, 'src')
+        tgt_in = onmt.IO.make_features(batch, 'tgt')[:-1]
 
         #  (1) run the encoder on the src
         encStates, context = self.model.encoder(src, src_lengths)
@@ -70,7 +71,7 @@ class Translator(object):
         tt = torch.cuda if self.opt.cuda else torch
         goldScores = tt.FloatTensor(batch.batch_size).fill_(0)
         decOut, decStates, attn = self.model.decoder(
-            batch.tgt[:-1], src, context, decStates)
+            tgt_in, src, context, decStates)
 
         # print(decOut.size(), batch.tgt[1:].data.size())
         # aeq(decOut.size(), batch.tgt[1:].data.size())

--- a/onmt/Translator.py
+++ b/onmt/Translator.py
@@ -59,7 +59,7 @@ class Translator(object):
     def _runTarget(self, batch, data):
 
         _, src_lengths = batch.src
-        src = onmt.IO.make_features(batch, self.fields)
+        src = onmt.IO.make_features(batch, 'src')
 
         #  (1) run the encoder on the src
         encStates, context = self.model.encoder(src, src_lengths)
@@ -90,7 +90,7 @@ class Translator(object):
 
         #  (1) run the encoder on the src
         _, src_lengths = batch.src
-        src = onmt.IO.make_features(batch, self.fields)
+        src = onmt.IO.make_features(batch, 'src')
         encStates, context = self.model.encoder(src, src_lengths)
         decStates = self.model.init_decoder_state(context, encStates)
 
@@ -108,8 +108,7 @@ class Translator(object):
                           vocab=self.fields["tgt"].vocab)
                 for __ in range(batchSize)]
 
-        #  (2) run the decoder to generate sentences, using beam search
-        i = 0
+        #  (2) run the decoder to generate sentences, using beam search\
 
         def bottle(m):
             return m.view(batchSize * beamSize, -1)
@@ -131,6 +130,10 @@ class Translator(object):
             if self.copy_attn:
                 inp = inp.masked_fill(
                     inp.gt(len(self.fields["tgt"].vocab) - 1), 0)
+
+            # Temporary kludge solution to handle changed dim expectation
+            # in the decoder
+            inp = inp.unsqueeze(2)
 
             # Run one step.
             decOut, decStates, attn = \

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -31,7 +31,7 @@ class TestModel(unittest.TestCase):
     def get_batch(self, sourceL=3, bsize=1):
         # len x batch x nfeat
         test_src = Variable(torch.ones(sourceL, bsize, 1)).long()
-        test_tgt = Variable(torch.ones(sourceL, bsize)).long()
+        test_tgt = Variable(torch.ones(sourceL, bsize, 1)).long()
         test_length = torch.ones(bsize).fill_(sourceL)
         return test_src, test_tgt, test_length
 

--- a/train.py
+++ b/train.py
@@ -57,7 +57,7 @@ if opt.exp_host != "":
 
 
 def eval(model, criterion, data, fields):
-    validData = onmt.IO.OrderedIterator(
+    valid_data = onmt.IO.OrderedIterator(
         dataset=data, device=opt.gpuid[0] if opt.gpuid else -1,
         batch_size=opt.batch_size, train=False, sort=True)
 
@@ -65,7 +65,7 @@ def eval(model, criterion, data, fields):
     model.eval()
     loss = onmt.Loss.LossCompute(model.generator, criterion,
                                  fields["tgt"].vocab, data, 0, opt)
-    for batch in validData:
+    for batch in valid_data:
         _, src_lengths = batch.src
         src = onmt.IO.make_features(batch, 'src')
         tgt = onmt.IO.make_features(batch, 'tgt')
@@ -78,7 +78,7 @@ def eval(model, criterion, data, fields):
     return stats
 
 
-def trainModel(model, trainData, validData, fields, optim):
+def train_model(model, train_data, valid_data, fields, optim):
     model.train()
 
     pad_id = fields['tgt'].vocab.stoi[onmt.IO.PAD_WORD]
@@ -94,13 +94,13 @@ def trainModel(model, trainData, validData, fields, optim):
     splitter = onmt.Loss.Splitter(opt.max_generator_batches)
 
     train = onmt.IO.OrderedIterator(
-        dataset=trainData, batch_size=opt.batch_size,
+        dataset=train_data, batch_size=opt.batch_size,
         device=opt.gpuid[0] if opt.gpuid else -1,
         repeat=False)
 
-    def trainEpoch(epoch):
+    def train_epoch(epoch):
         closs = onmt.Loss.LossCompute(model.generator, criterion,
-                                      fields["tgt"].vocab, trainData,
+                                      fields["tgt"].vocab, train_data,
                                       epoch, opt)
 
         total_stats = onmt.Loss.Statistics()
@@ -165,12 +165,12 @@ def trainModel(model, trainData, validData, fields, optim):
         print('')
 
         #  (1) train for one epoch on the training set
-        train_stats = trainEpoch(epoch)
+        train_stats = train_epoch(epoch)
         print('Train perplexity: %g' % train_stats.ppl())
         print('Train accuracy: %g' % train_stats.accuracy())
 
         #  (2) evaluate on the validation set
-        valid_stats = eval(model, criterion, validData, fields)
+        valid_stats = eval(model, criterion, valid_data, fields)
         print('Validation perplexity: %g' % valid_stats.ppl())
         print('Validation accuracy: %g' % valid_stats.accuracy())
 
@@ -286,8 +286,8 @@ def main():
             checkpoint['optim'].optimizer.state_dict())
     optim.set_parameters(model.parameters())
 
-    nParams = sum([p.nelement() for p in model.parameters()])
-    print('* number of parameters: %d' % nParams)
+    n_params = sum([p.nelement() for p in model.parameters()])
+    print('* number of parameters: %d' % n_params)
     enc = 0
     dec = 0
     for name, param in model.named_parameters():
@@ -302,7 +302,7 @@ def main():
 
     check_model_path()
 
-    trainModel(model, train, valid, fields, optim)
+    train_model(model, train, valid, fields, optim)
 
 
 if __name__ == "__main__":

--- a/train.py
+++ b/train.py
@@ -67,8 +67,9 @@ def eval(model, criterion, data, fields):
                                  fields["tgt"].vocab, data, 0, opt)
     for batch in validData:
         _, src_lengths = batch.src
-        src = onmt.IO.make_features(batch, fields)
-        outputs, attn, _ = model(src, batch.tgt, src_lengths)
+        src = onmt.IO.make_features(batch, 'src')
+        tgt = onmt.IO.make_features(batch, 'tgt')
+        outputs, attn, _ = model(src, tgt, src_lengths)
         gen_state = loss.makeLossBatch(outputs, batch, attn,
                                        (0, batch.tgt.size(0)))
         _, batch_stats = loss.computeLoss(batch=batch, **gen_state)


### PR DESCRIPTION
This pull request makes a few small changes to IO.py, Models.py, Translator.py, and train.py. The goal of the changes is to make it to get rid of some of the artificial barriers that are currently standing in the way of implementing target features.

I have eliminated two of these obstacles:

1. Previously, `Decoder.forward()` expected an input whose dimensions were length x batch_size. A third dimension, analogous to the nfeat dimension used in the encoder, is added. Tensor logic is changed as necessary in the decoder to make use of these new dimensions.

2. Code in other files is changed as necessary so that the target variables passed to the decoder will be the correct size. This required abstracting out `make_features` in IO.py: now it accepts a batch object and a side (src or tgt) and constructs the length x batch_size x nfeat tensor. I'm not convinced that IO.py is the right place to be doing tensor operations like that, but it's the status quo. Consequently, `make_features` no longer needs the `ONMTDataset.collect_features` static method, which is hard-coded to only work for src sequences. I'm not certain if that function is necessary anywhere else, so for now I did not delete it. I then needed to call the new feature-making code everywhere where data is passed through the model: in train.py and translator.py.