### PR TITLE
Use setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='OpenNMT',
       version='0.1',


### PR DESCRIPTION
Setuptools is widely used and has more features than distutils; e.g., [Development Mode](http://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode)

```
python setup.py develop
```

which I think is useful for development.