### PR TITLE
Cleanups

### DIFF
--- a/onmt/ModelConstructor.py
+++ b/onmt/ModelConstructor.py
@@ -1,6 +1,6 @@
 """
 This file is for models creation, which consults options
-and create each Encoder and Decoder accordingly.
+and creates each encoder and decoder accordingly.
 """
 import torch.nn as nn
 
@@ -27,7 +27,7 @@ def make_embeddings(opt, word_padding_idx, feats_padding_idx,
                                 in the embeddings.
         num_word_embeddings(int): size of dictionary
                                  of embedding for words.
-        for_encoder(bool): make Embeddings for Encoder or Decoder?
+        for_encoder(bool): make Embeddings for encoder or decoder?
         num_feat_embeddings([int]): list of size of dictionary
                                     of embedding for each feature.
     """
@@ -49,10 +49,10 @@ def make_embeddings(opt, word_padding_idx, feats_padding_idx,
 
 def make_encoder(opt, embeddings):
     """
-    Encoder dispatcher function.
+    Various encoder dispatcher function.
     Args:
         opt: the option in current environment.
-        embeddings (Embeddings): vocab embeddings for this Encoder.
+        embeddings (Embeddings): vocab embeddings for this encoder.
     """
     if opt.encoder_type == "transformer":
         return TransformerEncoder(opt.enc_layers, opt.rnn_size,
@@ -71,10 +71,10 @@ def make_encoder(opt, embeddings):
 
 def make_decoder(opt, embeddings):
     """
-    Decoder dispatcher function.
+    Various decoder dispatcher function.
     Args:
         opt: the option in current environment.
-        embeddings (Embeddings): vocab embeddings for this Decoder.
+        embeddings (Embeddings): vocab embeddings for this decoder.
     """
     if opt.decoder_type == "transformer":
         return TransformerDecoder(opt.dec_layers, opt.rnn_size,
@@ -118,7 +118,7 @@ def make_base_model(opt, model_opt, fields, checkpoint=None):
     assert model_opt.model_type in ["text", "img"], \
         ("Unsupported model type %s" % (model_opt.model_type))
 
-    # Make Encoder.
+    # Make encoder.
     if model_opt.model_type == "text":
         src_vocab = fields["src"].vocab
         feature_dicts = ONMTDataset.collect_feature_dicts(fields)
@@ -138,7 +138,7 @@ def make_base_model(opt, model_opt, fields, checkpoint=None):
                                model_opt.rnn_size,
                                model_opt.dropout)
 
-    # Make Decoder.
+    # Make decoder.
     tgt_vocab = fields["tgt"].vocab
     # TODO: prepare for a future where tgt features are possible
     feats_padding_idx = []
@@ -149,7 +149,7 @@ def make_base_model(opt, model_opt, fields, checkpoint=None):
                                      for_encoder=False)
     decoder = make_decoder(model_opt, tgt_embeddings)
 
-    # Make NMTModel(= Encoder + Decoder).
+    # Make NMTModel(= encoder + decoder).
     model = NMTModel(encoder, decoder)
 
     # Make Generator.
@@ -163,7 +163,7 @@ def make_base_model(opt, model_opt, fields, checkpoint=None):
         generator = CopyGenerator(model_opt, fields["src"].vocab,
                                   fields["tgt"].vocab)
 
-    # Load the modle states from checkpoint.
+    # Load the model states from checkpoint.
     if checkpoint is not None:
         print('Loading model')
         model.load_state_dict(checkpoint['model'])
@@ -183,6 +183,7 @@ def make_base_model(opt, model_opt, fields, checkpoint=None):
     else:
         model.cpu()
         generator.cpu()
+
     model.generator = generator
 
     return model

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -2,8 +2,8 @@ from __future__ import division
 import torch
 import torch.nn as nn
 from torch.autograd import Variable
-from torch.nn.utils.rnn import pad_packed_sequence as unpack
 from torch.nn.utils.rnn import pack_padded_sequence as pack
+from torch.nn.utils.rnn import pad_packed_sequence as unpack
 
 import onmt
 from onmt.Utils import aeq
@@ -11,7 +11,7 @@ from onmt.Utils import aeq
 
 class EncoderBase(nn.Module):
     """
-    EncoderBase class for sharing code among various *Encoder.
+    EncoderBase class for sharing code among various encoder.
     """
     def _check_args(self, input, lengths=None, hidden=None):
         s_len, n_batch, n_feats = input.size()
@@ -27,14 +27,14 @@ class EncoderBase(nn.Module):
             hidden: Initial hidden state.
         Returns:
             hidden_t (Variable): Pair of layers x batch x rnn_size - final
-                                    Encoder state
+                                    encoder state
             outputs (FloatTensor):  len x batch x rnn_size -  Memory bank
         """
         raise NotImplementedError
 
 
 class MeanEncoder(EncoderBase):
-    """ A trivial encoder without RNN, just takes mean of as final state. """
+    """ A trivial encoder without RNN, just takes mean as final state. """
     def __init__(self, num_layers, embeddings):
         super(MeanEncoder, self).__init__()
         self.num_layers = num_layers
@@ -86,7 +86,7 @@ class RNNEncoder(EncoderBase):
 
 class RNNDecoderBase(nn.Module):
     """
-    RNN Decoder base class.
+    RNN decoder base class.
     """
     def __init__(self, rnn_type, bidirectional_encoder, num_layers,
                  hidden_size, attn_type, coverage_attn, context_gate,
@@ -134,16 +134,16 @@ class RNNDecoderBase(nn.Module):
         Args:
             input (LongTensor): a sequence of input tokens tensors
                                 of size (len x batch x nfeats).
-            context (FloatTensor): output(tensor sequence) from the Encoder
+            context (FloatTensor): output(tensor sequence) from the encoder
                         RNN of size (src_len x batch x hidden_size).
-            state (FloatTensor): hidden state from the Encoder RNN for
+            state (FloatTensor): hidden state from the encoder RNN for
                                  initializing the decoder.
         Returns:
-            outputs (FloatTensor): a Tensor sequence of output from the Decoder
+            outputs (FloatTensor): a Tensor sequence of output from the decoder
                                    of shape (len x batch x hidden_size).
-            state (FloatTensor): final hidden state from the Decoder.
+            state (FloatTensor): final hidden state from the decoder.
             attns (dict of (str, FloatTensor)): a dictionary of different
-                                type of attention Tensor from the Decoder
+                                type of attention Tensor from the decoder
                                 of shape (src_len x batch).
         """
         # Args Check
@@ -191,7 +191,7 @@ class RNNDecoderBase(nn.Module):
 
 class StdRNNDecoder(RNNDecoderBase):
     """
-    Stardard RNN Decoder, with Attention.
+    Stardard RNN decoder, with Attention.
     Currently no 'coverage_attn' and 'copy_attn' support.
     """
     def _run_forward_pass(self, input, context, state):
@@ -201,18 +201,18 @@ class StdRNNDecoder(RNNDecoderBase):
         Args:
             input (LongTensor): a sequence of input tokens tensors
                                 of size (len x batch x nfeats).
-            context (FloatTensor): output(tensor sequence) from the Encoder
+            context (FloatTensor): output(tensor sequence) from the encoder
                         RNN of size (src_len x batch x hidden_size).
-            state (FloatTensor): hidden state from the Encoder RNN for
+            state (FloatTensor): hidden state from the encoder RNN for
                                  initializing the decoder.
         Returns:
-            hidden (Variable): final hidden state from the Decoder.
+            hidden (Variable): final hidden state from the decoder.
             outputs ([FloatTensor]): an array of output of every time
-                                     step from the Decoder.
+                                     step from the decoder.
             attns (dict of (str, [FloatTensor]): a dictionary of different
                             type of attention Tensor array of every time
-                            step from the Decoder.
-            coverage (FloatTensor, optional): coverage from the Decoder.
+                            step from the decoder.
+            coverage (FloatTensor, optional): coverage from the decoder.
         """
         assert not self._copy  # TODO, no support yet.
         assert not self._coverage  # TODO, no support yet.
@@ -258,7 +258,7 @@ class StdRNNDecoder(RNNDecoderBase):
     def _build_rnn(self, rnn_type, input_size,
                    hidden_size, num_layers, dropout):
         """
-        Private helper for building standard Decoder RNN.
+        Private helper for building standard decoder RNN.
         """
         return getattr(nn, rnn_type)(
             input_size, hidden_size,
@@ -275,7 +275,7 @@ class StdRNNDecoder(RNNDecoderBase):
 
 class InputFeedRNNDecoder(RNNDecoderBase):
     """
-    Stardard RNN Decoder, with Input Feed and Attention.
+    Stardard RNN decoder, with Input Feed and Attention.
     """
     def _run_forward_pass(self, input, context, state):
         """
@@ -357,13 +357,13 @@ class InputFeedRNNDecoder(RNNDecoderBase):
 
 class NMTModel(nn.Module):
     """
-    The Encoder + Decoder Neural Machine Translation Model.
+    The encoder + decoder Neural Machine Translation Model.
     """
     def __init__(self, encoder, decoder, multigpu=False):
         """
         Args:
-            encoder(Encoder): the Encoder.
-            decoder(*Decoder): the various *Decoder.
+            encoder(*Encoder): the various encoder.
+            decoder(*Decoder): the various decoder.
             multigpu(bool): run parellel on multi-GPU?
         """
         self.multigpu = multigpu
@@ -381,7 +381,7 @@ class NMTModel(nn.Module):
             lengths([int]): an array of the src length.
             dec_state: A decoder state object
         Returns:
-            outputs (FloatTensor): (len x batch x hidden_size): Decoder outputs
+            outputs (FloatTensor): (len x batch x hidden_size): decoder outputs
             attns (FloatTensor): Dictionary of (src_len x batch)
             dec_hidden (FloatTensor): tuple (1 x batch x hidden_size)
                                       Init hidden state
@@ -427,13 +427,13 @@ class RNNDecoderState(DecoderState):
     def __init__(self, context, hidden_size, rnnstate):
         """
         Args:
-            context (FloatTensor): output from the Encoder of size
+            context (FloatTensor): output from the encoder of size
                                    len x batch x rnn_size.
-            hidden_size (int): the size of hidden layer of the Decoder.
-            rnnstate (Variable): final hidden state from the Encoder.
+            hidden_size (int): the size of hidden layer of the decoder.
+            rnnstate (Variable): final hidden state from the encoder.
                 transformed to shape: layers x batch x (directions*dim).
-            input_feed (FloatTensor): output from last layer of the Decoder.
-            coverage (FloatTensor): coverage output from the Decoder.
+            input_feed (FloatTensor): output from last layer of the decoder.
+            coverage (FloatTensor): coverage output from the decoder.
         """
         if not isinstance(rnnstate, tuple):
             self.hidden = (rnnstate,)

--- a/onmt/modules/Conv2Conv.py
+++ b/onmt/modules/Conv2Conv.py
@@ -134,16 +134,16 @@ class CNNDecoder(nn.Module):
         Args:
             input (LongTensor): a sequence of input tokens tensors
                                 of size (len x batch x nfeats).
-            context (FloatTensor): output(tensor sequence) from the Encoder
+            context (FloatTensor): output(tensor sequence) from the encoder
                         CNN of size (src_len x batch x hidden_size).
-            state (FloatTensor): hidden state from the Encoder CNN for
+            state (FloatTensor): hidden state from the encoder CNN for
                                  initializing the decoder.
         Returns:
-            outputs (FloatTensor): a Tensor sequence of output from the Decoder
+            outputs (FloatTensor): a Tensor sequence of output from the decoder
                                    of shape (len x batch x hidden_size).
-            state (FloatTensor): final hidden state from the Decoder.
+            state (FloatTensor): final hidden state from the decoder.
             attns (dict of (str, FloatTensor)): a dictionary of different
-                                type of attention Tensor from the Decoder
+                                type of attention Tensor from the decoder
                                 of shape (src_len x batch).
         """
         # CHECKS

--- a/onmt/modules/Embeddings.py
+++ b/onmt/modules/Embeddings.py
@@ -27,7 +27,7 @@ class PositionalEncoding(nn.Module):
 
 class Embeddings(nn.Module):
     """
-    Words embeddings dictionary for Encoder/Decoder.
+    Words embeddings dictionary for encoder/decoder.
 
     Args:
         embedding_dim (int): size of the dictionary of embeddings.

--- a/onmt/modules/ImageEncoder.py
+++ b/onmt/modules/ImageEncoder.py
@@ -12,8 +12,8 @@ class ImageEncoder(nn.Module):
     def __init__(self, num_layers, bidirectional, rnn_size, dropout):
         """
         Args:
-            num_layers (int): number of Encoder layers.
-            bidirectional (bool): bidirectional Encoder.
+            num_layers (int): number of encoder layers.
+            bidirectional (bool): bidirectional encoder.
             rnn_size (int): size of hidden states of the rnn.
             dropout (float): dropout probablity.
         """

--- a/onmt/modules/Transformer.py
+++ b/onmt/modules/Transformer.py
@@ -40,9 +40,6 @@ class PositionwiseFeedForward(nn.Module):
 
 
 class TransformerEncoderLayer(nn.Module):
-    """
-    The Transformer Decoder from "Attention is All You Need".
-    """
     def __init__(self, size, dropout,
                  head_count=8, hidden_size=2048):
         """
@@ -69,7 +66,9 @@ class TransformerEncoderLayer(nn.Module):
 
 
 class TransformerEncoder(EncoderBase):
-    """ Transformer Encoder. """
+    """
+    The Transformer encoder from "Attention is All You Need".
+    """
     def __init__(self, num_layers, hidden_size,
                  dropout, embeddings):
         super(TransformerEncoder, self).__init__()
@@ -109,9 +108,6 @@ class TransformerEncoder(EncoderBase):
 
 
 class TransformerDecoderLayer(nn.Module):
-    """
-    The Transformer Decoder Layer from "Attetion is all you need".
-    """
     def __init__(self, size, dropout,
                  head_count=8, hidden_size=2048):
         """
@@ -180,7 +176,9 @@ class TransformerDecoderLayer(nn.Module):
 
 
 class TransformerDecoder(nn.Module):
-    """ Transformer Decoder. """
+    """
+    The Transformer decoder from "Attention is All You Need".
+    """
     def __init__(self, num_layers, hidden_size, attn_type,
                  copy_attn, dropout, embeddings):
         super(TransformerDecoder, self).__init__()
@@ -209,16 +207,16 @@ class TransformerDecoder(nn.Module):
         Args:
             input (LongTensor): a sequence of input tokens tensors
                                 of size (len x batch x nfeats).
-            context (FloatTensor): output(tensor sequence) from the Encoder
+            context (FloatTensor): output(tensor sequence) from the encoder
                                 of size (src_len x batch x hidden_size).
-            state (FloatTensor): hidden state from the Encoder RNN for
+            state (FloatTensor): hidden state from the encoder RNN for
                                  initializing the decoder.
         Returns:
-            outputs (FloatTensor): a Tensor sequence of output from the Decoder
+            outputs (FloatTensor): a Tensor sequence of output from the decoder
                                    of shape (len x batch x hidden_size).
-            state (FloatTensor): final hidden state from the Decoder.
+            state (FloatTensor): final hidden state from the decoder.
             attns (dict of (str, FloatTensor)): a dictionary of different
-                                type of attention Tensor from the Decoder
+                                type of attention Tensor from the decoder
                                 of shape (src_len x batch).
         """
         # CHECKS

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -47,11 +47,9 @@ class TestModel(unittest.TestCase):
             sourceL: Length of generated input sentence
             bsize: Batchsize of generated input
         '''
-        vocab = self.get_vocab()
-        feats_padding_idx = []
-        emb = make_embeddings(opt, vocab.stoi[onmt.IO.PAD_WORD],
-                              feats_padding_idx, len(vocab),
-                              for_encoder=True)
+        word_dict = self.get_vocab()
+        feature_dicts = []
+        emb = make_embeddings(opt, word_dict, feature_dicts)
         test_src, _, __ = self.get_batch(sourceL=sourceL,
                                          bsize=bsize)
         if opt.decoder_type == 'transformer':
@@ -73,11 +71,9 @@ class TestModel(unittest.TestCase):
             sourceL: Length of generated input sentence
             bsize: Batchsize of generated input
         '''
-        vocab = self.get_vocab()
-        feats_padding_idx = []
-        embeddings = make_embeddings(opt, vocab.stoi[onmt.IO.PAD_WORD],
-                                     feats_padding_idx, len(vocab),
-                                     for_encoder=True)
+        word_dict = self.get_vocab()
+        feature_dicts = []
+        embeddings = make_embeddings(opt, word_dict, feature_dicts)
         enc = make_encoder(opt, embeddings)
 
         test_src, test_tgt, test_length = self.get_batch(sourceL=sourceL,
@@ -107,17 +103,13 @@ class TestModel(unittest.TestCase):
             sourceL: length of input sequence
             bsize: batchsize
         """
-        vocab = self.get_vocab()
-        word_padding_idx = vocab.stoi[onmt.IO.PAD_WORD]
-        feats_padding_idx = []
+        word_dict = self.get_vocab()
+        feature_dicts = []
 
-        embeddings = make_embeddings(opt, word_padding_idx,
-                                     feats_padding_idx, len(vocab),
-                                     for_encoder=True)
+        embeddings = make_embeddings(opt, word_dict, feature_dicts)
         enc = make_encoder(opt, embeddings)
 
-        embeddings = make_embeddings(opt, word_padding_idx,
-                                     feats_padding_idx, len(vocab),
+        embeddings = make_embeddings(opt, word_dict, feature_dicts,
                                      for_encoder=False)
         dec = make_decoder(opt, embeddings)
 

--- a/tools/extract_embeddings.py
+++ b/tools/extract_embeddings.py
@@ -1,10 +1,8 @@
 from __future__ import division
 
-import onmt
 import torch
 import argparse
 
-import onmt.Models
 from onmt.ModelConstructor import make_embeddings, \
                             make_encoder, make_decoder
 
@@ -37,19 +35,12 @@ def main():
     model_opt = checkpoint['opt']
     src_dict = checkpoint['dicts']['src']
     tgt_dict = checkpoint['dicts']['tgt']
-    feat_padding_idx = []
+    feature_dicts = []
 
-    embeddings = make_embeddings(model_opt,
-                                 src_dict.stoi[onmt.IO.PAD_WORD],
-                                 feat_padding_idx,
-                                 len(src_dict),
-                                 for_encoder=True)
+    embeddings = make_embeddings(model_opt, src_dict, feature_dicts)
     encoder = make_encoder(model_opt, embeddings)
 
-    embeddings = make_embeddings(model_opt,
-                                 tgt_dict.stoi[onmt.IO.PAD_WORD],
-                                 feat_padding_idx,
-                                 len(tgt_dict),
+    embeddings = make_embeddings(model_opt, tgt_dict, feature_dicts,
                                  for_encoder=False)
     decoder = make_decoder(model_opt, embeddings)
 


### PR DESCRIPTION
This PR has 2 trivial cleanup patches:

1. 104afac encoder/decoder: fix comment

No `Encoder`/`Decoder` class now, fix stale comments

2. f255b7f make_embeddings: simplify its interface

old:

```
def make_embeddings(opt, word_padding_idx, feats_padding_idx,
                    num_word_embeddings, for_encoder,
                    num_feat_embeddings=[]):
```

new:

```
def make_embeddings(opt, word_dict, feature_dicts, for_encoder=True):
```
