### PR TITLE
Add support for "Training RNNs as fast as CNNs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PyOpenNMT: Open-Source Neural Machine Translation
+# OpenNMT-py: Open-Source Neural Machine Translation
 
 This is a [Pytorch](https://github.com/pytorch/pytorch)
 port of [OpenNMT](https://github.com/OpenNMT/OpenNMT),

--- a/onmt/ModelConstructor.py
+++ b/onmt/ModelConstructor.py
@@ -68,8 +68,7 @@ def make_encoder(opt, embeddings):
     else:
         # "rnn" or "brnn"
         return RNNEncoder(opt.rnn_type, opt.brnn, opt.dec_layers,
-                          opt.rnn_size, opt.no_pack_padded_seq,
-                          opt.dropout, embeddings)
+                          opt.rnn_size, opt.dropout, embeddings)
 
 
 def make_decoder(opt, embeddings):

--- a/onmt/ModelConstructor.py
+++ b/onmt/ModelConstructor.py
@@ -68,7 +68,8 @@ def make_encoder(opt, embeddings):
     else:
         # "rnn" or "brnn"
         return RNNEncoder(opt.rnn_type, opt.brnn, opt.dec_layers,
-                          opt.rnn_size, opt.dropout, embeddings)
+                          opt.rnn_size, opt.no_pack_padded_seq,
+                          opt.dropout, embeddings)
 
 
 def make_decoder(opt, embeddings):

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -53,22 +53,19 @@ class MeanEncoder(EncoderBase):
 class RNNEncoder(EncoderBase):
     """ The standard RNN encoder. """
     def __init__(self, rnn_type, bidirectional, num_layers,
-                 hidden_size, no_pack_padded_seq,
-                 dropout, embeddings):
+                 hidden_size, dropout, embeddings):
         super(RNNEncoder, self).__init__()
 
         num_directions = 2 if bidirectional else 1
         assert hidden_size % num_directions == 0
         hidden_size = hidden_size // num_directions
         self.embeddings = embeddings
-        self.no_pack_padded_seq = no_pack_padded_seq
+        self.no_pack_padded_seq = False
 
         # Use pytorch version when available.
         if rnn_type == "SRU":
-            if no_pack_padded_seq is False:
-                raise Exception("'SRU' doesn't support PackedSequence, "
-                                "please set option: -no_pack_padded_seq!")
-
+            # SRU doesn't support PackedSequence.
+            self.no_pack_padded_seq = True
             self.rnn = onmt.modules.SRU(
                     input_size=embeddings.embedding_size,
                     hidden_size=hidden_size,

--- a/onmt/modules/SRU.py
+++ b/onmt/modules/SRU.py
@@ -1,0 +1,574 @@
+"""
+Implementation of "Training RNNs as Fast as CNNs".
+TODO: turn to pytorch's implementation when it is available.
+
+This implementation is adpoted from the author of the paper:
+https://github.com/taolei87/sru/blob/master/cuda_functional.py.
+"""
+import torch
+import torch.nn as nn
+from torch.autograd import Function, Variable
+from cupy.cuda import function
+from pynvrtc.compiler import Program
+from collections import namedtuple
+
+
+tmp_ = torch.rand(1, 1).cuda()
+
+SRU_CODE = """
+extern "C" {
+
+    __forceinline__ __device__ float sigmoidf(float x)
+    {
+        return 1.f / (1.f + expf(-x));
+    }
+
+    __global__ void sru_fwd(const float * __restrict__ u,
+                            const float * __restrict__ x,
+                            const float * __restrict__ bias,
+                            const float * __restrict__ init,
+                            const float * __restrict__ mask_h,
+                            const int len, const int batch,
+                            const int d, const int k,
+                            float * __restrict__ h,
+                            float * __restrict__ c,
+                            const int use_tanh)
+    {
+        assert ((k == 3) || (x == NULL));
+
+        int ncols = batch*d;
+        int col = blockIdx.x * blockDim.x + threadIdx.x;
+        if (col >= ncols) return;
+
+        int ncols_u = ncols*k;
+        int ncols_x = (k == 3) ? ncols : ncols_u;
+
+        const float bias1 = *(bias + (col%d));
+        const float bias2 = *(bias + (col%d) + d);
+        const float mask = (mask_h == NULL) ? 1.0 : (*(mask_h + col));
+        float cur = *(init + col);
+
+        const float *up = u + (col*k);
+        const float *xp = (k == 3) ? (x + col) : (up + 3);
+        float *cp = c + col;
+        float *hp = h + col;
+
+        for (int row = 0; row < len; ++row)
+        {
+            float g1 = sigmoidf((*(up+1))+bias1);
+            float g2 = sigmoidf((*(up+2))+bias2);
+            cur = (cur-(*up))*g1 + (*up);
+            *cp = cur;
+            float val = use_tanh ? tanh(cur) : cur;
+            *hp = (val*mask-(*xp))*g2 + (*xp);
+            up += ncols_u;
+            xp += ncols_x;
+            cp += ncols;
+            hp += ncols;
+        }
+    }
+
+    __global__ void sru_bwd(const float * __restrict__ u,
+                            const float * __restrict__ x,
+                            const float * __restrict__ bias,
+                            const float * __restrict__ init,
+                            const float * __restrict__ mask_h,
+                            const float * __restrict__ c,
+                            const float * __restrict__ grad_h,
+                            const float * __restrict__ grad_last,
+                            const int len, const int batch,
+                            const int d, const int k,
+                            float * __restrict__ grad_u,
+                            float * __restrict__ grad_x,
+                            float * __restrict__ grad_bias,
+                            float * __restrict__ grad_init,
+                            int use_tanh)
+    {
+        assert((k == 3) || (x == NULL));
+        assert((k == 3) || (grad_x == NULL));
+
+        int ncols = batch*d;
+        int col = blockIdx.x * blockDim.x + threadIdx.x;
+        if (col >= ncols) return;
+
+        int ncols_u = ncols*k;
+        int ncols_x = (k == 3) ? ncols : ncols_u;
+
+        const float bias1 = *(bias + (col%d));
+        const float bias2 = *(bias + (col%d) + d);
+        const float mask = (mask_h == NULL) ? 1.0 : (*(mask_h + col));
+        float gbias1 = 0;
+        float gbias2 = 0;
+        float cur = *(grad_last + col);
+
+        const float *up = u + (col*k) + (len-1)*ncols_u;
+        const float *xp = (k == 3) ? (x + col + (len-1)*ncols) : (up + 3);
+        const float *cp = c + col + (len-1)*ncols;
+
+        const float *ghp = grad_h + col + (len-1)*ncols;
+        float *gup = grad_u + (col*k) + (len-1)*ncols_u;
+        float *gxp = (k == 3) ? (grad_x + col + (len-1)*ncols) : (gup + 3);
+
+        for (int row = len-1; row >= 0; --row)
+        {
+            const float g1 = sigmoidf((*(up+1))+bias1);
+            const float g2 = sigmoidf((*(up+2))+bias2);
+
+            const float c_val = use_tanh ? tanh(*cp) : (*cp);
+            const float x_val = *xp;
+            const float u_val = *up;
+            const float prev_c_val = (row>0) ? (*(cp-ncols)) : (*(init+col));
+
+            const float gh_val = *ghp;
+
+            // h = c*g2 + x*(1-g2) = (c-x)*g2 + x
+            // c = c'*g1 + g0*(1-g1) = (c'-g0)*g1 + g0
+
+            // grad wrt x
+            *gxp = gh_val*(1-g2);
+
+            // grad wrt g2, u2 and bias2
+            float gg2 = gh_val*(c_val*mask-x_val)*(g2*(1-g2));
+            *(gup+2) = gg2;
+            gbias2 += gg2;
+
+            // grad wrt c
+            const float tmp = use_tanh ? (g2*(1-c_val*c_val)) : g2;
+            const float gc = gh_val*mask*tmp + cur;
+
+            // grad wrt u0
+            *gup = gc*(1-g1);
+
+            // grad wrt g1, u1, and bias1
+            float gg1 = gc*(prev_c_val-u_val)*(g1*(1-g1));
+            *(gup+1) = gg1;
+            gbias1 += gg1;
+
+            // grad wrt c'
+            cur = gc*g1;
+
+            up -= ncols_u;
+            xp -= ncols_x;
+            cp -= ncols;
+            gup -= ncols_u;
+            gxp -= ncols_x;
+            ghp -= ncols;
+        }
+
+        *(grad_bias + col) = gbias1;
+        *(grad_bias + col + ncols) = gbias2;
+        *(grad_init +col) = cur;
+    }
+
+    __global__ void sru_bi_fwd(const float * __restrict__ u,
+                               const float * __restrict__ x,
+                               const float * __restrict__ bias,
+                               const float * __restrict__ init,
+                               const float * __restrict__ mask_h,
+                               const int len, const int batch,
+                               const int d, const int k,
+                               float * __restrict__ h,
+                               float * __restrict__ c,
+                               const int use_tanh)
+    {
+        assert ((k == 3) || (x == NULL));
+        assert ((k == 3) || (k == 4));
+
+        int ncols = batch*d*2;
+        int col = blockIdx.x * blockDim.x + threadIdx.x;
+        if (col >= ncols) return;
+
+        int ncols_u = ncols*k;
+        int ncols_x = (k == 3) ? ncols : ncols_u;
+        const float mask = (mask_h == NULL) ? 1.0 : (*(mask_h + col));
+        float cur = *(init + col);
+
+        const int d2 = d*2;
+        const bool flip = (col%d2) >= d;
+
+        const float bias1 = *(bias + (col%d2));
+        const float bias2 = *(bias + (col%d2) + d2);
+        const float *up = u + (col*k);
+        const float *xp = (k == 3) ? (x + col) : (up + 3);
+        float *cp = c + col;
+        float *hp = h + col;
+
+        if (flip) {
+            up += (len-1)*ncols_u;
+            xp += (len-1)*ncols_x;
+            cp += (len-1)*ncols;
+            hp += (len-1)*ncols;
+        }
+
+        int ncols_u_ = flip ? -ncols_u : ncols_u;
+        int ncols_x_ = flip ? -ncols_x : ncols_x;
+        int ncols_ = flip ? -ncols : ncols;
+
+        for (int cnt = 0; cnt < len; ++cnt)
+        {
+            float g1 = sigmoidf((*(up+1))+bias1);
+            float g2 = sigmoidf((*(up+2))+bias2);
+            cur = (cur-(*up))*g1 + (*up);
+            *cp = cur;
+            float val = use_tanh ? tanh(cur) : cur;
+            *hp = (val*mask-(*xp))*g2 + (*xp);
+            up += ncols_u_;
+            xp += ncols_x_;
+            cp += ncols_;
+            hp += ncols_;
+        }
+
+    }
+
+    __global__ void sru_bi_bwd(const float * __restrict__ u,
+                               const float * __restrict__ x,
+                               const float * __restrict__ bias,
+                               const float * __restrict__ init,
+                               const float * __restrict__ mask_h,
+                               const float * __restrict__ c,
+                               const float * __restrict__ grad_h,
+                               const float * __restrict__ grad_last,
+                               const int len, const int batch,
+                               const int d, const int k,
+                               float * __restrict__ grad_u,
+                               float * __restrict__ grad_x,
+                               float * __restrict__ grad_bias,
+                               float * __restrict__ grad_init,
+                               int use_tanh)
+    {
+        assert((k == 3) || (x == NULL));
+        assert((k == 3) || (grad_x == NULL));
+        assert((k == 3) || (k == 4));
+
+        int ncols = batch*d*2;
+        int col = blockIdx.x * blockDim.x + threadIdx.x;
+        if (col >= ncols) return;
+
+        int ncols_u = ncols*k;
+        int ncols_x = (k == 3) ? ncols : ncols_u;
+
+        const float mask = (mask_h == NULL) ? 1.0 : (*(mask_h + col));
+        float gbias1 = 0;
+        float gbias2 = 0;
+        float cur = *(grad_last + col);
+
+        const int d2 = d*2;
+        const bool flip = ((col%d2) >= d);
+
+        const float bias1 = *(bias + (col%d2));
+        const float bias2 = *(bias + (col%d2) + d2);
+        const float *up = u + (col*k);
+        const float *xp = (k == 3) ? (x + col) : (up + 3);
+        const float *cp = c + col;
+        const float *ghp = grad_h + col;
+        float *gup = grad_u + (col*k);
+        float *gxp = (k == 3) ? (grad_x + col) : (gup + 3);
+
+        if (!flip) {
+            up += (len-1)*ncols_u;
+            xp += (len-1)*ncols_x;
+            cp += (len-1)*ncols;
+            ghp += (len-1)*ncols;
+            gup += (len-1)*ncols_u;
+            gxp += (len-1)*ncols_x;
+        }
+
+        int ncols_u_ = flip ? -ncols_u : ncols_u;
+        int ncols_x_ = flip ? -ncols_x : ncols_x;
+        int ncols_ = flip ? -ncols : ncols;
+
+        for (int cnt = 0; cnt < len; ++cnt)
+        {
+            const float g1 = sigmoidf((*(up+1))+bias1);
+            const float g2 = sigmoidf((*(up+2))+bias2);
+
+            const float c_val = use_tanh ? tanh(*cp) : (*cp);
+            const float x_val = *xp;
+            const float u_val = *up;
+            const float prev_c_val = (cnt<len-1) ?
+                    (*(cp-ncols_)) : (*(init+col));
+
+            const float gh_val = *ghp;
+
+            // h = c*g2 + x*(1-g2) = (c-x)*g2 + x
+            // c = c'*g1 + g0*(1-g1) = (c'-g0)*g1 + g0
+
+            // grad wrt x
+            *gxp = gh_val*(1-g2);
+
+            // grad wrt g2, u2 and bias2
+            float gg2 = gh_val*(c_val*mask-x_val)*(g2*(1-g2));
+            *(gup+2) = gg2;
+            gbias2 += gg2;
+
+            // grad wrt c
+            const float tmp = use_tanh ? (g2*(1-c_val*c_val)) : g2;
+            const float gc = gh_val*mask*tmp + cur;
+
+            // grad wrt u0
+            *gup = gc*(1-g1);
+
+            // grad wrt g1, u1, and bias1
+            float gg1 = gc*(prev_c_val-u_val)*(g1*(1-g1));
+            *(gup+1) = gg1;
+            gbias1 += gg1;
+
+            // grad wrt c'
+            cur = gc*g1;
+
+            up -= ncols_u_;
+            xp -= ncols_x_;
+            cp -= ncols_;
+            gup -= ncols_u_;
+            gxp -= ncols_x_;
+            ghp -= ncols_;
+        }
+
+        *(grad_bias + col) = gbias1;
+        *(grad_bias + col + ncols) = gbias2;
+        *(grad_init +col) = cur;
+    }
+}
+"""
+
+SRU_PROG = Program(SRU_CODE.encode('utf-8'), 'sru_prog.cu'.encode('utf-8'))
+SRU_PTX = SRU_PROG.compile()
+SRU_MOD = function.Module()
+SRU_MOD.load(bytes(SRU_PTX.encode()))
+SRU_FWD_FUNC = SRU_MOD.get_function('sru_fwd')
+SRU_BWD_FUNC = SRU_MOD.get_function('sru_bwd')
+SRU_BiFWD_FUNC = SRU_MOD.get_function('sru_bi_fwd')
+SRU_BiBWD_FUNC = SRU_MOD.get_function('sru_bi_bwd')
+
+Stream = namedtuple('Stream', ['ptr'])
+SRU_STREAM = Stream(ptr=torch.cuda.current_stream().cuda_stream)
+
+
+class SRU_Compute(Function):
+
+    def __init__(self, use_tanh, d_out, bidirectional=False):
+        super(SRU_Compute, self).__init__()
+        self.use_tanh = use_tanh
+        self.d_out = d_out
+        self.bidirectional = bidirectional
+
+    def forward(self, u, x, bias, init=None, mask_h=None):
+        bidir = 2 if self.bidirectional else 1
+        length = x.size(0) if x.dim() == 3 else 1
+        batch = x.size(-2)
+        d = self.d_out
+        k = u.size(-1) // d
+        k_ = k // 2 if self.bidirectional else k
+        ncols = batch * d * bidir
+        thread_per_block = min(512, ncols)
+        num_block = (ncols-1)/thread_per_block+1
+
+        init_ = x.new(ncols).zero_() if init is None else init
+        size = (length, batch, d*bidir) if x.dim() == 3 else (batch, d*bidir)
+        c = x.new(*size)
+        h = x.new(*size)
+
+        FUNC = SRU_FWD_FUNC if not self.bidirectional else SRU_BiFWD_FUNC
+        FUNC(args=[
+            u.contiguous().data_ptr(),
+            x.contiguous().data_ptr() if k_ == 3 else 0,
+            bias.data_ptr(),
+            init_.contiguous().data_ptr(),
+            mask_h.data_ptr() if mask_h is not None else 0,
+            length,
+            batch,
+            d,
+            k_,
+            h.data_ptr(),
+            c.data_ptr(),
+            self.use_tanh],
+            block=(thread_per_block, 1, 1), grid=(num_block, 1, 1),
+            stream=SRU_STREAM
+        )
+
+        self.save_for_backward(u, x, bias, init, mask_h)
+        self.intermediate = c
+        if x.dim() == 2:
+            last_hidden = c
+        elif self.bidirectional:
+            last_hidden = torch.cat((c[-1, :, :d], c[0, :, d:]), dim=1)
+        else:
+            last_hidden = c[-1]
+        return h, last_hidden
+
+    def backward(self, grad_h, grad_last):
+        bidir = 2 if self.bidirectional else 1
+        u, x, bias, init, mask_h = self.saved_tensors
+        c = self.intermediate
+        length = x.size(0) if x.dim() == 3 else 1
+        batch = x.size(-2)
+        d = self.d_out
+        k = u.size(-1) // d
+        k_ = k//2 if self.bidirectional else k
+        ncols = batch*d*bidir
+        thread_per_block = min(512, ncols)
+        num_block = (ncols-1)/thread_per_block+1
+
+        init_ = x.new(ncols).zero_() if init is None else init
+        grad_u = u.new(*u.size())
+        grad_bias = x.new(2, batch, d*bidir)
+        grad_init = x.new(batch, d*bidir)
+
+        # For DEBUG
+        # if x.dim() == 3
+        #    size = (length, batch, x.size(-1))
+        # else
+        #    size = (batch, x.size(-1))
+        # if k_ == 3
+        #    grad_x = x.new(*x.size())
+        # else
+        #    grad_x = x.new(*size).zero_()
+
+        # Normal use
+        grad_x = x.new(*x.size()) if k_ == 3 else None
+
+        FUNC = SRU_BWD_FUNC if not self.bidirectional else SRU_BiBWD_FUNC
+        FUNC(args=[
+            u.contiguous().data_ptr(),
+            x.contiguous().data_ptr() if k_ == 3 else 0,
+            bias.data_ptr(),
+            init_.contiguous().data_ptr(),
+            mask_h.data_ptr() if mask_h is not None else 0,
+            c.data_ptr(),
+            grad_h.contiguous().data_ptr(),
+            grad_last.contiguous().data_ptr(),
+            length,
+            batch,
+            d,
+            k_,
+            grad_u.data_ptr(),
+            grad_x.data_ptr() if k_ == 3 else 0,
+            grad_bias.data_ptr(),
+            grad_init.data_ptr(),
+            self.use_tanh],
+            block=(thread_per_block, 1, 1), grid=(num_block, 1, 1),
+            stream=SRU_STREAM
+        )
+        return grad_u, grad_x, grad_bias.sum(1).view(-1), grad_init, None
+
+
+class SRUCell(nn.Module):
+    def __init__(self, n_in, n_out, dropout=0, vari_dropout=0,
+                 use_tanh=1, bidirectional=False):
+        super(SRUCell, self).__init__()
+        self.n_in = n_in
+        self.n_out = n_out
+        self.vari_dropout = vari_dropout
+        self.dropout = dropout
+        self.bidirectional = bidirectional
+        self.use_tanh = use_tanh
+
+        out_size = n_out*2 if bidirectional else n_out
+        k = 4 if n_in != out_size else 3
+        self.size_per_dir = n_out*k
+        self.weight = nn.Parameter(torch.Tensor(
+            n_in,
+            self.size_per_dir*2 if bidirectional else self.size_per_dir
+        ))
+        self.bias = nn.Parameter(torch.Tensor(
+            n_out*4 if bidirectional else n_out*2
+        ))
+        self.init_weight()
+
+    def init_weight(self):
+        val_range = (3.0/self.n_in)**0.5
+        self.weight.data.uniform_(-val_range, val_range)
+        self.bias.data.zero_()
+
+    def set_bias(self, bias_val=0):
+        n_out = self.n_out
+        if self.bidirectional:
+            self.bias.data[n_out*2:].zero_().add_(bias_val)
+        else:
+            self.bias.data[n_out:].zero_().add_(bias_val)
+
+    def forward(self, input, hidden=None):
+        assert input.dim() == 2 or input.dim() == 3
+        n_in, n_out = self.n_in, self.n_out
+        batch = input.size(-2)
+        if hidden is None:
+            hidden = Variable(input.data.new(
+                batch, n_out if not self.bidirectional else n_out*2
+            ).zero_())
+
+        if self.training and (self.vari_dropout > 0):
+            mask = self.get_dropout_mask_((batch, n_in), self.vari_dropout)
+            x = input * mask.expand_as(input)
+        else:
+            x = input
+
+        x_2d = x if x.dim() == 2 else x.contiguous().view(-1, n_in)
+        u = x_2d.mm(self.weight)
+
+        if self.training and (self.dropout > 0):
+            bidir = 2 if self.bidirectional else 1
+            mask_h = self.get_dropout_mask_((batch, n_out*bidir), self.dropout)
+            h, c = SRU_Compute(self.use_tanh, n_out,
+                               self.bidirectional)(
+                        u, input, self.bias, hidden, mask_h
+                   )
+        else:
+            h, c = SRU_Compute(self.use_tanh, n_out,
+                               self.bidirectional)(
+                        u, input, self.bias, hidden
+                   )
+
+        return h, c
+
+    def get_dropout_mask_(self, size, p):
+        w = self.weight.data
+        return Variable(w.new(*size).bernoulli_(1-p).div_(1-p))
+
+
+class SRU(nn.Module):
+    def __init__(self, input_size, hidden_size,
+                 num_layers=2, dropout=0, vari_dropout=0,
+                 use_tanh=1, bidirectional=False):
+        super(SRU, self).__init__()
+        self.n_in = input_size
+        self.n_out = hidden_size
+        self.depth = num_layers
+        self.dropout = dropout
+        self.vari_dropout = vari_dropout
+        self.rnn_lst = nn.ModuleList()
+        self.bidirectional = bidirectional
+        self.out_size = hidden_size*2 if bidirectional else hidden_size
+
+        for i in range(num_layers):
+            l = SRUCell(n_in=self.n_in if i == 0 else self.out_size,
+                        n_out=self.n_out,
+                        dropout=dropout if i+1 != num_layers else 0,
+                        vari_dropout=vari_dropout,
+                        use_tanh=use_tanh,
+                        bidirectional=bidirectional)
+            self.rnn_lst.append(l)
+
+    def set_bias(self, bias_val=0):
+        for l in self.rnn_lst:
+            l.set_bias(bias_val)
+
+    def forward(self, input, hidden=None):
+        assert input.dim() == 3  # (len, batch, n_in)
+        dir_ = 2 if self.bidirectional else 1
+        if hidden is None:
+            zeros = Variable(input.data.new(
+                input.size(1), self.n_out*dir_
+            ).zero_())
+            hidden = [zeros for i in range(self.depth)]
+        else:
+            assert hidden.dim() == 3    # (depth, batch, n_out*dir_)
+            hidden = hidden.chunk(self.depth, 0)
+
+        output = input
+        lstc = []
+        for i, rnn in enumerate(self.rnn_lst):
+            h, c = rnn(output, hidden[i])
+            output = h
+            lstc.append(c)
+
+        return output, torch.stack(lstc)

--- a/onmt/modules/__init__.py
+++ b/onmt/modules/__init__.py
@@ -13,9 +13,9 @@ from onmt.modules.StackedRNN import StackedLSTM, StackedGRU
 from onmt.modules.Embeddings import Embeddings
 from onmt.modules.WeightNorm import WeightNormConv2d
 
-from opts import check_sru_requirement
-can_export_sru = check_sru_requirement()
-if can_export_sru:
+from onmt.modules.SRU import check_sru_requirement
+can_use_sru = check_sru_requirement()
+if can_use_sru:
     from onmt.modules.SRU import SRU
 
 
@@ -26,5 +26,5 @@ __all__ = [GlobalAttention, ImageEncoder, CopyGenerator, MultiHeadedAttention,
            CopyCriterion, MatrixTree, WeightNormConv2d, ConvMultiStepAttention,
            CNNEncoder, CNNDecoder, StackedLSTM, StackedGRU, ContextGateFactory]
 
-if can_export_sru:
-    __all__.append(SRU)
+if can_use_sru:
+    __all__.extend([SRU, check_sru_requirement])

--- a/onmt/modules/__init__.py
+++ b/onmt/modules/__init__.py
@@ -13,6 +13,11 @@ from onmt.modules.StackedRNN import StackedLSTM, StackedGRU
 from onmt.modules.Embeddings import Embeddings
 from onmt.modules.WeightNorm import WeightNormConv2d
 
+from opts import check_sru_requirement
+can_export_sru = check_sru_requirement()
+if can_export_sru:
+    from onmt.modules.SRU import SRU
+
 
 # For flake8 compatibility.
 __all__ = [GlobalAttention, ImageEncoder, CopyGenerator, MultiHeadedAttention,
@@ -20,3 +25,6 @@ __all__ = [GlobalAttention, ImageEncoder, CopyGenerator, MultiHeadedAttention,
            TransformerEncoder, TransformerDecoder, Embeddings, Elementwise,
            CopyCriterion, MatrixTree, WeightNormConv2d, ConvMultiStepAttention,
            CNNEncoder, CNNDecoder, StackedLSTM, StackedGRU, ContextGateFactory]
+
+if can_export_sru:
+    __all__.append(SRU)

--- a/opts.py
+++ b/opts.py
@@ -60,6 +60,11 @@ def model_opts(parser):
     parser.add_argument('-rnn_type', type=str, default='LSTM',
                         choices=['LSTM', 'GRU'],
                         help="""The gate type to use in the RNNs""")
+    parser.add_argument('-no_pack_padded_seq', action="store_true",
+                        default=False,
+                        help="""Do not use pytorch's rnn.pack_padded_sequence
+                        to pack rnn input that contains padded sequences of
+                        variable length.""")
     # parser.add_argument('-residual',   action="store_true",
     #                     help="Add residual connections between RNN layers.")
 

--- a/opts.py
+++ b/opts.py
@@ -1,7 +1,5 @@
 import argparse
-import subprocess
-import os
-import re
+from onmt.modules.SRU import CheckSRU
 
 
 def model_opts(parser):
@@ -61,27 +59,10 @@ def model_opts(parser):
                         additional input (via concatenation with the word
                         embeddings) to the decoder.""")
 
-    class CheckSRU(argparse.Action):
-        def __init__(self, option_strings, dest, **kwargs):
-            super(CheckSRU, self).__init__(option_strings, dest, **kwargs)
-
-        def __call__(self, parser, namespace, values, option_string=None):
-            print(self.dest)
-            print(values)
-            if values == 'SRU':
-                check_sru_requirement(abort=True)
-            # Check pass, set the args.
-            setattr(namespace, self.dest, values)
-
     parser.add_argument('-rnn_type', type=str, default='LSTM',
                         choices=['LSTM', 'GRU', 'SRU'],
                         action=CheckSRU,
                         help="""The gate type to use in the RNNs""")
-    parser.add_argument('-no_pack_padded_seq', action="store_true",
-                        default=False,
-                        help="""Do not use pytorch's rnn.pack_padded_sequence
-                        to pack rnn input that contains padded sequences of
-                        variable length.""")
     # parser.add_argument('-residual',   action="store_true",
     #                     help="Add residual connections between RNN layers.")
 
@@ -238,37 +219,6 @@ def preprocess_opts(parser):
 def add_md_help_argument(parser):
     parser.add_argument('-md', action=MarkdownHelpAction,
                         help='print Markdown-formatted help text and exit.')
-
-
-# Our current SRU version implements its own cuda-level optimization,
-# so it needs the `cupy` and `pynvrtc` package. It also needs the cuda
-# library path set, e.g.: 'export LD_LIBRARY_PATH=/usr/local/cuda/lib64'.
-def check_sru_requirement(abort=False):
-    """
-    Return True if check pass; if check fails and abort is True,
-    raise an Exception, othereise return False.
-    """
-    try:
-        pip_out = subprocess.Popen(
-            ('pip', 'freeze'), stdout=subprocess.PIPE)
-        subprocess.check_output(('grep', 'cupy\|pynvrtc'),
-                                stdin=pip_out.stdout)
-        pip_out.wait()
-    except subprocess.CalledProcessError:
-        if not abort:
-            return False
-        raise Exception("Using 'SRU' requires 'cupy' and 'pynvrtc' "
-                        "python packages installed.")
-
-    pattern = re.compile(".*cuda/lib.*")
-    ld_path = os.getenv('LD_LIBRARY_PATH', "")
-    if re.match(pattern, ld_path) is None:
-        if not abort:
-            return False
-        raise Exception("Using 'SRU' requires setting the cuda library path, "
-                        "e.g. export LD_LIBRARY_PATH=/usr/local/cuda/lib64.")
-
-    return True
 
 
 # MARKDOWN boilerplate

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-setup(name='OpenNMT',
+setup(name='OpenNMT-py',
+      description='A python implementation of OpenNMT',
       version='0.1',
-      description='OpenNMT',
       packages=['onmt', 'onmt.modules'])

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -204,5 +204,12 @@ tests_ntmodel = [[('rnn_type', 'GRU')],
                  []
                  ]
 
+if opts.check_sru_requirement():
+    """ Only do SRU test if requirment is safisfied. """
+    # SRU doesn't support PackedSequence, so set
+    # 'no_pack_padded_seq' to True.
+    tests_ntmodel.append(
+        [('rnn_type', 'SRU'), ('no_pack_padded_seq', True)])
+
 for p in tests_ntmodel:
     _add_test(p, 'ntmmodel_forward')

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -204,12 +204,9 @@ tests_ntmodel = [[('rnn_type', 'GRU')],
                  []
                  ]
 
-if opts.check_sru_requirement():
+if onmt.modules.check_sru_requirement():
     """ Only do SRU test if requirment is safisfied. """
-    # SRU doesn't support PackedSequence, so set
-    # 'no_pack_padded_seq' to True.
-    tests_ntmodel.append(
-        [('rnn_type', 'SRU'), ('no_pack_padded_seq', True)])
+    tests_ntmodel.append([('rnn_type', 'SRU')])
 
 for p in tests_ntmodel:
     _add_test(p, 'ntmmodel_forward')

--- a/train.py
+++ b/train.py
@@ -37,6 +37,9 @@ opt.brnn = (opt.encoder_type == "brnn")
 if opt.seed > 0:
     torch.manual_seed(opt.seed)
 
+if opt.rnn_type == "SRU" and not opt.gpuid:
+    raise AssertionError("Using SRU requires -gpuid set.")
+
 if torch.cuda.is_available() and not opt.gpuid:
     print("WARNING: You have a CUDA device, should run with -gpuid 0")
 


### PR DESCRIPTION
This PR addresses Issue https://github.com/OpenNMT/OpenNMT-py/issues/251, trying to incorporate the author's implementation into our project. I am doing this by adding a new `-rnn_type`: **SRU** in `RNNEncoder` and `StdRNNDecoder`, not to create a new `SRUEncoder` and `SRUDecoder`. I think this makes much more sense - `SRU` is just a variant of `RNN`, the same as `LSTM` and `GRU`. Thanks to our modular structure, I am trying to keep this less intrusive to the code structure.  Hopefully sometime in the future when pytorch community supports this RNN variant, we could easily migrate to use it.

**Patch list**

This PR has 2 patches.

**1.** 97929d5 **RNNEncoder: Add a command-line option to disable pack_padded_sequence**

This is a preparing patch.  Since this SRU doesn't support `PackedSequence`,  rather to create a almost the same new `NoPackedSeqSupportRNNEncoder`, I just incorporates an option `no_pack_padded_seq`, which defaults to be `False`.  And when it is set, the `lengths` argument in encoder's `forward()` is just ignored and no `pack/unpack` behavior is taken.  When `SRU` is used, it is mandated to also set this option, or the below error will be spewed:

```
Exception: 'SRU' doesn't support PackedSequence, please set option: -no_pack_padded_seq!
```

**2.** e9a07db **Introduce a rnn_type: SRU**

This patch introduces the SRU implementation, with slight modification. The whole code locates in
`onmt/modules/SRU.py`.

This SRU implementation does the cuda level optimization by itself and thus requires the `cupy` and `pynvrtc` packages installed, also requires the cuda library path is set in the `LD_LIBRARY_PATH` environment settings.

We don't mandate these requirements to not upset users who don't use `SRU`.  So a conditional requirement is checked, and I incorporates a function called `check_sru_requirement()` in `opts.py`, and do checks in these places:

1.  **In the unittest**.  The test of `-rnn_type SRU` is only performed when `check_sru_requirement()` is satisfied.
2. **In the `onmt/modules/__init__.py`.**  `SRU` is only exported to other modules when `check_sru_requirement()` is satisfied.
3. **In the command line parsing**.  When user explicitly requires `-rnn_type SRU`,  `check_sru_requirement()`  is also called by using `argparse.Action`. And since this is user's purpose,
we abort if these requirements are not satisfied and relevant error is printed:

```
Exception: Using 'SRU' requires 'cupy' and 'pynvrtc' python packages installed.
```

**Test  Done**
1. unittest is performed **w/** and **w/o** these requirements, passed.
2. `python train.py` is run with `-rnn_type SRU`,  **w/**  and **w/o**  `-no_pack_padded_seq`, as designed.

One interesting observation is that the training perplexity rockets really high at first(Train perplexity: 1.34152e+10 in Epoch 2),  but latter when learning rate drops, it drops to 2000 in Epoch 8, and stops at 1785.05 in Epoch 13, the final one).