### PR TITLE
Fix embedding bug

### DIFF
--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -61,7 +61,7 @@ class RNNEncoder(EncoderBase):
         hidden_size = hidden_size // num_directions
         self.embeddings = embeddings
         self.rnn = getattr(nn, rnn_type)(
-                input_size=embeddings.embedding_dim,
+                input_size=embeddings.embedding_size,
                 hidden_size=hidden_size,
                 num_layers=num_layers,
                 dropout=dropout,
@@ -270,7 +270,7 @@ class StdRNNDecoder(RNNDecoderBase):
         """
         Private helper returning the number of expected features.
         """
-        return self.embeddings.embedding_dim
+        return self.embeddings.embedding_size
 
 
 class InputFeedRNNDecoder(RNNDecoderBase):
@@ -352,7 +352,7 @@ class InputFeedRNNDecoder(RNNDecoderBase):
         """
         Using input feed by concatenating input with attention vectors.
         """
-        return self.embeddings.embedding_dim + self.hidden_size
+        return self.embeddings.embedding_size + self.hidden_size
 
 
 class NMTModel(nn.Module):

--- a/onmt/modules/Conv2Conv.py
+++ b/onmt/modules/Conv2Conv.py
@@ -66,7 +66,7 @@ class CNNEncoder(EncoderBase):
         super(CNNEncoder, self).__init__()
 
         self.embeddings = embeddings
-        input_size = embeddings.embedding_dim
+        input_size = embeddings.embedding_size
         self.linear = nn.Linear(input_size, hidden_size)
         self.cnn = StackedCNN(num_layers, hidden_size,
                               cnn_kernel_width, dropout)
@@ -107,7 +107,7 @@ class CNNDecoder(nn.Module):
         self.dropout = dropout
 
         # Build the CNN.
-        input_size = self.embeddings.embedding_dim
+        input_size = self.embeddings.embedding_size
         self.linear = nn.Linear(input_size, self.hidden_size)
         self.conv_layers = nn.ModuleList()
         for i in range(self.num_layers):

--- a/onmt/modules/Embeddings.py
+++ b/onmt/modules/Embeddings.py
@@ -53,13 +53,10 @@ class Embeddings(nn.Module):
                  word_vocab_size, feat_vocab_sizes=[]):
         super(Embeddings, self).__init__()
 
-        self.word_padding_idx = word_padding_idx
-
         # Parameters for constructing the word embedding matrix
         vocab_sizes = [word_vocab_size]
         emb_dims = [embedding_dim]
         pad_indices = [word_padding_idx]
-        self.embedding_dim = embedding_dim
 
         # Parameters for additional feature embedding matrices
         # (these have no effect if feat_vocab_sizes is empty)

--- a/onmt/modules/Embeddings.py
+++ b/onmt/modules/Embeddings.py
@@ -64,7 +64,8 @@ class Embeddings(nn.Module):
             feat_dims = [int(vocab ** feat_vec_exponent)
                          for vocab in feat_vocab_sizes]
         else:
-            feat_dim = embedding_dim if feat_merge == 'sum' else feat_embedding_dim
+            feat_dim = embedding_dim \
+                if feat_merge == 'sum' else feat_embedding_dim
             feat_dims = [feat_dim] * len(feat_vocab_sizes)
         vocab_sizes.extend(feat_vocab_sizes)
         emb_dims.extend(feat_dims)
@@ -79,6 +80,8 @@ class Embeddings(nn.Module):
 
         # The final output size of word + feature vectors. This can vary
         # from the word vector size if and only if features are defined.
+        # This is the attribute you should access if you need to know
+        # how big your embeddings are going to be.
         self.embedding_size = (sum(emb_dims) if feat_merge == 'concat'
                                else embedding_dim)
 

--- a/onmt/modules/Embeddings.py
+++ b/onmt/modules/Embeddings.py
@@ -92,7 +92,7 @@ class Embeddings(nn.Module):
 
         if feat_merge == 'mlp':
             in_dim = sum(emb_dims)
-            out_dim = feat_embedding_dim
+            out_dim = embedding_dim
             mlp = nn.Sequential(BottleLinear(in_dim, out_dim), nn.ReLU())
             self.make_embedding.add_module('mlp', mlp)
 

--- a/onmt/modules/Embeddings.py
+++ b/onmt/modules/Embeddings.py
@@ -53,6 +53,8 @@ class Embeddings(nn.Module):
                  word_vocab_size, feat_vocab_sizes=[]):
         super(Embeddings, self).__init__()
 
+        self.word_padding_idx = word_padding_idx
+
         # Parameters for constructing the word embedding matrix
         vocab_sizes = [word_vocab_size]
         emb_dims = [embedding_dim]

--- a/onmt/modules/Embeddings.py
+++ b/onmt/modules/Embeddings.py
@@ -64,10 +64,7 @@ class Embeddings(nn.Module):
             feat_dims = [int(vocab ** feat_vec_exponent)
                          for vocab in feat_vocab_sizes]
         else:
-            if feat_merge == 'sum':
-                feat_dim = embedding_dim
-            else:
-                feat_dim = feat_embedding_dim
+            feat_dim = embedding_dim if feat_merge == 'sum' else feat_embedding_dim
             feat_dims = [feat_dim] * len(feat_vocab_sizes)
         vocab_sizes.extend(feat_vocab_sizes)
         emb_dims.extend(feat_dims)


### PR DESCRIPTION
This pull request addresses the bug discussed in #261. Incorrect embedding dimensions were getting passed all over the place. Some of these errors are the results of recent pull requests, while the ones with `mlp` have been around for longer. Getting training with features up and running again allows us to train test models that use features, which should make it more difficult for errors like this to arise again in the future.

Besides fixing the mlp issue, the state of Embeddings.py is now essentially the same as it was a week ago, the difference being that some of the argument names have changed. I had tried to keep them close to the relevant command line names (i.e. `word_vec_size` and `feat_vec_size` in the old version versus `embedding_dim` and  `feat_embedding_size` currently), but po-tay-to po-tah-to.