### PR TITLE
Clean train.py and adjacent files

### DIFF
--- a/onmt/Beam.py
+++ b/onmt/Beam.py
@@ -148,8 +148,8 @@ class GNMTGlobalScorer(object):
         "Additional term add to log probability"
         cov = beam.globalState["coverage"]
         pen = self.beta * torch.min(cov, cov.clone().fill_(1.0)).log().sum(1)
-        l_term = (((5 + len(beam.nextYs)) ** self.alpha)
-                  / ((5 + 1) ** self.alpha))
+        l_term = (((5 + len(beam.nextYs)) ** self.alpha) /
+                  ((5 + 1) ** self.alpha))
         return (logprobs / l_term) + pen
 
     def updateGlobalState(self, beam):

--- a/onmt/Loss.py
+++ b/onmt/Loss.py
@@ -83,7 +83,7 @@ class Statistics:
 
 class Splitter:
     """
-    Spliter is a utilty that splits a dictionary of
+    Splitter is a utilty that splits a dictionary of
     data up into shards and waits for them to be backprop'd.
     It blocks until all gradients have been computed and then
     call backward on its inputs.
@@ -93,7 +93,7 @@ class Splitter:
         self.shard_max = shard_max
         self.eval = eval
 
-    def splitIter(self, d):
+    def split_iter(self, d):
         # If eval mode, don't need to split at all
         if self.eval:
             yield d
@@ -152,7 +152,7 @@ class LossCompute:
                 "attn": attns.get("copy")}
 
     def compute_loss(self, batch, out, target, attn=None,
-                    align=None, coverage=None):
+                     align=None, coverage=None):
         def bottle(v):
             return v.view(-1, v.size(2))
 
@@ -178,6 +178,7 @@ class LossCompute:
             scores_data = bottle(scores_data)
 
             # Correct target is copy when only option.
+            # TODO: replace for loop with masking or boolean indexing
             target = target.data.clone()
             for i in range(target.size(0)):
                 if target[i] == 0 and align.data[i] != 0:

--- a/onmt/Loss.py
+++ b/onmt/Loss.py
@@ -3,7 +3,7 @@ This file handles the details of the loss function during training.
 
 This includes: loss criterion, training statistics, and memory optimizations.
 """
-
+from __future__ import division
 import time
 import sys
 import math
@@ -44,7 +44,7 @@ class Statistics:
         self.n_correct += stat.n_correct
 
     def accuracy(self):
-        return 100 * (self.n_correct / float(self.n_words))
+        return 100 * (self.n_correct / self.n_words)
 
     def ppl(self):
         return math.exp(min(self.loss / self.n_words, 100))

--- a/onmt/Loss.py
+++ b/onmt/Loss.py
@@ -140,7 +140,7 @@ class LossCompute:
         self.epoch = epoch
         self.opt = opt
 
-    def makeLossBatch(self, outputs, batch, attns, range_):
+    def make_loss_batch(self, outputs, batch, attns, range_):
         """Create all the variables that need to be sharded.
         This needs to match compute loss exactly.
         """
@@ -151,7 +151,7 @@ class LossCompute:
                 "coverage": attns.get("coverage"),
                 "attn": attns.get("copy")}
 
-    def computeLoss(self, batch, out, target, attn=None,
+    def compute_loss(self, batch, out, target, attn=None,
                     align=None, coverage=None):
         def bottle(v):
             return v.view(-1, v.size(2))

--- a/onmt/Loss.py
+++ b/onmt/Loss.py
@@ -117,7 +117,7 @@ class Splitter:
                     shards.append({})
                 shards[i][k] = val
 
-        for i, shard in enumerate(shards):
+        for shard in shards:
             yield shard
 
         # Assumed backprop'd

--- a/onmt/Loss.py
+++ b/onmt/Loss.py
@@ -15,14 +15,14 @@ from torch.autograd import Variable
 import onmt
 
 
-def NMTCriterion(vocabSize, opt, pad_id):
+def nmt_criterion(vocab_size, gpuid, pad_id):
     """
     Construct the standard NMT Criterion
     """
-    weight = torch.ones(vocabSize)
+    weight = torch.ones(vocab_size)
     weight[pad_id] = 0
     crit = nn.NLLLoss(weight, size_average=False)
-    if opt.gpuid:
+    if gpuid:
         crit.cuda()
     return crit
 

--- a/onmt/ModelConstructor.py
+++ b/onmt/ModelConstructor.py
@@ -160,7 +160,7 @@ def make_base_model(model_opt, fields, gpuid, checkpoint=None):
         print('Loading model')
         model.load_state_dict(checkpoint['model'])
         generator.load_state_dict(checkpoint['generator'])
-    
+
     # add the generator to the module (does this register the parameter?)
     model.generator = generator
 

--- a/onmt/ModelConstructor.py
+++ b/onmt/ModelConstructor.py
@@ -107,12 +107,12 @@ def make_decoder(opt, embeddings):
                              embeddings)
 
 
-def make_base_model(model_opt, fields, gpuid, checkpoint=None):
+def make_base_model(model_opt, fields, gpu, checkpoint=None):
     """
     Args:
         model_opt: the option loaded from checkpoint.
         fields: `Field` objects for the model.
-        gpuid: a list of integers, one for each gpu
+        gpu: Boolean: whether to use gpu.
         checkpoint: the snapshot model.
     Returns:
         the NMTModel.
@@ -165,7 +165,7 @@ def make_base_model(model_opt, fields, gpuid, checkpoint=None):
     model.generator = generator
 
     # Make the whole model leverage GPU if indicated to do so.
-    if gpuid:
+    if gpu:
         model.cuda()
     else:
         model.cpu()

--- a/onmt/Translator.py
+++ b/onmt/Translator.py
@@ -6,6 +6,7 @@ import onmt.Models
 import onmt.ModelConstructor
 import onmt.modules
 import onmt.IO
+from onmt.Utils import use_gpu
 
 
 class Translator(object):
@@ -25,7 +26,7 @@ class Translator(object):
         self.copy_attn = model_opt.copy_attn
 
         self.model = onmt.ModelConstructor.make_base_model(
-                            opt, model_opt, self.fields, checkpoint)
+                            model_opt, self.fields, use_gpu(opt), checkpoint)
         self.model.eval()
         self.model.generator.eval()
 

--- a/onmt/Utils.py
+++ b/onmt/Utils.py
@@ -1,9 +1,8 @@
-def aeq(base, *rest):
-    """ Assert the first arg equals to each of the rest."""
-    for a in rest[:]:
-        assert a == base, "base(" + str(base) \
-            + ") doesn't equals to each of " + str(rest)
-
-
-def use_gpu(opt):
-    return len(opt.gpuid) > 0
+def aeq(*args):
+    """
+    Assert all arguments have the same value
+    """
+    arguments = (arg for arg in args)
+    first = next(arguments)
+    assert all(arg == first for arg in arguments), \
+        "Not all arguments have the same value: " + str(args)

--- a/onmt/Utils.py
+++ b/onmt/Utils.py
@@ -4,5 +4,6 @@ def aeq(base, *rest):
         assert a == base, "base(" + str(base) \
             + ") doesn't equals to each of " + str(rest)
 
+
 def use_gpu(opt):
     return len(opt.gpuid) > 0

--- a/onmt/Utils.py
+++ b/onmt/Utils.py
@@ -1,6 +1,8 @@
-
 def aeq(base, *rest):
     """ Assert the first arg equals to each of the rest."""
     for a in rest[:]:
         assert a == base, "base(" + str(base) \
             + ") doesn't equals to each of " + str(rest)
+
+def use_gpu(opt):
+    return len(opt.gpuid) > 0

--- a/onmt/Utils.py
+++ b/onmt/Utils.py
@@ -6,3 +6,8 @@ def aeq(*args):
     first = next(arguments)
     assert all(arg == first for arg in arguments), \
         "Not all arguments have the same value: " + str(args)
+
+
+def use_gpu(opt):
+    return (hasattr(opt, 'gpuid') and len(opt.gpuid) > 0) or \
+        (hasattr(opt, 'gpu') and opt.gpu > -1)

--- a/train.py
+++ b/train.py
@@ -10,6 +10,7 @@ import onmt
 import onmt.Models
 import onmt.ModelConstructor
 import onmt.modules
+from onmt.Utils import use_gpu
 import opts
 
 parser = argparse.ArgumentParser(description='train.py')
@@ -267,7 +268,7 @@ def main():
     print('Building model...')
 
     model = onmt.ModelConstructor.make_base_model(model_opt, fields,
-                                                  opt.gpuid, checkpoint)
+                                                  use_gpu(opt), checkpoint)
     if len(opt.gpuid) > 1:
         print('Multi gpu training ', opt.gpuid)
         model = nn.DataParallel(model, device_ids=opt.gpuid, dim=1)

--- a/train.py
+++ b/train.py
@@ -65,7 +65,7 @@ def eval(model, criterion, data, fields):
     stats = onmt.Loss.Statistics()
     model.eval()
     loss = onmt.Loss.LossCompute(model.generator, criterion,
-                                 fields["tgt"].vocab, data, 0, opt)
+                                 fields["tgt"].vocab, data, 0, opt.copy_attn)
     for batch in valid_data:
         _, src_lengths = batch.src
         src = onmt.IO.make_features(batch, 'src')

--- a/train.py
+++ b/train.py
@@ -71,9 +71,9 @@ def eval(model, criterion, data, fields):
         src = onmt.IO.make_features(batch, 'src')
         tgt = onmt.IO.make_features(batch, 'tgt')
         outputs, attn, _ = model(src, tgt, src_lengths)
-        gen_state = loss.makeLossBatch(outputs, batch, attn,
-                                       (0, batch.tgt.size(0)))
-        _, batch_stats = loss.computeLoss(batch=batch, **gen_state)
+        gen_state = loss.make_loss_batch(
+            outputs, batch, attn, (0, batch.tgt.size(0)))
+        _, batch_stats = loss.compute_loss(batch=batch, **gen_state)
         stats.update(batch_stats)
     model.train()
     return stats

--- a/train.py
+++ b/train.py
@@ -85,9 +85,10 @@ def train_model(model, train_data, valid_data, fields, optim):
     padding_idx = fields['tgt'].vocab.stoi[onmt.IO.PAD_WORD]
 
     # Define criterion of each GPU.
+    # what attributes of opt does NMTCriterion use?
     if not opt.copy_attn:
-        criterion = onmt.Loss.NMTCriterion(len(fields['tgt'].vocab), opt,
-                                           padding_idx)
+        criterion = onmt.Loss.nmt_criterion(
+            len(fields['tgt'].vocab), opt.gpuid, padding_idx)
     else:
         criterion = onmt.modules.CopyCriterion(len(fields['tgt'].vocab),
                                                opt.copy_attn_force,

--- a/train.py
+++ b/train.py
@@ -138,7 +138,7 @@ def train_model(model, train_data, valid_data, fields, optim):
                 batch_stats = onmt.Loss.Statistics()
                 gen_state = closs.make_loss_batch(outputs, batch, attn,
                                                 (j, j + trunc_size))
-                for shard in splitter.splitIter(gen_state):
+                for shard in splitter.split_iter(gen_state):
 
                     # Compute loss and backprop shard.
                     loss, stats = closs.compute_loss(batch=batch,

--- a/train.py
+++ b/train.py
@@ -85,7 +85,6 @@ def train_model(model, train_data, valid_data, fields, optim):
     padding_idx = fields['tgt'].vocab.stoi[onmt.IO.PAD_WORD]
 
     # Define criterion of each GPU.
-    # what attributes of opt does NMTCriterion use?
     if not opt.copy_attn:
         criterion = onmt.Loss.nmt_criterion(
             len(fields['tgt'].vocab), opt.gpuid, padding_idx)
@@ -137,12 +136,12 @@ def train_model(model, train_data, valid_data, fields, optim):
                 # (2) F-prop/B-prob generator in shards for memory
                 # efficiency.
                 batch_stats = onmt.Loss.Statistics()
-                gen_state = closs.makeLossBatch(outputs, batch, attn,
+                gen_state = closs.make_loss_batch(outputs, batch, attn,
                                                 (j, j + trunc_size))
                 for shard in splitter.splitIter(gen_state):
 
                     # Compute loss and backprop shard.
-                    loss, stats = closs.computeLoss(batch=batch,
+                    loss, stats = closs.compute_loss(batch=batch,
                                                     **shard)
                     loss.div(batch.batch_size).backward()
                     batch_stats.update(stats)

--- a/train.py
+++ b/train.py
@@ -245,7 +245,7 @@ def main():
     # have the structure it does?
     src_features = [fields["src_feat_"+str(j)]
                     for j in range(train.nfeatures)]
-    model_opt = opt # model opt is either the same as opt or it's from checkpoint
+    model_opt = opt
     checkpoint = None
 
     if opt.train_from:
@@ -264,9 +264,9 @@ def main():
     print(' * maximum batch size. %d' % opt.batch_size)
 
     print('Building model...')
-    # Awkward that make_base_model signature takes opt AND model_opt
-    model = onmt.ModelConstructor.make_base_model(opt, model_opt,
-                                                  fields, checkpoint)
+
+    model = onmt.ModelConstructor.make_base_model(model_opt, fields,
+                                                  opt.gpuid, checkpoint)
     if len(opt.gpuid) > 1:
         print('Multi gpu training ', opt.gpuid)
         model = nn.DataParallel(model, device_ids=opt.gpuid, dim=1)


### PR DESCRIPTION
This PR clarifies code in train.py and adjacent files. Specifically,

1. I clarified the process in train.py's `main()`. There used to be several separate if/elses regarding `opt.train_from`. Now there's just one.
2. I snake_cased variable and function names in train.py and Loss.py.
3. I removed the `Splitter` class. It had only one function and no interesting state, so I decided that its purpose would better be implemented with a generator function. I simplified the implementation of that function, replacing some indexing logic with a fair quantity of well-commenting zipping and unzipping. The function is renamed `shards`. I'm a little bit skeptical of backpropping the variables after the last yield of a generator function, but I don't know what would be a better way to do it.
4. Where possible, I removed `opt` from the argument signatures of functions. It's rarely necessary to pass all the script's arguments.
5. I changed the implementation of `aeq`.