### PR TITLE
Change behavior for feature dimensions

### DIFF
--- a/onmt/modules/Embeddings.py
+++ b/onmt/modules/Embeddings.py
@@ -30,14 +30,14 @@ class Embeddings(nn.Module):
     Words embeddings dictionary for encoder/decoder.
 
     Args:
-        embedding_dim (int): size of the dictionary of embeddings.
+        word_vec_size (int): size of the dictionary of embeddings.
         position_encoding (bool): use a sin to mark relative words positions.
         feat_merge (string): merge action for the features embeddings:
                     concat, sum or mlp.
         feat_vec_exponent (float): when using '-feat_merge concat', feature
                     embedding size is N^feat_dim_exponent, where N is the
                     number of values of feature takes.
-        feat_embedding_dim (int): embedding dimension for features when using
+        feat_vec_size (int): embedding dimension for features when using
                     '-feat_merge mlp'
         dropout (float): dropout probability.
         word_padding_idx (int): padding index for words in the embeddings.
@@ -47,28 +47,27 @@ class Embeddings(nn.Module):
         feat_vocab_sizes ([int], optional): list of size of dictionary
                                     of embeddings for each feature.
     """
-    def __init__(self, embedding_dim, position_encoding, feat_merge,
-                 feat_vec_exponent, feat_embedding_dim, dropout,
+    def __init__(self, word_vec_size, position_encoding, feat_merge,
+                 feat_vec_exponent, feat_vec_size, dropout,
                  word_padding_idx, feat_padding_idx,
                  word_vocab_size, feat_vocab_sizes=[]):
-        super(Embeddings, self).__init__()
 
         self.word_padding_idx = word_padding_idx
 
-        # Parameters for constructing the word embedding matrix
+        # Dimensions and padding for constructing the word embedding matrix
         vocab_sizes = [word_vocab_size]
-        emb_dims = [embedding_dim]
+        emb_dims = [word_vec_size]
         pad_indices = [word_padding_idx]
 
-        # Parameters for additional feature embedding matrices
+        # Dimensions and padding for feature embedding matrices
         # (these have no effect if feat_vocab_sizes is empty)
-        if feat_merge == 'concat':
+        if feat_merge == 'sum':
+            feat_dims = [word_vec_size] * len(feat_vocab_sizes)
+        elif feat_vec_size > 0:
+            feat_dims = [feat_vec_size] * len(feat_vocab_sizes)
+        else:
             feat_dims = [int(vocab ** feat_vec_exponent)
                          for vocab in feat_vocab_sizes]
-        else:
-            feat_dim = embedding_dim \
-                if feat_merge == 'sum' else feat_embedding_dim
-            feat_dims = [feat_dim] * len(feat_vocab_sizes)
         vocab_sizes.extend(feat_vocab_sizes)
         emb_dims.extend(feat_dims)
         pad_indices.extend(feat_padding_idx)
@@ -85,19 +84,20 @@ class Embeddings(nn.Module):
         # This is the attribute you should access if you need to know
         # how big your embeddings are going to be.
         self.embedding_size = (sum(emb_dims) if feat_merge == 'concat'
-                               else embedding_dim)
+                               else word_vec_size)
 
         # The sequence of operations that converts the input sequence
         # into a sequence of embeddings. At minimum this consists of
         # looking up the embeddings for each word and feature in the
         # input. Model parameters may require the sequence to contain
         # additional operations as well.
+        super(Embeddings, self).__init__()
         self.make_embedding = nn.Sequential()
         self.make_embedding.add_module('emb_luts', emb_luts)
 
         if feat_merge == 'mlp':
             in_dim = sum(emb_dims)
-            out_dim = embedding_dim
+            out_dim = word_vec_size
             mlp = nn.Sequential(BottleLinear(in_dim, out_dim), nn.ReLU())
             self.make_embedding.add_module('mlp', mlp)
 

--- a/opts.py
+++ b/opts.py
@@ -17,16 +17,17 @@ def model_opts(parser):
     parser.add_argument('-tgt_word_vec_size', type=int, default=500,
                         help='Tgt word embedding sizes')
 
-    parser.add_argument('-feat_vec_size', type=int, default=20,
-                        help="""When using -feat_merge mlp, feature embedding
-                        sizes will be set to this.""")
     parser.add_argument('-feat_merge', type=str, default='concat',
                         choices=['concat', 'sum', 'mlp'],
                         help='Merge action for the features embeddings')
+    parser.add_argument('-feat_vec_size', type=int, default=-1,
+                        help="""If specified, feature embedding sizes
+                        will be set to this. Otherwise, feat_vec_exponent
+                        will be used.""")
     parser.add_argument('-feat_vec_exponent', type=float, default=0.7,
-                        help="""When using -feat_merge concat, feature embedding
-                        sizes will be set to N^feat_vec_exponent where N is the
-                        number of values the feature takes.""")
+                        help="""If -feat_merge_size is not set, feature
+                        embedding sizes will be set to N^feat_vec_exponent
+                        where N is the number of values the feature takes.""")
     parser.add_argument('-position_encoding', action='store_true',
                         help='Use a sin to mark relative words positions.')
     parser.add_argument('-share_decoder_embeddings', action='store_true',


### PR DESCRIPTION
This pull request changes the behavior of the `-feat_vec_size` and `-feat_vec_exponent` command line options for building embeddings. Previously, `-feat_vec_exponent` was only used for `-feat_merge concat` and `feat_vec_size` was only used for `-feat_merge mlp`. This would lead to a lot of frustration if a person had pretrained feature embeddings of a known dimension that they wanted to concatenate, because they couldn't just specify that dimension with `-feat_vec_size`.

I changed this so that if `-feat_vec_size` is specified, it is used. `-feat_vec_exponent` is only used to determine the feature embedding size if `-feat_vec_size` is not specified.

I also changed around a couple of variable names in Embeddings.py to be clearer (`word_vec_size` is a better description of the variable's purpose than `embedding_dim`) and more consistent with the names of the command line options (the corresponding flag is `-word_vec_size`). And finally, I moved the `nn.Module` super init farther down in the constructor because it's only necessary for the bit where submodules, parameters, and buffers are created, and that happens at the end.