### PR TITLE
SRU: fix the decoder when rnn_type SRU is used

### DIFF
--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -364,6 +364,8 @@ class InputFeedRNNDecoder(RNNDecoderBase):
 
     def _build_rnn(self, rnn_type, input_size,
                    hidden_size, num_layers, dropout):
+        assert not rnn_type == "SRU", "SRU doesn't support input feed! " \
+                "Please set -input_feed 0!"
         if rnn_type == "LSTM":
             stacked_cell = onmt.modules.StackedLSTM
         else:

--- a/onmt/modules/SRU.py
+++ b/onmt/modules/SRU.py
@@ -627,6 +627,9 @@ class SRU(nn.Module):
             ).zero_())
             hidden = [zeros for i in range(self.depth)]
         else:
+            if isinstance(hidden, tuple):
+                # RNNDecoderState wraps hidden as a tuple.
+                hidden = hidden[0]
             assert hidden.dim() == 3    # (depth, batch, n_out*dir_)
             hidden = hidden.chunk(self.depth, 0)
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -206,7 +206,8 @@ tests_ntmodel = [[('rnn_type', 'GRU')],
 
 if onmt.modules.check_sru_requirement():
     """ Only do SRU test if requirment is safisfied. """
-    tests_ntmodel.append([('rnn_type', 'SRU')])
+    # SRU doesn't support input_feed.
+    tests_ntmodel.append([('rnn_type', 'SRU'), ('input_feed', 0)])
 
 for p in tests_ntmodel:
     _add_test(p, 'ntmmodel_forward')


### PR DESCRIPTION
This is a fix to the https://github.com/OpenNMT/OpenNMT-py/pull/260.

I forgot to check in this patch. 

SRU doesn't support InputFeed. So add a check in `make_decoder()` to use `StdRNNEncoder` instead.