### PR TITLE
Clean translate

### DIFF
--- a/translate.py
+++ b/translate.py
@@ -75,7 +75,7 @@ def main():
     if opt.cuda:
         torch.cuda.set_device(opt.gpu)
     translator = onmt.Translator(opt, dummy_opt.__dict__)
-    outF = codecs.open(opt.output, 'w', 'utf-8')
+    out_file = codecs.open(opt.output, 'w', 'utf-8')
     pred_score_total, pred_words_total = 0, 0
     gold_score_total, gold_words_total = 0, 0
     count = 0
@@ -101,16 +101,9 @@ def main():
 
         for b in range(len(pred_batch)):
             count += 1
-            try:
-                # python2 (should be the same)
-                for n in range(opt.n_best):
-                    outF.write(" ".join([i
-                               for i in pred_batch[b][n]]) + '\n')
-            except AttributeError:
-                # python3: can't do .decode on a str object
-                for n in range(opt.n_best):
-                    outF.write(" ".join(pred_batch[b][n]) + '\n')
-            outF.flush()
+            for n in range(opt.n_best):
+                out_file.write(" ".join(pred_batch[b][n]) + '\n')
+            out_file.flush()
 
             if opt.verbose:
                 words = []

--- a/translate.py
+++ b/translate.py
@@ -9,7 +9,11 @@ import torch
 import onmt
 import onmt.IO
 import opts
-from itertools import zip_longest, takewhile, count
+from itertools import takewhile, count
+try:
+    from itertools import zip_longest
+except ImportError:
+    from itertools import izip_longest as zip_longest
 
 parser = argparse.ArgumentParser(description='translate.py')
 opts.add_md_help_argument(parser)

--- a/translate.py
+++ b/translate.py
@@ -58,10 +58,10 @@ parser.add_argument('-share_vocab', action='store_true',
                     help="Share source and target vocabulary")
 
 
-def reportScore(name, scoreTotal, wordsTotal):
+def report_score(name, score_total, words_total):
     print("%s AVG SCORE: %.4f, %s PPL: %.4f" % (
-        name, scoreTotal / wordsTotal,
-        name, math.exp(-scoreTotal/wordsTotal)))
+        name, score_total / words_total,
+        name, math.exp(-score_total/words_total)))
 
 
 def main():
@@ -140,9 +140,9 @@ def main():
                                  " ".join(predBatch[b][n])),
                             'UTF-8'))
 
-    reportScore('PRED', predScoreTotal, predWordsTotal)
+    report_score('PRED', predScoreTotal, predWordsTotal)
     if opt.tgt:
-        reportScore('GOLD', goldScoreTotal, goldWordsTotal)
+        report_score('GOLD', goldScoreTotal, goldWordsTotal)
 
     if opt.dump_beam:
         json.dump(translator.beam_accum,


### PR DESCRIPTION
This PR makes a few changes to standardize the style and clarify what's going on in translate.py. These are just cosmetic changes, but they should ease future debugging of the script. I removed all indexing logic and accumulator variables and updated naming styles. I think it's possible to do even a little bit more, but incremental progress matters. Note that the `attn_debug` command line option is not actually implemented. This would be a useful future step.