### PR TITLE
Make transformer and cnn use their own commandline options instead of using rnn_size

### DIFF
--- a/onmt/ModelConstructor.py
+++ b/onmt/ModelConstructor.py
@@ -168,15 +168,17 @@ def make_base_model(model_opt, fields, gpu, checkpoint=None):
         generator.load_state_dict(checkpoint['generator'])
     else:
         if model_opt.param_init != 0.0:
-            print('Intializing parameters.')
+            print('Intializing model parameters.')
             for p in model.parameters():
+                p.data.uniform_(-model_opt.param_init, model_opt.param_init)
+            for p in generator.parameters():
                 p.data.uniform_(-model_opt.param_init, model_opt.param_init)
         model.encoder.embeddings.load_pretrained_vectors(
                 model_opt.pre_word_vecs_enc, model_opt.fix_word_vecs_enc)
         model.decoder.embeddings.load_pretrained_vectors(
                 model_opt.pre_word_vecs_dec, model_opt.fix_word_vecs_dec)
 
-    # add the generator to the module (does this register the parameter?)
+    # Add generator to model (this registers it as parameter of model).
     model.generator = generator
 
     # Make the whole model leverage GPU if indicated to do so.

--- a/onmt/Trainer.py
+++ b/onmt/Trainer.py
@@ -133,10 +133,9 @@ class Trainer(object):
                     dec_state.detach()
 
             if report_func is not None:
-                report_func(epoch, i, len(self.train_iter),
-                            total_stats.start_time, self.optim.lr,
-                            report_stats)
-                report_stats = Statistics()
+                report_stats = report_func(
+                        epoch, i, len(self.train_iter),
+                        total_stats.start_time, self.optim.lr, report_stats)
 
         return total_stats
 

--- a/train.py
+++ b/train.py
@@ -67,18 +67,24 @@ def report_func(epoch, batch, num_batches,
     """
     This is the user-defined batch-level traing progress
     report function.
+
     Args:
         epoch(int): current epoch count.
         batch(int): current batch count.
         num_batches(int): total number of batches.
         start_time(float): last report time.
         lr(float): current learning rate.
-        report_stats(Statistics): a Statistics instance.
+        report_stats(Statistics): old Statistics instance.
+    Returns:
+        report_stats(Statistics): updated Statistics instance.
     """
     if batch % opt.report_every == -1 % opt.report_every:
         report_stats.output(epoch, batch+1, num_batches, start_time)
         if opt.exp_host:
             report_stats.log("progress", experiment, lr)
+        report_stats = onmt.Statistics()
+
+    return report_stats
 
 
 def make_train_data_iter(train_data, opt):


### PR DESCRIPTION
It is preparation for the Optim refactor work.  The `noam` learning rate decay formula has a `rnn_size` factor in it, but since we now have `transformer` and `cnn`, it is ambiguous to use `rnn_size`. So this PR
adds `transformer_size`, `transformer_hidden_size` and `transformer_head_count` for `transformer`,  and adds `cnn_size` for `cnn`. They will not use `rnn_size` anymore. Assertion failure will be thrown if users use them with `rnn_size`. Also group the options for each model in `opts.py`.


**Patch list**
1. d7571b5 Transformer: add its own options for fine tuning
It adds the aforementioned options, also adds assertion for the size match with `[src_|tgt_]word_vec_size`. It now asserts failure if user use `rnn_size` for `transformer`.

2. e3fb909 Conv2Conv: add its own options for fine tuning
It adds the aforementioned option. It now asserts failure if user use `rnn_size` for `cnn`.

3. 1dd2b99 Optim: add self.model_dim for correct compute of noam multiplicative factor
4. a014027 added model_hidden_size for get model size based on model type

We now have `-rnn_size` for RNN, `-transformer_size` for transformer,
and `-cnn_size` for CNN, so add `get_model_size(opt, model_name)` in `onmt/Utils` 
to get the size based on model type.



