### PR TITLE
Refactor dataset

### DIFF
--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -165,8 +165,6 @@ class ONMTDataset(torchtext.data.Dataset):
                 self.src_vocabs.append(src_vocab)
                 # mapping source tokens to indices in the dynamic dict
                 src_map = torch.LongTensor([src_vocab.stoi[w] for w in src])
-
-                self.src_vocabs.append(src_vocab)
                 example["src_map"] = src_map
 
                 if "tgt" in example:

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -145,29 +145,33 @@ def collect_feature_dicts(fields):
     return feature_dicts
 
 
-def get_fields(n_features=0):
+def get_fields(n_src_features, n_tgt_features):
     """
-    n_features: the number of source features to create Field objects for.
+    n_src_features: the number of source features to create Field objects for.
+    n_tgt_features: the number of target features to create Field objects for.
     returns: A dictionary whose keys are strings and whose values are the
             corresponding Field objects.
     """
     fields = {}
     fields["src"] = torchtext.data.Field(
-        init_token=BOS_WORD, eos_token=EOS_WORD,
         pad_token=PAD_WORD,
         include_lengths=True)
 
     # fields = [("src_img", torchtext.data.Field(
     #     include_lengths=True))]
 
-    for j in range(n_features):
+    for j in range(n_src_features):
         fields["src_feat_"+str(j)] = \
-            torchtext.data.Field(init_token=BOS_WORD, eos_token=EOS_WORD,
-                                 pad_token=PAD_WORD)
+            torchtext.data.Field(pad_token=PAD_WORD)
 
     fields["tgt"] = torchtext.data.Field(
         init_token=BOS_WORD, eos_token=EOS_WORD,
         pad_token=PAD_WORD)
+
+    for j in range(n_tgt_features):
+        fields["tgt_feat_"+str(j)] = \
+            torchtext.data.Field(init_token=BOS_WORD, eos_token=EOS_WORD,
+                                 pad_token=PAD_WORD)
 
     def make_src(data, _):
         src_size = max([t.size(0) for t in data])

--- a/onmt/ModelConstructor.py
+++ b/onmt/ModelConstructor.py
@@ -123,7 +123,7 @@ def make_base_model(model_opt, fields, gpu, checkpoint=None):
     # Make encoder.
     if model_opt.model_type == "text":
         src_dict = fields["src"].vocab
-        feature_dicts = onmt.IO.collect_feature_dicts(fields)
+        feature_dicts = onmt.IO.collect_feature_dicts(fields, 'src')
         src_embeddings = make_embeddings(model_opt, src_dict,
                                          feature_dicts)
         encoder = make_encoder(model_opt, src_embeddings)
@@ -136,7 +136,7 @@ def make_base_model(model_opt, fields, gpu, checkpoint=None):
     # Make decoder.
     tgt_dict = fields["tgt"].vocab
     # TODO: prepare for a future where tgt features are possible.
-    feature_dicts = []
+    feature_dicts = onmt.IO.collect_feature_dicts(fields, 'tgt')
     tgt_embeddings = make_embeddings(model_opt, tgt_dict,
                                      feature_dicts, for_encoder=False)
 

--- a/onmt/ModelConstructor.py
+++ b/onmt/ModelConstructor.py
@@ -7,7 +7,6 @@ import torch.nn as nn
 import onmt
 import onmt.Models
 import onmt.modules
-from onmt.IO import ONMTDataset
 from onmt.Models import NMTModel, MeanEncoder, RNNEncoder, \
                         StdRNNDecoder, InputFeedRNNDecoder
 from onmt.modules import Embeddings, ImageEncoder, CopyGenerator, \
@@ -124,7 +123,7 @@ def make_base_model(model_opt, fields, gpu, checkpoint=None):
     # Make encoder.
     if model_opt.model_type == "text":
         src_dict = fields["src"].vocab
-        feature_dicts = ONMTDataset.collect_feature_dicts(fields)
+        feature_dicts = onmt.IO.collect_feature_dicts(fields)
         src_embeddings = make_embeddings(model_opt, src_dict,
                                          feature_dicts)
         encoder = make_encoder(model_opt, src_embeddings)

--- a/onmt/Trainer.py
+++ b/onmt/Trainer.py
@@ -188,7 +188,7 @@ class Trainer(object):
         checkpoint = {
             'model': model_state_dict,
             'generator': generator_state_dict,
-            'vocab': onmt.IO.ONMTDataset.save_vocab(fields),
+            'vocab': onmt.IO.save_vocab(fields),
             'opt': opt,
             'epoch': epoch,
             'optim': self.optim

--- a/onmt/Translator.py
+++ b/onmt/Translator.py
@@ -15,7 +15,7 @@ class Translator(object):
         self.opt = opt
         checkpoint = torch.load(opt.model,
                                 map_location=lambda storage, loc: storage)
-        self.fields = onmt.IO.ONMTDataset.load_fields(checkpoint['vocab'])
+        self.fields = onmt.IO.load_fields(checkpoint['vocab'])
 
         model_opt = checkpoint['opt']
         for arg in dummy_opt:

--- a/preprocess.py
+++ b/preprocess.py
@@ -53,9 +53,12 @@ def main():
     print('Preparing training ...')
     with codecs.open(opt.train_src, "r", "utf-8") as src_file:
         src_line = src_file.readline().strip().split()
-        _, _, n_features = onmt.IO.extract_features(src_line)
+        _, _, n_src_features = onmt.IO.extract_features(src_line)
+    with codecs.open(opt.train_tgt, "r", "utf-8") as tgt_file:
+        tgt_line = tgt_file.readline().strip().split()
+        _, _, n_tgt_features = onmt.IO.extract_features(tgt_line)
 
-    fields = onmt.IO.get_fields(n_features)
+    fields = onmt.IO.get_fields(n_src_features, n_tgt_features)
     print("Building Training...")
     train = onmt.IO.ONMTDataset(
         opt.train_src, opt.train_tgt, fields,

--- a/preprocess.py
+++ b/preprocess.py
@@ -71,7 +71,7 @@ def main():
 
     print("Building Valid...")
     valid = onmt.IO.ONMTDataset(
-        opt.train_src, opt.train_tgt, fields,
+        opt.valid_src, opt.valid_tgt, fields,
         opt.src_seq_length, opt.tgt_seq_length,
         src_seq_length_trunc=opt.src_seq_length_trunc,
         tgt_seq_length_trunc=opt.tgt_seq_length_trunc,

--- a/preprocess.py
+++ b/preprocess.py
@@ -57,12 +57,22 @@ def main():
 
     fields = onmt.IO.get_fields(n_features)
     print("Building Training...")
-    train = onmt.IO.ONMTDataset(opt.train_src, opt.train_tgt, fields, opt)
+    train = onmt.IO.ONMTDataset(
+        opt.train_src, opt.train_tgt, fields,
+        opt.src_seq_length, opt.tgt_seq_length,
+        src_seq_length_trunc=opt.src_seq_length_trunc,
+        tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
+        dynamic_dict=opt.dynamic_dict)
     print("Building Vocab...")
     onmt.IO.build_vocab(train, opt)
 
     print("Building Valid...")
-    valid = onmt.IO.ONMTDataset(opt.valid_src, opt.valid_tgt, fields, opt)
+    valid = onmt.IO.ONMTDataset(
+        opt.train_src, opt.train_tgt, fields,
+        opt.src_seq_length, opt.tgt_seq_length,
+        src_seq_length_trunc=opt.src_seq_length_trunc,
+        tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
+        dynamic_dict=opt.dynamic_dict)
     print("Saving train/valid/fields")
 
     # Can't save fields, so remove/reconstruct at training time.

--- a/preprocess.py
+++ b/preprocess.py
@@ -53,20 +53,20 @@ def main():
     print('Preparing training ...')
     with codecs.open(opt.train_src, "r", "utf-8") as src_file:
         src_line = src_file.readline().strip().split()
-        _, _, nFeatures = onmt.IO.extract_features(src_line)
+        _, _, n_features = onmt.IO.extract_features(src_line)
 
-    fields = onmt.IO.ONMTDataset.get_fields(nFeatures)
+    fields = onmt.IO.get_fields(n_features)
     print("Building Training...")
     train = onmt.IO.ONMTDataset(opt.train_src, opt.train_tgt, fields, opt)
     print("Building Vocab...")
-    onmt.IO.ONMTDataset.build_vocab(train, opt)
+    onmt.IO.build_vocab(train, opt)
 
     print("Building Valid...")
     valid = onmt.IO.ONMTDataset(opt.valid_src, opt.valid_tgt, fields, opt)
     print("Saving train/valid/fields")
 
     # Can't save fields, so remove/reconstruct at training time.
-    torch.save(onmt.IO.ONMTDataset.save_vocab(fields),
+    torch.save(onmt.IO.save_vocab(fields),
                open(opt.save_data + '.vocab.pt', 'wb'))
     train.fields = []
     valid.fields = []

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -28,7 +28,7 @@ class TestModel(unittest.TestCase):
     # Helper to generate a vocabulary
 
     def get_vocab(self):
-        src = onmt.IO.ONMTDataset.get_fields()["src"]
+        src = onmt.IO.get_fields()["src"]
         src.build_vocab([])
         return src.vocab
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -28,7 +28,7 @@ class TestModel(unittest.TestCase):
     # Helper to generate a vocabulary
 
     def get_vocab(self):
-        src = onmt.IO.get_fields()["src"]
+        src = onmt.IO.get_fields(0, 0)["src"]
         src.build_vocab([])
         return src.vocab
 

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -52,7 +52,7 @@ class TestData(unittest.TestCase):
 
         self.assertEqual(Counter({'c': 6, 'b': 4, 'a': 2, 'e': 2, 'f': 1}),
                          merged.freqs)
-        self.assertEqual(9, len(merged.itos))
+        self.assertEqual(6, len(merged.itos))
         self.assertTrue('b' in merged.itos)
 
 

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -25,17 +25,21 @@ class TestData(unittest.TestCase):
     def dataset_build(self, opt):
         fields = onmt.IO.get_fields()
 
-        train = onmt.IO.ONMTDataset(opt.train_src,
-                                    opt.train_tgt,
-                                    fields,
-                                    opt)
+        train = onmt.IO.ONMTDataset(
+            opt.train_src, opt.train_tgt, fields,
+            opt.src_seq_length, opt.tgt_seq_length,
+            src_seq_length_trunc=opt.src_seq_length_trunc,
+            tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
+            dynamic_dict=opt.dynamic_dict)
 
         onmt.IO.build_vocab(train, opt)
 
-        onmt.IO.ONMTDataset(opt.valid_src,
-                            opt.valid_tgt,
-                            fields,
-                            opt)
+        onmt.IO.ONMTDataset(
+            opt.valid_src, opt.valid_tgt, fields,
+            opt.src_seq_length, opt.tgt_seq_length,
+            src_seq_length_trunc=opt.src_seq_length_trunc,
+            tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
+            dynamic_dict=opt.dynamic_dict)
 
 
 def _add_test(paramSetting, methodname):

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -30,8 +30,7 @@ class TestData(unittest.TestCase):
                                     fields,
                                     opt)
 
-        onmt.IO.ONMTDataset.build_vocab(train,
-                                        opt)
+        onmt.IO.build_vocab(train, opt)
 
         onmt.IO.ONMTDataset(opt.valid_src,
                             opt.valid_tgt,

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -23,7 +23,7 @@ class TestData(unittest.TestCase):
         self.opt = opt
 
     def dataset_build(self, opt):
-        fields = onmt.IO.ONMTDataset.get_fields()
+        fields = onmt.IO.get_fields()
 
         train = onmt.IO.ONMTDataset(opt.train_src,
                                     opt.train_tgt,

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -26,7 +26,7 @@ class TestData(unittest.TestCase):
         self.opt = opt
 
     def dataset_build(self, opt):
-        fields = onmt.IO.get_fields()
+        fields = onmt.IO.get_fields(0, 0)
 
         train = onmt.IO.ONMTDataset(
             opt.train_src, opt.train_tgt, fields,

--- a/train.py
+++ b/train.py
@@ -206,7 +206,7 @@ def collect_features(train, fields):
     # TODO: account for target features.
     # Also, why does fields need to have the structure it does?
     src_features = onmt.IO.collect_features(fields)
-    aeq(len(src_features), train.nfeatures)
+    aeq(len(src_features), train.n_src_feats)
 
     return src_features
 

--- a/train.py
+++ b/train.py
@@ -185,7 +185,7 @@ def tally_parameters(model):
 
 
 def load_fields(train, valid, checkpoint):
-    fields = onmt.IO.ONMTDataset.load_fields(
+    fields = onmt.IO.load_fields(
                 torch.load(opt.data + '.vocab.pt'))
     fields = dict([(k, f) for (k, f) in fields.items()
                   if k in train.examples[0].__dict__])
@@ -194,7 +194,7 @@ def load_fields(train, valid, checkpoint):
 
     if opt.train_from:
         print('Loading vocab from checkpoint at %s.' % opt.train_from)
-        fields = onmt.IO.ONMTDataset.load_fields(checkpoint['vocab'])
+        fields = onmt.IO.load_fields(checkpoint['vocab'])
 
     print(' * vocabulary size. source = %d; target = %d' %
           (len(fields['src'].vocab), len(fields['tgt'].vocab)))
@@ -205,7 +205,7 @@ def load_fields(train, valid, checkpoint):
 def collect_features(train, fields):
     # TODO: account for target features.
     # Also, why does fields need to have the structure it does?
-    src_features = onmt.IO.ONMTDataset.collect_features(fields)
+    src_features = onmt.IO.collect_features(fields)
     aeq(len(src_features), train.nfeatures)
 
     return src_features

--- a/translate.py
+++ b/translate.py
@@ -93,7 +93,9 @@ def main():
     if opt.dump_beam != "":
         import json
         translator.initBeamAccum()
-    data = onmt.IO.ONMTDataset(opt.src, opt.tgt, translator.fields, None)
+    data = onmt.IO.ONMTDataset(
+        opt.src, opt.tgt, translator.fields,
+        use_filter_pred=False)
 
     test_data = onmt.IO.OrderedIterator(
         dataset=data, device=opt.gpu,


### PR DESCRIPTION
This pull request makes some changes to IO.py in order to make the Dataset creation process clearer and easier to extend. Changes are primarily these:

1. I removed almost all of `ONMTDataset`'s static methods. They now live in IO.py as normal functions. Static methods are not necessary very often, and I felt that here they were obscuring the purpose of the `ONMTDataset` class here.
2. I altered the constructor of the `ONMTDataset` so that it no longer takes `opt` as an argument. Although this results in having to pass in more arguments, I think it is better to be explicit.
3. I consolidated the functionality of the various iterators over the data files. The process is now taken care of in the `read_corpus_file` generator.
4. I included an assertion in `ONMTDataset` that the `src_img_dir` is none, which seems reasonable since image datasets are not implemented yet.
5. I renamed the attribute that refers to the number of features to indicate that it is for source features. There is now also an attribute for the target features.

I noted in a comment on #283 that our work in not reading the whole source file in at once may not have the intended effect because the parent class's constructor often turns the examples sequence into a list, thus eliminating the benefit of doing things lazily. The parent class also implements `__getitem__`. Based on my inspection of the parent class, we don't really need to call its constructor, and I don't think we actually use the `ONMTDataset's` `__getitem__` anywhere, so we could just raise an error if it's called. More serious than that, though, is our use of `OrderedIterator`. We can't order the training data unless we're willing to store all of it at once.