### PR TITLE
fix wrong argument in tutorial document

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ python preprocess.py -train_src data/multi30k/train.en.atok -train_tgt data/mult
 ### 2) Train the model.
 
 ```bash
-python train.py -data data/multi30k.atok.low.train.pt -save_model multi30k_model -gpuid 0
+python train.py -data data/multi30k.atok.low -save_model multi30k_model -gpuid 0
 ```
 
 ### 3) Translate sentences.

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ python train.py -data data/multi30k.atok.low -save_model multi30k_model -gpuid 0
 ### 3) Translate sentences.
 
 ```bash
-python translate.py -gpu 0 -model multi30k_model_e13_*.pt -src data/multi30k/test.en.atok -tgt data/multi30k/test.de.atok -replace_unk -verbose -output multi30k.test.pred.atok
+python translate.py -gpu 0 -model multi30k_model_*_e13.pt -src data/multi30k/test.en.atok -tgt data/multi30k/test.de.atok -replace_unk -verbose -output multi30k.test.pred.atok
 ```
 
 ### 4) Evaluate.


### PR DESCRIPTION
Fix wrong argument in tutorial document, when execute below command line, then
$ python train.py -data data/multi30k.atok.low.train.pt -save_model multi30k_model -gpuid 0
below error occured and I changed data argument to data/multi30k.atok.low , it works well.

Loading data from 'data/multi30k.atok.low.train.pt'
Traceback (most recent call last):
  File "train.py", line 318, in <module>
    main()
  File "train.py", line 231, in main
    train = torch.load(opt.data + '.train.pt', pickle_module=dill)
  File "/opt/conda/envs/pytorch-py35/lib/python3.5/site-packages/torch/serialization.py", line 229, in load
    f = open(f, 'rb')
FileNotFoundError: [Errno 2] No such file or directory: 'data/multi30k.atok.low.train.pt.train.pt'