### PR TITLE
Add option to share embedding

### DIFF
--- a/onmt/ModelConstructor.py
+++ b/onmt/ModelConstructor.py
@@ -136,7 +136,6 @@ def make_base_model(model_opt, fields, gpu, checkpoint=None):
 
     # Make decoder.
     tgt_dict = fields["tgt"].vocab
-
     # TODO: prepare for a future where tgt features are possible.
     feature_dicts = []
     tgt_embeddings = make_embeddings(model_opt, tgt_dict,

--- a/onmt/ModelConstructor.py
+++ b/onmt/ModelConstructor.py
@@ -136,10 +136,13 @@ def make_base_model(model_opt, fields, gpu, checkpoint=None):
 
     # Make decoder.
     tgt_dict = fields["tgt"].vocab
-    # TODO: prepare for a future where tgt features are possible.
-    feature_dicts = []
-    tgt_embeddings = make_embeddings(model_opt, tgt_dict,
-                                     feature_dicts, for_encoder=False)
+    if model_opt.share_embeddings:
+        tgt_embeddings = src_embeddings
+    else:
+        # TODO: prepare for a future where tgt features are possible.
+        feature_dicts = []
+        tgt_embeddings = make_embeddings(model_opt, tgt_dict,
+                                         feature_dicts, for_encoder=False)
     decoder = make_decoder(model_opt, tgt_embeddings)
 
     # Make NMTModel(= encoder + decoder).

--- a/onmt/ModelConstructor.py
+++ b/onmt/ModelConstructor.py
@@ -136,13 +136,15 @@ def make_base_model(model_opt, fields, gpu, checkpoint=None):
 
     # Make decoder.
     tgt_dict = fields["tgt"].vocab
-    if model_opt.share_embeddings:
-        tgt_embeddings = src_embeddings
-    else:
-        # TODO: prepare for a future where tgt features are possible.
-        feature_dicts = []
-        tgt_embeddings = make_embeddings(model_opt, tgt_dict,
-                                         feature_dicts, for_encoder=False)
+
+    # TODO: prepare for a future where tgt features are possible.
+    feature_dicts = []
+    tgt_embeddings = make_embeddings(model_opt, tgt_dict,
+                                     feature_dicts, for_encoder=False)
+
+    # Share the embedding matrix - preprocess with share_vocab required
+    # if model_opt.share_embeddings:
+    #     tgt_embeddings = src_embeddings
     decoder = make_decoder(model_opt, tgt_embeddings)
 
     # Make NMTModel(= encoder + decoder).

--- a/onmt/ModelConstructor.py
+++ b/onmt/ModelConstructor.py
@@ -143,8 +143,9 @@ def make_base_model(model_opt, fields, gpu, checkpoint=None):
                                      feature_dicts, for_encoder=False)
 
     # Share the embedding matrix - preprocess with share_vocab required
-    # if model_opt.share_embeddings:
-    #     tgt_embeddings = src_embeddings
+    if model_opt.share_embeddings:
+        tgt_embeddings.word_lut.weight = src_embeddings.word_lut.weight
+
     decoder = make_decoder(model_opt, tgt_embeddings)
 
     # Make NMTModel(= encoder + decoder).

--- a/opts.py
+++ b/opts.py
@@ -33,6 +33,9 @@ def model_opts(parser):
                         help='Use a sin to mark relative words positions.')
     parser.add_argument('-share_decoder_embeddings', action='store_true',
                         help='Share the word and out embeddings for decoder.')
+    parser.add_argument('-share_embeddings', action='store_true',
+                        help="""Share the word embeddings between encoder
+                         and decoder.""")
 
     # RNN Options
     parser.add_argument('-encoder_type', type=str, default='rnn',


### PR DESCRIPTION
This is a small addition to model_constructor to enable shared embeddings between encoder and decoder. 

I tested by running a model with and without the option (wvec size 128, vocab size 50k) - The total parameters decreased by 6.4 mio as expected. 