### PR TITLE
Fixing copy_attn validation

### DIFF
--- a/onmt/Trainer.py
+++ b/onmt/Trainer.py
@@ -156,8 +156,9 @@ class Trainer(object):
             outputs, attns, _ = self.model(src, tgt, src_lengths)
 
             # Compute loss.
+            copy_attn = (attns.get("copy") is not None)
             gen_state = onmt.Loss.make_gen_state(
-                outputs, batch, attns, (0, batch.tgt.size(0)))
+                outputs, batch, attns, (0, batch.tgt.size(0)), copy_attn=copy_attn)
             _, batch_stats = self.valid_loss(batch, **gen_state)
 
             # Update statistics.

--- a/onmt/Trainer.py
+++ b/onmt/Trainer.py
@@ -158,7 +158,8 @@ class Trainer(object):
             # Compute loss.
             copy_attn = (attns.get("copy") is not None)
             gen_state = onmt.Loss.make_gen_state(
-                outputs, batch, attns, (0, batch.tgt.size(0)), copy_attn=copy_attn)
+                outputs, batch, attns, (0, batch.tgt.size(0)),
+                copy_attn=copy_attn)
             _, batch_stats = self.valid_loss(batch, **gen_state)
 
             # Update statistics.

--- a/onmt/modules/CopyGenerator.py
+++ b/onmt/modules/CopyGenerator.py
@@ -90,7 +90,7 @@ class CopyGeneratorLossCompute(onmt.Loss.LossComputeBase):
         self.criterion = CopyGeneratorCriterion(len(tgt_vocab), force_copy,
                                                 self.padding_idx)
 
-    def compute_loss(self, batch, output, target, copy_attn, align):
+    def compute_loss(self, batch, output, target, copy_attn, align, **kwargs):
         """
         Compute the loss. The args must match Loss.make_gen_state().
         Args:


### PR DESCRIPTION
- add `**kwargs` in `onmt.modules.CopyGenerator.CopyGeneratorLossCompute.forward`
- set `copy_attn` parameter for `validation_loss` in `Trainer`

Fixing #313 