### PR TITLE
Fix IO.merge_vocab()

### DIFF
--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -53,7 +53,7 @@ def merge_vocabs(vocabs, vocab_size=None):
     Return:
         `torchtext.vocab.Vocab`
     """
-    merged = Counter(chain(*[vocab.freqs for vocab in vocabs]))
+    merged = sum([vocab.freqs for vocab in vocabs], Counter())
     return torchtext.vocab.Vocab(merged,
                                  specials=[PAD_WORD, BOS_WORD, EOS_WORD],
                                  max_size=vocab_size)

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -5,7 +5,6 @@ import onmt
 import opts
 import torchtext
 
-
 from collections import Counter
 
 

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -3,6 +3,10 @@ import copy
 import unittest
 import onmt
 import opts
+import torchtext
+
+
+from collections import Counter
 
 
 parser = argparse.ArgumentParser(description='preprocess.py')
@@ -37,6 +41,17 @@ class TestData(unittest.TestCase):
                             opt.valid_tgt,
                             fields,
                             opt)
+
+    def test_merge_vocab(self):
+        va = torchtext.vocab.Vocab(Counter('abbccc'))
+        vb = torchtext.vocab.Vocab(Counter('eeabbcccf'))
+
+        merged = onmt.IO.merge_vocabs([va, vb], 2)
+
+        self.assertEqual(Counter({'c': 6, 'b': 4, 'a': 2, 'e': 2, 'f': 1}),
+                         merged.freqs)
+        self.assertEqual(6, len(merged.itos))
+        self.assertTrue('b' in merged.itos)
 
 
 def _add_test(paramSetting, methodname):


### PR DESCRIPTION
When using the preprocessing option `share_vocab`, the called function `merge_vocab` had unintended behavior. 

Namely, instead of adding the token frequencies of the src and tgt vocabularies, it counted in how many dictionaries a word appeared in. Example behavior below:

```
va = torchtext.vocab.Vocab(Counter('abbccc'))
vb = torchtext.vocab.Vocab(Counter('eeabbcccf'))
print(merge_vocabs([va, vb], 1).freqs)
>>> Counter({'a': 2, 'c': 2, 'b': 2, 'e': 1, 'f': 1})
```

I updated the behavior so that now it produces the expected output: 

```
va = torchtext.vocab.Vocab(Counter('abbccc'))
vb = torchtext.vocab.Vocab(Counter('eeabbcccf'))
print(merge_vocabs([va, vb], 1).freqs)
>>> Counter({'c': 6, 'b': 4, 'a': 2, 'e': 2, 'f': 1})
```

I also added an extra test in `test_preprocess.py` to check this function for the future.  

