### PR TITLE
Turn off multigpu for train and batch_size for translate

### DIFF
--- a/opts.py
+++ b/opts.py
@@ -98,6 +98,38 @@ def model_opts(parser):
                         help='Lambda value for coverage.')
 
 
+def preprocess_opts(parser):
+    # Dictionary Options
+    parser.add_argument('-src_vocab_size', type=int, default=50000,
+                        help="Size of the source vocabulary")
+    parser.add_argument('-tgt_vocab_size', type=int, default=50000,
+                        help="Size of the target vocabulary")
+
+    parser.add_argument('-src_words_min_frequency', type=int, default=0)
+    parser.add_argument('-tgt_words_min_frequency', type=int, default=0)
+
+    # Truncation options
+    parser.add_argument('-src_seq_length', type=int, default=50,
+                        help="Maximum source sequence length")
+    parser.add_argument('-src_seq_length_trunc', type=int, default=0,
+                        help="Truncate source sequence length.")
+    parser.add_argument('-tgt_seq_length', type=int, default=50,
+                        help="Maximum target sequence length to keep.")
+    parser.add_argument('-tgt_seq_length_trunc', type=int, default=0,
+                        help="Truncate target sequence length.")
+
+    # Data processing options
+    parser.add_argument('-shuffle', type=int, default=1,
+                        help="Shuffle data")
+    parser.add_argument('-lower', action='store_true', help='lowercase data')
+
+    # Options most relevant to summarization
+    parser.add_argument('-dynamic_dict', action='store_true',
+                        help="Create dynamic dictionaries")
+    parser.add_argument('-share_vocab', action='store_true',
+                        help="Share source and target vocabulary")
+
+
 def train_opts(parser):
     # Model loading/saving options
     parser.add_argument('-data', required=True,
@@ -193,32 +225,45 @@ def train_opts(parser):
                         help="Name of the experiment for logging.")
 
 
-def preprocess_opts(parser):
-    # Dictionary Options
-    parser.add_argument('-src_vocab_size', type=int, default=50000,
-                        help="Size of the source vocabulary")
-    parser.add_argument('-tgt_vocab_size', type=int, default=50000,
-                        help="Size of the target vocabulary")
-
-    parser.add_argument('-src_words_min_frequency', type=int, default=0)
-    parser.add_argument('-tgt_words_min_frequency', type=int, default=0)
-
-    # Truncation options
-    parser.add_argument('-src_seq_length', type=int, default=50,
-                        help="Maximum source sequence length")
-    parser.add_argument('-src_seq_length_trunc', type=int, default=0,
-                        help="Truncate source sequence length.")
-    parser.add_argument('-tgt_seq_length', type=int, default=50,
-                        help="Maximum target sequence length to keep.")
-    parser.add_argument('-tgt_seq_length_trunc', type=int, default=0,
-                        help="Truncate target sequence length.")
-
-    # Data processing options
-    parser.add_argument('-shuffle', type=int, default=1,
-                        help="Shuffle data")
-    parser.add_argument('-lower', action='store_true', help='lowercase data')
-
-    # Options most relevant to summarization
+def translate_opts(parser):
+    parser.add_argument('-model', required=True,
+                        help='Path to model .pt file')
+    parser.add_argument('-src',   required=True,
+                        help="""Source sequence to decode (one line per
+                        sequence)""")
+    parser.add_argument('-src_img_dir',   default="",
+                        help='Source image directory')
+    parser.add_argument('-tgt',
+                        help='True target sequence (optional)')
+    parser.add_argument('-output', default='pred.txt',
+                        help="""Path to output the predictions (each line will
+                        be the decoded sequence""")
+    parser.add_argument('-beam_size',  type=int, default=5,
+                        help='Beam size')
+    parser.add_argument('-batch_size', type=int, default=30,
+                        help='Batch size')
+    parser.add_argument('-max_sent_length', type=int, default=100,
+                        help='Maximum sentence length.')
+    parser.add_argument('-replace_unk', action="store_true",
+                        help="""Replace the generated UNK tokens with the
+                        source token that had highest attention weight. If
+                        phrase_table is provided, it will lookup the
+                        identified source token and give the corresponding
+                        target token. If it is not provided(or the identified
+                        source token does not exist in the table) then it
+                        will copy the source token""")
+    parser.add_argument('-verbose', action="store_true",
+                        help='Print scores and predictions for each sentence')
+    parser.add_argument('-attn_debug', action="store_true",
+                        help='Print best attn for each word')
+    parser.add_argument('-dump_beam', type=str, default="",
+                        help='File to dump beam information to.')
+    parser.add_argument('-n_best', type=int, default=1,
+                        help="""If verbose is set, will output the n_best
+                        decoded sentences""")
+    parser.add_argument('-gpu', type=int, default=-1,
+                        help="Device to run on")
+    # Options most relevant to summarization.
     parser.add_argument('-dynamic_dict', action='store_true',
                         help="Create dynamic dictionaries")
     parser.add_argument('-share_vocab', action='store_true',

--- a/train.py
+++ b/train.py
@@ -1,6 +1,7 @@
 from __future__ import division
 
 import os
+import sys
 import argparse
 import torch
 import torch.nn as nn
@@ -43,6 +44,10 @@ if opt.gpuid:
     cuda.set_device(opt.gpuid[0])
     if opt.seed > 0:
         torch.cuda.manual_seed(opt.seed)
+
+if len(opt.gpuid) > 1:
+    sys.stderr.write("Sorry, multigpu isn't supported yet, coming soon!\n")
+    sys.exit(1)
 
 
 # Set up the Crayon logging server.
@@ -216,7 +221,7 @@ def build_model(model_opt, opt, fields, checkpoint):
     model = onmt.ModelConstructor.make_base_model(model_opt, fields,
                                                   use_gpu(opt), checkpoint)
     if len(opt.gpuid) > 1:
-        print('Multi gpu training ', opt.gpuid)
+        print('Multi gpu training: ', opt.gpuid)
         model = nn.DataParallel(model, device_ids=opt.gpuid, dim=1)
     print(model)
 

--- a/translate.py
+++ b/translate.py
@@ -17,50 +17,7 @@ except ImportError:
 
 parser = argparse.ArgumentParser(description='translate.py')
 opts.add_md_help_argument(parser)
-
-parser.add_argument('-model', required=True,
-                    help='Path to model .pt file')
-parser.add_argument('-src',   required=True,
-                    help='Source sequence to decode (one line per sequence)')
-parser.add_argument('-src_img_dir',   default="",
-                    help='Source image directory')
-parser.add_argument('-tgt',
-                    help='True target sequence (optional)')
-parser.add_argument('-output', default='pred.txt',
-                    help="""Path to output the predictions (each line will
-                    be the decoded sequence""")
-parser.add_argument('-beam_size',  type=int, default=5,
-                    help='Beam size')
-parser.add_argument('-batch_size', type=int, default=30,
-                    help='Batch size')
-parser.add_argument('-max_sent_length', type=int, default=100,
-                    help='Maximum sentence length.')
-parser.add_argument('-replace_unk', action="store_true",
-                    help="""Replace the generated UNK tokens with the source
-                    token that had highest attention weight. If phrase_table
-                    is provided, it will lookup the identified source token and
-                    give the corresponding target token. If it is not provided
-                    (or the identified source token does not exist in the
-                    table) then it will copy the source token""")
-parser.add_argument('-verbose', action="store_true",
-                    help='Print scores and predictions for each sentence')
-parser.add_argument('-attn_debug', action="store_true",
-                    help='Print best attn for each word')
-
-parser.add_argument('-dump_beam', type=str, default="",
-                    help='File to dump beam information to.')
-
-parser.add_argument('-n_best', type=int, default=1,
-                    help="""If verbose is set, will output the n_best
-                    decoded sentences""")
-
-parser.add_argument('-gpu', type=int, default=-1,
-                    help="Device to run on")
-# options most relevant to summarization
-parser.add_argument('-dynamic_dict', action='store_true',
-                    help="Create dynamic dictionaries")
-parser.add_argument('-share_vocab', action='store_true',
-                    help="Share source and target vocabulary")
+opts.translate_opts(parser)
 
 
 def report_score(name, score_total, words_total):

--- a/translate.py
+++ b/translate.py
@@ -19,6 +19,12 @@ parser = argparse.ArgumentParser(description='translate.py')
 opts.add_md_help_argument(parser)
 opts.translate_opts(parser)
 
+opt = parser.parse_args()
+if opt.batch_size != 1:
+    print("WARNING: -batch_size isn't supported currently, "
+          "we set it to 1 for now!")
+    opt.batch_size = 1
+
 
 def report_score(name, score_total, words_total):
     print("%s AVG SCORE: %.4f, %s PPL: %.4f" % (
@@ -34,7 +40,6 @@ def get_src_words(src_indices, index2str):
 
 
 def main():
-    opt = parser.parse_args()
 
     dummy_parser = argparse.ArgumentParser(description='train.py')
     opts.model_opts(dummy_parser)


### PR DESCRIPTION
This PR is trivial:

-  Turn off multigpu for `train.py` for now, error message will be spewed if user specify multiple gpu ids.
    This temporarily fixes https://github.com/OpenNMT/OpenNMT-py/issues/323.
-  Turn off `-batch_size` for `translate.py` for now,  it will be set to 1 and a warning is printed.
-  Move the options declaration in `translate.py` to `opts.py`, as like preprocess and train.