### PR TITLE
RNNEncoder:  fix "mistake dec_layers as enc_layers" bug

### DIFF
--- a/onmt/ModelConstructor.py
+++ b/onmt/ModelConstructor.py
@@ -67,7 +67,7 @@ def make_encoder(opt, embeddings):
         return MeanEncoder(opt.enc_layers, embeddings)
     else:
         # "rnn" or "brnn"
-        return RNNEncoder(opt.rnn_type, opt.brnn, opt.dec_layers,
+        return RNNEncoder(opt.rnn_type, opt.brnn, opt.enc_layers,
                           opt.rnn_size, opt.dropout, embeddings)
 
 


### PR DESCRIPTION
This PR fixes #341, a silly bug due to typo, but hasn't been noticed for quite long.