### PR TITLE
Fix #344

### DIFF
--- a/opts.py
+++ b/opts.py
@@ -11,24 +11,31 @@ def model_opts(parser):
     parser.add_argument('-model_type', default='text',
                         help="Type of encoder to use. Options are [text|img].")
     # Embedding Options
-    parser.add_argument('-word_vec_size', type=int, default=-1,
-                        help='Word embedding for both.')
-    parser.add_argument('-src_word_vec_size', type=int, default=500,
-                        help='Src word embedding sizes')
-    parser.add_argument('-tgt_word_vec_size', type=int, default=500,
-                        help='Tgt word embedding sizes')
+    parser.add_argument('-word_vec_size', type=int, default=0,
+                        help="""Shared word embedding size. If set, this
+                        overrides -src_word_vec_size and
+                        -tgt_word_vec_size.""")
+    parser.add_argument('-src_word_vec_size', type=int, default=[500],
+                        nargs='+',
+                        help="""List of source embedding sizes:
+                        word[ feat1[ feat2[ ...] ] ].""")
+    parser.add_argument('-tgt_word_vec_size', type=int, default=[500],
+                        nargs='+',
+                        help="""List of source embedding sizes:
+                        word[ feat1[ feat2[ ...] ] ].""")
 
     parser.add_argument('-feat_merge', type=str, default='concat',
                         choices=['concat', 'sum', 'mlp'],
                         help='Merge action for the features embeddings')
-    parser.add_argument('-feat_vec_size', type=int, default=-1,
-                        help="""If specified, feature embedding sizes
-                        will be set to this. Otherwise, feat_vec_exponent
-                        will be used.""")
+    parser.add_argument('-feat_vec_size', type=int, default=20,
+                        help="""When features embedding sizes are not set
+                        and using -feat_merge sum, this is the common
+                        embedding size of the features.""")
     parser.add_argument('-feat_vec_exponent', type=float, default=0.7,
-                        help="""If -feat_merge_size is not set, feature
-                        embedding sizes will be set to N^feat_vec_exponent
-                        where N is the number of values the feature takes.""")
+                        help="""When features embedding sizes are not set
+                        and using -feat_merge concat, their dimension will
+                        be set to N^feat_vec_exponent where N is the number
+                        of values the feature takes.""")
     parser.add_argument('-position_encoding', action='store_true',
                         help='Use a sin to mark relative words positions.')
     parser.add_argument('-share_decoder_embeddings', action='store_true',

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -56,10 +56,12 @@ class TestModel(unittest.TestCase):
         if opt.decoder_type == 'transformer':
             input = torch.cat([test_src, test_src], 0)
             res = emb(input)
-            compare_to = torch.zeros(sourceL * 2, bsize, opt.src_word_vec_size)
+            compare_to = torch.zeros(
+                sourceL * 2, bsize, opt.src_word_vec_size[0])
         else:
             res = emb(test_src)
-            compare_to = torch.zeros(sourceL, bsize, opt.src_word_vec_size)
+            compare_to = torch.zeros(
+                sourceL, bsize, opt.src_word_vec_size[0])
 
         self.assertEqual(res.size(), compare_to.size())
 
@@ -179,16 +181,16 @@ tests_ntmodel = [[('rnn_type', 'GRU')],
                  [('input_feed', 0)],
                  [('decoder_type', 'transformer'),
                   ('encoder_type', 'transformer'),
-                  ('src_word_vec_size', 16),
-                  ('tgt_word_vec_size', 16),
+                  ('src_word_vec_size', [16]),
+                  ('tgt_word_vec_size', [16]),
                   ('rnn_size', 16)],
                  # [('encoder_type', 'transformer'),
                  #  ('word_vec_size', 16),
                  #  ('rnn_size', 16)],
                  [('decoder_type', 'transformer'),
                   ('encoder_type', 'transformer'),
-                  ('src_word_vec_size', 16),
-                  ('tgt_word_vec_size', 16),
+                  ('src_word_vec_size', [16]),
+                  ('tgt_word_vec_size', [16]),
                   ('rnn_size', 16),
                   ('position_encoding', True)],
                  [('coverage_attn', True)],

--- a/train.py
+++ b/train.py
@@ -22,9 +22,9 @@ opts.model_opts(parser)
 opts.train_opts(parser)
 
 opt = parser.parse_args()
-if opt.word_vec_size != -1:
-    opt.src_word_vec_size = opt.word_vec_size
-    opt.tgt_word_vec_size = opt.word_vec_size
+if opt.word_vec_size > 0:
+    opt.src_word_vec_size = [opt.word_vec_size]
+    opt.tgt_word_vec_size = [opt.word_vec_size]
 
 if opt.layers != -1:
     opt.enc_layers = opt.layers


### PR DESCRIPTION
This pull request addresses the difference between the python and lua options for word vector sizes. It brings the python options (mostly) back into line with what's in lua, and makes it possible to have different manually specified embedding dimensions for different layers of features.