### PR TITLE
Raise error for deprecated opts

### DIFF
--- a/opts.py
+++ b/opts.py
@@ -70,7 +70,7 @@ def model_opts(parser):
     # parser.add_argument('-residual',   action="store_true",
     #                     help="Add residual connections between RNN layers.")
 
-    parser.add_argument('-brnn', action="store_true",
+    parser.add_argument('-brnn', action=DeprecateAction,
                         help="Deprecated, use `encoder_type`.")
     parser.add_argument('-brnn_merge', default='concat',
                         choices=['concat', 'sum'],
@@ -332,3 +332,14 @@ class MarkdownHelpAction(argparse.Action):
         parser.formatter_class = MarkdownHelpFormatter
         parser.print_help()
         parser.exit()
+
+
+class DeprecateAction(argparse.Action):
+    def __init__(self, option_strings, dest, help=None, **kwargs):
+        super(DeprecateAction, self).__init__(option_strings, dest, nargs=0,
+                                              help=help, **kwargs)
+
+    def __call__(self, parser, namespace, values, flag_name):
+        help = self.help if self.help is not None else ""
+        msg = "Flag '%s' is deprecated. %s" % (flag_name, help)
+        raise argparse.ArgumentTypeError(msg)


### PR DESCRIPTION
`-brnn` wasnt really deprecated in that the flag was still existing but useless. It's really confusing as user has no way to know about this deprecation. 

Just removing the flag isn't a really good solution either because it does not provide a solution. I added an action in opts.py for argparse so that the flag, when set, raise an error with a message (provided in help) so we can point users to the correct usage.

