### PR TITLE
Modify forward pass of rnn for GRU

### DIFF
--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -242,7 +242,10 @@ class StdRNNDecoder(RNNDecoderBase):
         emb = self.embeddings(input)
 
         # Run the forward pass of the RNN.
-        rnn_output, hidden = self.rnn(emb, state.hidden)
+        if isinstance(self.rnn, nn.GRU):
+            rnn_output, hidden = self.rnn(emb, state.hidden[0])
+        else:
+            rnn_output, hidden = self.rnn(emb, state.hidden)
         # Result Check
         input_len, input_batch, _ = input.size()
         output_len, output_batch, _ = rnn_output.size()


### PR DESCRIPTION
Current version of OpenNMT crashes when using `GRU` in `StdRNNDecoder`. This is happening because the input to forward are different for [GRU](https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/rnn.py#L399-L405) as compared to [LSTM](https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/rnn.py#L322-L330). This PR accounts for the variation in input.

Command to run `GRU` version:

```
python train.py \
-data data/demo \
-save_model demo-model \
-enc_layers 1 \
-dec_layers 1 \
-epochs 4 \
-rnn_type GRU \
-input_feed 0 \
-batch_size 4
```