### PR TITLE
FIX: Print default values of CLI args

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -9,7 +9,8 @@ import onmt
 import onmt.IO
 import opts
 
-parser = argparse.ArgumentParser(description='preprocess.py',
+parser = argparse.ArgumentParser(
+    description='preprocess.py',
     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 opts.add_md_help_argument(parser)
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import argparse
@@ -8,7 +9,8 @@ import onmt
 import onmt.IO
 import opts
 
-parser = argparse.ArgumentParser(description='preprocess.py')
+parser = argparse.ArgumentParser(description='preprocess.py',
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 opts.add_md_help_argument(parser)
 
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -10,7 +10,7 @@ import onmt.IO
 import opts
 
 parser = argparse.ArgumentParser(description='preprocess.py',
-                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 opts.add_md_help_argument(parser)
 
 

--- a/train.py
+++ b/train.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import division
 
 import os
@@ -14,7 +16,8 @@ import onmt.modules
 from onmt.Utils import aeq, use_gpu
 import opts
 
-parser = argparse.ArgumentParser(description='train.py')
+parser = argparse.ArgumentParser(description='train.py',
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
 # opts.py
 opts.add_md_help_argument(parser)

--- a/train.py
+++ b/train.py
@@ -16,7 +16,8 @@ import onmt.modules
 from onmt.Utils import aeq, use_gpu
 import opts
 
-parser = argparse.ArgumentParser(description='train.py',
+parser = argparse.ArgumentParser(
+    description='train.py',
     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
 # opts.py

--- a/train.py
+++ b/train.py
@@ -17,7 +17,7 @@ from onmt.Utils import aeq, use_gpu
 import opts
 
 parser = argparse.ArgumentParser(description='train.py',
-                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
 # opts.py
 opts.add_md_help_argument(parser)

--- a/translate.py
+++ b/translate.py
@@ -17,7 +17,8 @@ try:
 except ImportError:
     from itertools import izip_longest as zip_longest
 
-parser = argparse.ArgumentParser(description='translate.py',
+parser = argparse.ArgumentParser(
+    description='translate.py',
     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 opts.add_md_help_argument(parser)
 opts.translate_opts(parser)

--- a/translate.py
+++ b/translate.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from __future__ import division
 from builtins import bytes
 import os
@@ -15,7 +17,8 @@ try:
 except ImportError:
     from itertools import izip_longest as zip_longest
 
-parser = argparse.ArgumentParser(description='translate.py')
+parser = argparse.ArgumentParser(description='translate.py',
+                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 opts.add_md_help_argument(parser)
 opts.translate_opts(parser)
 

--- a/translate.py
+++ b/translate.py
@@ -18,7 +18,7 @@ except ImportError:
     from itertools import izip_longest as zip_longest
 
 parser = argparse.ArgumentParser(description='translate.py',
-                                 formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 opts.add_md_help_argument(parser)
 opts.translate_opts(parser)
 


### PR DESCRIPTION
This is a small change related to CLI user experience.

## Summary:
  1. `-h` CLI option prints the default values assumed by the cli args
 2. `{preprocess, train, translate}.py` files are made executable.



### Before 
```
$python translate.py -h
 
....(truncated)... 

optional arguments:
  -h, --help            show this help message and exit
  -md                   print Markdown-formatted help text and exit.
  -model MODEL          Path to model .pt file
  -src SRC              Source sequence to decode (one line per sequence)
  -src_img_dir SRC_IMG_DIR
                        Source image directory
  -tgt TGT              True target sequence (optional)
  -output OUTPUT        Path to output the predictions (each line will be the
                        decoded sequence
  -beam_size BEAM_SIZE  Beam size
  -batch_size BATCH_SIZE
                        Batch size
  -max_sent_length MAX_SENT_LENGTH
                        Maximum sentence length.
  -replace_unk          Replace the generated UNK tokens with the source token
                        that had highest attention weight. If phrase_table is
                        provided, it will lookup the identified source token
                        and give the corresponding target token. If it is not
                        provided(or the identified source token does not exist
                        in the table) then it will copy the source token
  -verbose              Print scores and predictions for each sentence
  -attn_debug           Print best attn for each word
  -dump_beam DUMP_BEAM  File to dump beam information to.
  -n_best N_BEST        If verbose is set, will output the n_best decoded
                        sentences
  -gpu GPU              Device to run on
  -dynamic_dict         Create dynamic dictionaries
  -share_vocab          Share source and target vocabulary
```

### After:
```
$ ./translate.py -h

....(truncated)... 

optional arguments:
  -h, --help            show this help message and exit
  -md                   print Markdown-formatted help text and exit.
  -model MODEL          Path to model .pt file (default: None)
  -src SRC              Source sequence to decode (one line per sequence)
                        (default: None)
  -src_img_dir SRC_IMG_DIR
                        Source image directory (default: )
  -tgt TGT              True target sequence (optional) (default: None)
  -output OUTPUT        Path to output the predictions (each line will be the
                        decoded sequence (default: pred.txt)
  -beam_size BEAM_SIZE  Beam size (default: 5)
  -batch_size BATCH_SIZE
                        Batch size (default: 30)
  -max_sent_length MAX_SENT_LENGTH
                        Maximum sentence length. (default: 100)
  -replace_unk          Replace the generated UNK tokens with the source token
                        that had highest attention weight. If phrase_table is
                        provided, it will lookup the identified source token
                        and give the corresponding target token. If it is not
                        provided(or the identified source token does not exist
                        in the table) then it will copy the source token
                        (default: False)
  -verbose              Print scores and predictions for each sentence
                        (default: False)
  -attn_debug           Print best attn for each word (default: False)
  -dump_beam DUMP_BEAM  File to dump beam information to. (default: )
  -n_best N_BEST        If verbose is set, will output the n_best decoded
                        sentences (default: 1)
  -gpu GPU              Device to run on (default: -1)
  -dynamic_dict         Create dynamic dictionaries (default: False)
  -share_vocab          Share source and target vocabulary (default: False)
```