### PR TITLE
Fix the issue: OpenNMT/OpenNMT-py#345

### DIFF
--- a/train.py
+++ b/train.py
@@ -110,7 +110,7 @@ def make_valid_data_iter(valid_data, opt):
     return onmt.IO.OrderedIterator(
                 dataset=valid_data, batch_size=opt.batch_size,
                 device=opt.gpuid[0] if opt.gpuid else -1,
-                train=False, sort=True)
+                train=False, sort=True, sort_within_batch=False)
 
 
 def make_loss_compute(model, tgt_vocab, dataset, opt):


### PR DESCRIPTION
Fix the issue: OpenNMT/OpenNMT-py#345

In torchtext 0.2.0, they add:
```python
                if self.sort_within_batch:
                    # NOTE: `rnn.pack_padded_sequence` requires that a minibatch
                    # be sorted by decreasing order, which requires reversing
                    # relative to typical sort keys
                    if self.sort:
                        minibatch.reverse()
                    else:
                        minibatch.sort(key=self.sort_key, reverse=True)
```