### PR TITLE
Fix issue #368 by forcing torchtext 0.1.1

### DIFF
--- a/onmt/modules/SRU.py
+++ b/onmt/modules/SRU.py
@@ -569,7 +569,7 @@ class SRU(nn.Module):
         self.out_size = hidden_size*2 if bidirectional else hidden_size
 
         for i in range(num_layers):
-            l = SRUCell(
+            sru_cell = SRUCell(
                 n_in=self.n_in if i == 0 else self.out_size,
                 n_out=self.n_out,
                 dropout=dropout if i+1 != num_layers else 0,
@@ -578,7 +578,7 @@ class SRU(nn.Module):
                 use_tanh=use_tanh,
                 use_relu=use_relu,
             )
-            self.rnn_lst.append(l)
+            self.rnn_lst.append(sru_cell)
 
     def set_bias(self, bias_val=0):
         for l in self.rnn_lst:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 six
 tqdm
-torchtext
+torchtext==0.1.1
 future


### PR DESCRIPTION
Running the commands in the README.md fail with the following message: `ValueError: lengths array has to be sorted in decreasing order`.  Forcing `torchtext==0.1.1` resolves the issue.