### PR TITLE
Fix fully CNN model attention

### DIFF
--- a/onmt/modules/ConvMultiStepAttention.py
+++ b/onmt/modules/ConvMultiStepAttention.py
@@ -62,7 +62,9 @@ class ConvMultiStepAttention(nn.Module):
         if self.mask is not None:
             pre_attn.data.masked_fill_(self.mask, -float('inf'))
 
+        pre_attn = pre_attn.transpose(0, 2)
         attn = F.softmax(pre_attn)
+        attn = attn.transpose(0, 2).contiguous()
         context_output = torch.bmm(
             attn, torch.transpose(encoder_out_combine, 1, 2))
         context_output = torch.transpose(


### PR DESCRIPTION
The fully convolutional model has used attention in a wrong way.
The shape of `pre_attn` is `[bs, dec_seq, enc_seq]`
And according to https://github.com/pytorch/pytorch/issues/1020 the softmax is done over dimension 0, whereas it should be done over dimension 2.