### PR TITLE
Changed the value of the parameter value of the Adam optimizer beta2 in

### DIFF
--- a/onmt/Optim.py
+++ b/onmt/Optim.py
@@ -18,9 +18,18 @@ class Optim(object):
         else:
             raise RuntimeError("Invalid optim method: " + self.method)
 
+    # We use the default parameters for Adam that are suggested by the original paper
+    # https://arxiv.org/pdf/1412.6980.pdf
+    # These values are also used by other established implementations, e.g.
+    # https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
+    # https://keras.io/optimizers/          
+    # Recently there are slightly different values used in the paper "Attention is all you need"
+    # https://arxiv.org/pdf/1706.03762.pdf, particularly the value beta2=0.98 was used there
+    # however, beta2=0.999 is still arguably the more established value, so we use that here as well  
     def __init__(self, method, lr, max_grad_norm,
                  lr_decay=1, start_decay_at=None,
-                 beta1=0.9, beta2=0.98,
+                 beta1=0.9, beta2=0.999,
+#                beta1=0.9, beta2=0.98,
                  opt=None):
         self.last_ppl = None
         self.lr = lr

--- a/onmt/Optim.py
+++ b/onmt/Optim.py
@@ -18,18 +18,20 @@ class Optim(object):
         else:
             raise RuntimeError("Invalid optim method: " + self.method)
 
-    # We use the default parameters for Adam that are suggested by the original paper
-    # https://arxiv.org/pdf/1412.6980.pdf
-    # These values are also used by other established implementations, e.g.
-    # https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
-    # https://keras.io/optimizers/          
-    # Recently there are slightly different values used in the paper "Attention is all you need"
-    # https://arxiv.org/pdf/1706.03762.pdf, particularly the value beta2=0.98 was used there
-    # however, beta2=0.999 is still arguably the more established value, so we use that here as well  
+    # We use the default parameters for Adam that are suggested by
+    # the original paper https://arxiv.org/pdf/1412.6980.pdf
+    # These values are also used by other established implementations,
+    # e.g. https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
+    # https://keras.io/optimizers/
+    # Recently there are slightly different values used in the paper
+    # "Attention is all you need"
+    # https://arxiv.org/pdf/1706.03762.pdf, particularly the value beta2=0.98
+    # was used there however, beta2=0.999 is still arguably the more
+    # established value, so we use that here as well
     def __init__(self, method, lr, max_grad_norm,
                  lr_decay=1, start_decay_at=None,
                  beta1=0.9, beta2=0.999,
-#                beta1=0.9, beta2=0.98,
+                 #  beta1=0.9, beta2=0.98,
                  opt=None):
         self.last_ppl = None
         self.lr = lr

--- a/opts.py
+++ b/opts.py
@@ -195,6 +195,24 @@ def train_opts(parser):
                         help="Dropout probability; applied in LSTM stacks.")
     parser.add_argument('-truncated_decoder', type=int, default=0,
                         help="""Truncated bptt.""")
+    parser.add_argument('-beta1', type=float, default=0.9,
+                        help="""The beta1 parameter used by Adam.
+                        Almost without exception a value of 0.9 is used in
+                        the literature, seemingly giving good results,
+                        so we would discourage changing this value from
+                        the default without due consideration.""")
+    parser.add_argument('-beta2', type=float, default=0.999,
+                        help="""The beta2 parameter used by Adam.
+                        Typically a value of 0.999 is recommended, as this is
+                        the value suggested by the original paper describing
+                        Adam, and is also the value adopted in other frameworks
+                        such as Tensorflow and Kerras, i.e. see:
+                        https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
+                        https://keras.io/optimizers/ .
+                        Whereas recently the paper "Attention is All You Need"
+                        suggested a value of 0.98 for beta2, this parameter may
+                        not work well for normal models / default
+                        baselines.""")
     # learning rate
     parser.add_argument('-learning_rate', type=float, default=1.0,
                         help="""Starting learning rate.

--- a/opts.py
+++ b/opts.py
@@ -200,13 +200,13 @@ def train_opts(parser):
                         help="Dropout probability; applied in LSTM stacks.")
     parser.add_argument('-truncated_decoder', type=int, default=0,
                         help="""Truncated bptt.""")
-    parser.add_argument('-beta1', type=float, default=0.9,
+    parser.add_argument('-adam_beta1', type=float, default=0.9,
                         help="""The beta1 parameter used by Adam.
                         Almost without exception a value of 0.9 is used in
                         the literature, seemingly giving good results,
                         so we would discourage changing this value from
                         the default without due consideration.""")
-    parser.add_argument('-beta2', type=float, default=0.999,
+    parser.add_argument('-adam_beta2', type=float, default=0.999,
                         help="""The beta2 parameter used by Adam.
                         Typically a value of 0.999 is recommended, as this is
                         the value suggested by the original paper describing

--- a/train.py
+++ b/train.py
@@ -250,8 +250,8 @@ def build_optim(model, checkpoint):
             opt.optim, opt.learning_rate, opt.max_grad_norm,
             lr_decay=opt.learning_rate_decay,
             start_decay_at=opt.start_decay_at,
-            beta1=opt.beta1,
-            beta2=opt.beta2,
+            beta1=opt.adam_beta1,
+            beta2=opt.adam_beta2,
             adagrad_accum=opt.adagrad_accumulator_init,
             opt=opt
         )

--- a/train.py
+++ b/train.py
@@ -250,6 +250,8 @@ def build_optim(model, checkpoint):
             opt.optim, opt.learning_rate, opt.max_grad_norm,
             lr_decay=opt.learning_rate_decay,
             start_decay_at=opt.start_decay_at,
+            beta1=opt.beta1,
+            beta2=opt.beta2,
             opt=opt
         )
 


### PR DESCRIPTION
onmt/Optim.py.
Change it from the value 0.98
(earlier adopted from "Attention is all you need"
https://arxiv.org/pdf/1706.03762.pdf)
to the more widely established value of 0.999
which was sugggested in the original paper about Adam
https://arxiv.org/pdf/1412.6980.pdf.
The new value of 0.999 is still being used by default in the main nmt architectures
and frameworks, including tensorflow and kerras.
https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
https://keras.io/optimizers/

	modified:   onmt/Optim.py