### PR TITLE
Preprocess sharding work

### DIFF
--- a/onmt/Trainer.py
+++ b/onmt/Trainer.py
@@ -79,7 +79,7 @@ class Trainer(object):
             optim: the optimizer responsible for lr update.
             trunc_size: a batch is divided by several truncs of this size.
             shard_size: compute loss in shards of this size for efficiency.
-            data_type: type of the source input. Options are [text|img].
+            data_type: type of the source input: [text|img|audio].
         """
         # Basic attributes.
         self.model = model

--- a/onmt/io/IO.py
+++ b/onmt/io/IO.py
@@ -295,12 +295,12 @@ def build_dataset(fields, data_type, src_path, tgt_path, src_dir=None,
     return dataset
 
 
-def build_vocab(train, data_type, share_vocab,
+def build_vocab(train_datasets, data_type, share_vocab,
                 src_vocab_size, src_words_min_frequency,
                 tgt_vocab_size, tgt_words_min_frequency):
     """
     Args:
-        train: a train dataset.
+        train_datasets: a list of train dataset.
         data_type: "text", "img" or "audio"?
         share_vocab(bool): share source and target vocabulary?
         src_vocab_size(int): size of the source vocabulary.
@@ -310,18 +310,19 @@ def build_vocab(train, data_type, share_vocab,
         tgt_words_min_frequency(int): the minimum frequency needed to
                 include a target word in the vocabulary.
     """
-    fields = train.fields
+    # All datasets have same fields, get the first one is OK.
+    fields = train_datasets[0].fields
 
-    fields["tgt"].build_vocab(train, max_size=tgt_vocab_size,
+    fields["tgt"].build_vocab(*train_datasets, max_size=tgt_vocab_size,
                               min_freq=tgt_words_min_frequency)
-    for j in range(train.n_tgt_feats):
-        fields["tgt_feat_" + str(j)].build_vocab(train)
+    for j in range(train_datasets[0].n_tgt_feats):
+        fields["tgt_feat_" + str(j)].build_vocab(*train_datasets)
 
     if data_type == 'text':
-        fields["src"].build_vocab(train, max_size=src_vocab_size,
+        fields["src"].build_vocab(*train_datasets, max_size=src_vocab_size,
                                   min_freq=src_words_min_frequency)
-        for j in range(train.n_src_feats):
-            fields["src_feat_" + str(j)].build_vocab(train)
+        for j in range(train_datasets[0].n_src_feats):
+            fields["src_feat_" + str(j)].build_vocab(*train_datasets)
 
         # Merge the input and output vocabularies.
         if share_vocab:

--- a/onmt/io/IO.py
+++ b/onmt/io/IO.py
@@ -498,17 +498,19 @@ def _read_audio_file(path, src_dir, side, sample_rate, window_size,
 
 def _make_examples_numfeats_tpl(path, truncate, side):
     """
-    Process the text corpus into (examples iterator, num_feats) tuple.
+    Process the text corpus into (example_dict iterator, num_feats) tuple.
     """
     assert side in ['src', 'tgt']
 
     if path is None:
         return (None, 0)
 
-    examples_tpl = _read_text_file(path, truncate, side)
-    (_, num_feats), examples_tpl = _peek(examples_tpl)
+    # All examples have same number of features, so we peek first one
+    # to get the num_feats.
+    examples_nfeats_iter = _read_text_file(path, truncate, side)
+    (_, num_feats), examples_nfeats_iter = _peek(examples_nfeats_iter)
 
-    examples_iter = (ex for ex, nfeats in examples_tpl)
+    examples_iter = (ex for ex, nfeats in examples_nfeats_iter)
 
     return (examples_iter, num_feats)
 

--- a/onmt/io/IO.py
+++ b/onmt/io/IO.py
@@ -9,6 +9,8 @@ import torch
 import torchtext.data
 import torchtext.vocab
 
+from onmt.Utils import aeq
+
 
 PAD_WORD = '<blank>'
 UNK = 0
@@ -575,3 +577,25 @@ class ONMTDatasetBase(torchtext.data.Dataset):
                     scores[:, b, ti] += scores[:, b, offset + i]
                     scores[:, b, offset + i].fill_(1e-20)
         return scores
+
+    @staticmethod
+    def coalesce_datasets(datasets):
+        """Coalesce all dataset instances. """
+        final = datasets[0]
+        for d in datasets[1:]:
+            # `src_vocabs` is a list of `torchtext.vocab.Vocab`.
+            # Each sentence transforms into on Vocab.
+            # Coalesce them into one big list.
+            final.src_vocabs += d.src_vocabs
+
+            # All datasets have same number of features.
+            aeq(final.n_src_feats, d.n_src_feats)
+            aeq(final.n_tgt_feats, d.n_tgt_feats)
+
+            # `examples` is a list of `torchtext.data.Example`.
+            # Coalesce them into one big list.
+            final.examples += d.examples
+
+            # All datasets have same fields, no need to update.
+
+        return final

--- a/onmt/io/__init__.py
+++ b/onmt/io/__init__.py
@@ -4,7 +4,7 @@ from onmt.io.IO import PAD_WORD, BOS_WORD, EOS_WORD, UNK, \
                        load_fields_from_vocab, get_fields, \
                        save_fields_to_vocab, build_dataset, \
                        build_vocab, merge_vocabs, OrderedIterator
-from onmt.io.TextDataset import TextDataset
+from onmt.io.TextDataset import TextDataset, ShardedTextCorpusIterator
 from onmt.io.ImageDataset import ImageDataset
 from onmt.io.AudioDataset import AudioDataset
 
@@ -15,4 +15,5 @@ __all__ = [PAD_WORD, BOS_WORD, EOS_WORD, UNK,
            load_fields_from_vocab, get_fields,
            save_fields_to_vocab, build_dataset,
            build_vocab, merge_vocabs, OrderedIterator,
-           TextDataset, ImageDataset, AudioDataset]
+           TextDataset, ImageDataset, AudioDataset,
+           ShardedTextCorpusIterator]

--- a/onmt/io/__init__.py
+++ b/onmt/io/__init__.py
@@ -1,4 +1,4 @@
-from onmt.io.IO import PAD_WORD, BOS_WORD, EOS_WORD, UNK, \
+from onmt.io.IO import PAD_WORD, BOS_WORD, EOS_WORD, UNK, ONMTDatasetBase, \
                        collect_feature_vocabs, make_features, \
                        collect_features, extract_features, \
                        load_fields_from_vocab, get_fields, \
@@ -9,7 +9,7 @@ from onmt.io.ImageDataset import ImageDataset
 from onmt.io.AudioDataset import AudioDataset
 
 
-__all__ = [PAD_WORD, BOS_WORD, EOS_WORD, UNK,
+__all__ = [PAD_WORD, BOS_WORD, EOS_WORD, UNK, ONMTDatasetBase,
            collect_feature_vocabs, make_features,
            collect_features, extract_features,
            load_fields_from_vocab, get_fields,

--- a/opts.py
+++ b/opts.py
@@ -139,8 +139,9 @@ def preprocess_opts(parser):
     group.add_argument('-max_shard_size', type=int, default=0,
                        help="""For text corpus of large volume, it will
                        be divided into shards of this size to preprocess.
-                       If 0, the data will be handled as a whole.
-                       The unit is in bytes.""")
+                       If 0, the data will be handled as a whole. The unit
+                       is in bytes. Optimal value should be multiples of
+                       64 bytes.""")
 
     # Dictionary options, for text corpus
 

--- a/opts.py
+++ b/opts.py
@@ -136,6 +136,12 @@ def preprocess_opts(parser):
     group.add_argument('-save_data', required=True,
                        help="Output file for the prepared data")
 
+    group.add_argument('-max_shard_size', type=int, default=0,
+                       help="""For text corpus of large volume, it will
+                       be divided into shards of this size to preprocess.
+                       If 0, the data will be handled as a whole.
+                       The unit is in bytes.""")
+
     # Dictionary options, for text corpus
 
     group = parser.add_argument_group('Vocab')
@@ -350,6 +356,7 @@ def translate_opts(parser):
     group.add_argument('-output', default='pred.txt',
                        help="""Path to output the predictions (each line will
                        be the decoded sequence""")
+
     # Options most relevant to summarization.
     group.add_argument('-dynamic_dict', action='store_true',
                        help="Create dynamic dictionaries")

--- a/preprocess.py
+++ b/preprocess.py
@@ -103,7 +103,7 @@ def build_save_text_dataset_in_shards(src_corpus, tgt_corpus, fields,
             dataset.fields = []
             pt_file = "{:s}.{:s}.{:d}.pt".format(
                     opt.save_data, corpus_type, index)
-            torch.save(dataset, open(pt_file, 'wb'))
+            torch.save(dataset, pt_file)
 
     if index == 1:
         # Only one shard, strip the index in the filename.
@@ -149,7 +149,7 @@ def build_save_dataset(corpus_type, fields, opt, save=True):
         # We save fields in vocab.pt seperately, so make it empty.
         dataset.fields = []
         pt_file = "{:s}.{:s}.pt".format(opt.save_data, corpus_type)
-        torch.save(dataset, open(pt_file, 'wb'))
+        torch.save(dataset, pt_file)
 
     return [dataset]
 
@@ -168,8 +168,8 @@ def build_save_vocab(train_dataset, fields, opt, save=True):
 
     if save:
         # Can't save fields, so remove/reconstruct at training time.
-        torch.save(onmt.io.save_fields_to_vocab(fields),
-                   open(opt.save_data + '.vocab.pt', 'wb'))
+        vocab_file = opt.save_data + '.vocab.pt'
+        torch.save(onmt.io.save_fields_to_vocab(fields), vocab_file)
 
 
 def main():

--- a/preprocess.py
+++ b/preprocess.py
@@ -84,7 +84,7 @@ def main():
     train = build_dataset('train', fields, opt)
 
     print("Building vocabulary...")
-    onmt.io.build_vocab(train, opt.data_type, opt.share_vocab,
+    onmt.io.build_vocab([train], opt.data_type, opt.share_vocab,
                         opt.src_vocab_size,
                         opt.src_words_min_frequency,
                         opt.tgt_vocab_size,

--- a/preprocess.py
+++ b/preprocess.py
@@ -57,10 +57,11 @@ def build_save_text_dataset_in_shards(src_corpus, tgt_corpus, fields,
     The reason we do this is to avoid taking up too much memory due
     to sucking in a huge corpus file.
 
-    To tackle this, we only read in part of the corpus file of
-    size `max_shard_size`, and process it into dataset, then write
-    it to disk along the way. By doing this, we only focus on part
-    of the corpus at any moment, thus effectively reducing memory use.
+    To tackle this, we only read in part of the corpus file of size
+    `max_shard_size`(actually it is multiples of 64 bytes that equals
+    or is slightly larger than this size), and process it into dataset,
+    then write it to disk along the way. By doing this, we only focus on
+    part of the corpus at any moment, thus effectively reducing memory use.
     According to test, this method can reduce memory footprint by ~50%.
 
     Note! As we process along the shards, previous shards might still

--- a/preprocess.py
+++ b/preprocess.py
@@ -4,11 +4,25 @@
 import argparse
 import codecs
 import os
+import glob
+import sys
 
 import torch
 
 import onmt.io
 import opts
+
+
+def check_existing_pt_files(opt):
+    # We will use glob.glob() to find sharded {train|valid}.[0-9]*.pt
+    # when training, so check to avoid tampering with existing pt files
+    # or mixing them up.
+    for t in ['train', 'valid', 'vocab']:
+        pattern = opt.save_data + '.' + t + '*.pt'
+        if glob.glob(pattern):
+            sys.stderr.write("Please backup exisiting pt file: %s, "
+                             "to avoid tampering!\n" % pattern)
+            sys.exit(1)
 
 
 def parse_args():
@@ -21,6 +35,8 @@ def parse_args():
 
     opt = parser.parse_args()
     torch.manual_seed(opt.seed)
+
+    check_existing_pt_files(opt)
 
     return opt
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -104,6 +104,10 @@ def build_save_text_dataset_in_shards(src_corpus, tgt_corpus, fields,
                     opt.save_data, corpus_type, index)
             torch.save(dataset, open(pt_file, 'wb'))
 
+    if index == 1:
+        # Only one shard, strip the index in the filename.
+        os.rename(pt_file, opt.save_data + '.' + corpus_type + '.pt')
+
     return ret_list
 
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -46,7 +46,7 @@ def get_num_features(side, opt):
     return n_features
 
 
-def build_dataset(corpus_type, fields, opt):
+def build_save_dataset(corpus_type, fields, opt, save=True):
     assert corpus_type in ['train', 'valid']
 
     if corpus_type == 'train':
@@ -68,6 +68,12 @@ def build_dataset(corpus_type, fields, opt):
                 window_size=opt.window_size,
                 window_stride=opt.window_stride,
                 window=opt.window)
+
+    if save:
+        # We save fields in vocab.pt seperately, so make it empty.
+        dataset.fields = []
+        pt_file = "{:s}.{:s}.pt".format(opt.save_data, corpus_type)
+        torch.save(dataset, open(pt_file, 'wb'))
 
     return dataset
 
@@ -98,20 +104,14 @@ def main():
     n_tgt_features = get_num_features('tgt', opt)
     fields = onmt.io.get_fields(opt.data_type, n_src_features, n_tgt_features)
 
-    print("Building training data...")
-    train = build_dataset('train', fields, opt)
+    print("Building & saving training data...")
+    train = build_save_dataset('train', fields, opt)
 
     print("Building & saving vocabulary...")
     build_save_vocab([train], fields, opt)
 
-    print("Building validation data...")
-    valid = build_dataset('valid', fields, opt)
-
-    print("Saving train/valid...")
-    train.fields = []
-    valid.fields = []
-    torch.save(train, open(opt.save_data + '.train.pt', 'wb'))
-    torch.save(valid, open(opt.save_data + '.valid.pt', 'wb'))
+    print("Building & saving validation data...")
+    build_save_dataset('valid', fields, opt)
 
 
 if __name__ == "__main__":

--- a/test/pull_request_chk.sh
+++ b/test/pull_request_chk.sh
@@ -11,6 +11,7 @@ TEST_DIR="$PROJECT_ROOT/test"
 clean_up()
 {
     rm ${LOG_FILE}
+    rm -rf /tmp/*pt
     rm -rf /tmp/im2text
     rm -rf /tm/speech
 }
@@ -73,6 +74,7 @@ echo "Succeeded" | tee -a ${LOG_FILE}
 echo "[+] Doing preprocess test..."
 
 echo -n "  [+] Testing NMT preprocessing..."
+rm -rf /tmp/data*pt
 python preprocess.py -train_src ${DATA_DIR}/src-train.txt \
 		     -train_tgt ${DATA_DIR}/tgt-train.txt \
 		     -valid_src ${DATA_DIR}/src-val.txt \
@@ -84,6 +86,7 @@ python preprocess.py -train_src ${DATA_DIR}/src-train.txt \
 echo "Succeeded" | tee -a ${LOG_FILE}
 
 echo -n "  [+] Testing img2text preprocessing..."
+rm -rf /tmp/im2text/data*pt
 python preprocess.py -data_type img \
 		     -src_dir /tmp/im2text/images \
 		     -train_src /tmp/im2text/src-train.txt \
@@ -95,6 +98,7 @@ python preprocess.py -data_type img \
 echo "Succeeded" | tee -a ${LOG_FILE}
 
 echo -n "  [+] Testing speech2text preprocessing..."
+rm -rf /tmp/speech/data*pt
 python preprocess.py -data_type audio \
 		     -src_dir /tmp/speech/an4_dataset \
 		     -train_src /tmp/speech/src-train.txt \
@@ -147,6 +151,7 @@ echo "Succeeded" | tee -a ${LOG_FILE}
 echo -n "[+] Doing NMT {preprocess + train + translation} test..."
 head ${DATA_DIR}/src-val.txt > /tmp/src-val.txt
 head ${DATA_DIR}/tgt-val.txt > /tmp/tgt-val.txt
+rm -rf /tmp/q*pt
 python preprocess.py -train_src /tmp/src-val.txt \
 		     -train_tgt /tmp/tgt-val.txt \
 		     -valid_src /tmp/src-val.txt \
@@ -171,6 +176,7 @@ echo "Succeeded" | tee -a ${LOG_FILE}
 echo -n "[+] Doing im2text {preprocess + train} test..."
 head /tmp/im2text/src-val.txt > /tmp/im2text/src-val-head.txt
 head /tmp/im2text/tgt-val.txt > /tmp/im2text/tgt-val-head.txt
+rm -rf /tmp/im2text/q*pt
 python preprocess.py -data_type img \
 	             -src_dir /tmp/im2text/images \
 		     -train_src /tmp/im2text/src-val-head.txt \
@@ -188,6 +194,7 @@ echo "Succeeded" | tee -a ${LOG_FILE}
 echo -n "[+] Doing speech2text {preprocess + train} test..."
 head /tmp/speech/src-val.txt > /tmp/speech/src-val-head.txt
 head /tmp/speech/tgt-val.txt > /tmp/speech/tgt-val-head.txt
+rm -rf /tmp/speech/q*pt
 python preprocess.py -data_type audio \
 	             -src_dir /tmp/speech/an4_dataset \
 		     -train_src /tmp/speech/src-val-head.txt \

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -37,11 +37,7 @@ class TestData(unittest.TestCase):
 
         train = preprocess.build_dataset('train', fields, opt)
 
-        onmt.io.build_vocab([train], opt.data_type, opt.share_vocab,
-                            opt.src_vocab_size,
-                            opt.src_words_min_frequency,
-                            opt.tgt_vocab_size,
-                            opt.tgt_words_min_frequency)
+        preprocess.build_save_vocab([train], fields, opt, save=False)
 
         preprocess.build_dataset('valid', fields, opt)
 

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -35,10 +35,10 @@ class TestData(unittest.TestCase):
     def dataset_build(self, opt):
         fields = onmt.io.get_fields("text", 0, 0)
 
-        train = preprocess.build_save_dataset('train', fields,
-                                              opt, save=False)
+        trains = preprocess.build_save_dataset('train', fields,
+                                               opt, save=False)
 
-        preprocess.build_save_vocab([train], fields, opt, save=False)
+        preprocess.build_save_vocab(trains, fields, opt, save=False)
 
         preprocess.build_save_dataset('valid', fields, opt, save=False)
 

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -35,11 +35,12 @@ class TestData(unittest.TestCase):
     def dataset_build(self, opt):
         fields = onmt.io.get_fields("text", 0, 0)
 
-        train = preprocess.build_dataset('train', fields, opt)
+        train = preprocess.build_save_dataset('train', fields,
+                                              opt, save=False)
 
         preprocess.build_save_vocab([train], fields, opt, save=False)
 
-        preprocess.build_dataset('valid', fields, opt)
+        preprocess.build_save_dataset('valid', fields, opt, save=False)
 
     def test_merge_vocab(self):
         va = torchtext.vocab.Vocab(Counter('abbccc'))

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -37,7 +37,7 @@ class TestData(unittest.TestCase):
 
         train = preprocess.build_dataset('train', fields, opt)
 
-        onmt.io.build_vocab(train, opt.data_type, opt.share_vocab,
+        onmt.io.build_vocab([train], opt.data_type, opt.share_vocab,
                             opt.src_vocab_size,
                             opt.src_words_min_frequency,
                             opt.tgt_vocab_size,

--- a/train.py
+++ b/train.py
@@ -261,10 +261,14 @@ def load_fields(train_dataset, valid_dataset, checkpoint):
     return fields
 
 
-def collect_features(fields):
-    # TODO: account for target features.
-    src_features = onmt.io.collect_features(fields)
-    return src_features
+def collect_report_features(fields):
+    src_features = onmt.io.collect_features(fields, side='src')
+    tgt_features = onmt.io.collect_features(fields, side='tgt')
+
+    for j, feat in enumerate(src_features):
+        print(' * src feature %d size = %d' % (j, len(fields[feat].vocab)))
+    for j, feat in enumerate(tgt_features):
+        print(' * tgt feature %d size = %d' % (j, len(fields[feat].vocab)))
 
 
 def build_model(model_opt, opt, fields, checkpoint):
@@ -324,10 +328,8 @@ def main():
     # Load fields generated from preprocess phase.
     fields = load_fields(train_dataset, valid_dataset, checkpoint)
 
-    # Collect features.
-    src_features = collect_features(fields)
-    for j, feat in enumerate(src_features):
-        print(' * src feature %d size = %d' % (j, len(fields[feat].vocab)))
+    # Report src/tgt features.
+    collect_report_features(fields)
 
     # Build model.
     model = build_model(model_opt, opt, fields, checkpoint)

--- a/train.py
+++ b/train.py
@@ -2,9 +2,10 @@
 
 from __future__ import division
 
+import argparse
+import glob
 import os
 import sys
-import argparse
 import random
 
 import torch
@@ -16,7 +17,7 @@ import onmt.io
 import onmt.Models
 import onmt.ModelConstructor
 import onmt.modules
-from onmt.Utils import aeq, use_gpu
+from onmt.Utils import use_gpu
 import opts
 
 
@@ -96,7 +97,7 @@ def report_func(epoch, batch, num_batches,
     return report_stats
 
 
-def make_train_data_iter(train_data, opt):
+def make_train_data_iter(train_dataset, opt):
     """
     This returns user-defined train data iterator for the trainer
     to iterate over during each train epoch. We implement simple
@@ -104,12 +105,12 @@ def make_train_data_iter(train_data, opt):
     like curriculum learning is ok too.
     """
     return onmt.io.OrderedIterator(
-                dataset=train_data, batch_size=opt.batch_size,
+                dataset=train_dataset, batch_size=opt.batch_size,
                 device=opt.gpuid[0] if opt.gpuid else -1,
                 repeat=False)
 
 
-def make_valid_data_iter(valid_data, opt):
+def make_valid_data_iter(valid_dataset, opt):
     """
     This returns user-defined validate data iterator for the trainer
     to iterate over during each validate epoch. We implement simple
@@ -117,7 +118,7 @@ def make_valid_data_iter(valid_data, opt):
     is ok too.
     """
     return onmt.io.OrderedIterator(
-                dataset=valid_data, batch_size=opt.batch_size,
+                dataset=valid_dataset, batch_size=opt.batch_size,
                 device=opt.gpuid[0] if opt.gpuid else -1,
                 train=False, sort=True)
 
@@ -141,21 +142,24 @@ def make_loss_compute(model, tgt_vocab, dataset, opt):
     return compute
 
 
-def train_model(model, train, valid, fields, optim, model_opt):
-    train_iter = make_train_data_iter(train, opt)
-    valid_iter = make_valid_data_iter(valid, opt)
+def train_model(model, train_dataset, valid_dataset,
+                fields, optim, model_opt):
+
+    train_iter = make_train_data_iter(train_dataset, opt)
+    valid_iter = make_valid_data_iter(valid_dataset, opt)
 
     train_loss = make_loss_compute(model, fields["tgt"].vocab,
-                                   train, opt)
+                                   train_dataset, opt)
     valid_loss = make_loss_compute(model, fields["tgt"].vocab,
-                                   valid, opt)
+                                   valid_dataset, opt)
 
     trunc_size = opt.truncated_decoder  # Badly named...
     shard_size = opt.max_generator_batches
+    data_type = train_dataset.data_type
 
     trainer = onmt.Trainer(model, train_iter, valid_iter,
                            train_loss, valid_loss, optim,
-                           trunc_size, shard_size, train.data_type)
+                           trunc_size, shard_size, data_type)
 
     for epoch in range(opt.start_epoch, opt.epochs + 1):
         print('')
@@ -204,14 +208,43 @@ def tally_parameters(model):
     print('decoder: ', dec)
 
 
-def load_fields(train, valid, checkpoint):
-    data_type = train.data_type
+def load_dataset(data_type):
+    assert data_type in ["train", "valid"]
+
+    print("Loading %s data from '%s'" % (data_type, opt.data))
+
+    pts = glob.glob(opt.data + '.' + data_type + '.[0-9]*.pt')
+    if pts:
+        # Multiple onmt.io.*Dataset's, coalesce all.
+        # torch.load loads them imemediately, which might eat up
+        # too much memory. A lazy load would be better, but later
+        # when we create data iterator, it still requires these
+        # data to be loaded. So it seams we don't have a good way
+        # to avoid this now.
+        datasets = []
+        for pt in pts:
+            datasets.append(torch.load(pt))
+        dataset = onmt.io.ONMTDatasetBase.coalesce_datasets(datasets)
+    else:
+        # Only one onmt.io.*Dataset, simple!
+        dataset = torch.load(opt.data + '.' + data_type + '.pt')
+
+    print(' * number of %s sentences: %d' % (data_type, len(dataset)))
+
+    return dataset
+
+
+def load_fields(train_dataset, valid_dataset, checkpoint):
+    data_type = train_dataset.data_type
+
     fields = onmt.io.load_fields_from_vocab(
                 torch.load(opt.data + '.vocab.pt'), data_type)
     fields = dict([(k, f) for (k, f) in fields.items()
-                  if k in train.examples[0].__dict__])
-    train.fields = fields
-    valid.fields = fields
+                  if k in train_dataset.examples[0].__dict__])
+
+    # We save fields in vocab.pt, so assign them back to dataset here.
+    train_dataset.fields = fields
+    valid_dataset.fields = fields
 
     if opt.train_from:
         print('Loading vocab from checkpoint at %s.' % opt.train_from)
@@ -228,12 +261,9 @@ def load_fields(train, valid, checkpoint):
     return fields
 
 
-def collect_features(train, fields):
+def collect_features(fields):
     # TODO: account for target features.
-    # Also, why does fields need to have the structure it does?
     src_features = onmt.io.collect_features(fields)
-    aeq(len(src_features), train.n_src_feats)
-
     return src_features
 
 
@@ -275,10 +305,8 @@ def build_optim(model, checkpoint):
 def main():
 
     # Load train and validate data.
-    print("Loading train and validate data from '%s'" % opt.data)
-    train = torch.load(opt.data + '.train.pt')
-    valid = torch.load(opt.data + '.valid.pt')
-    print(' * number of training sentences: %d' % len(train))
+    train_dataset = load_dataset("train")
+    valid_dataset = load_dataset("valid")
     print(' * maximum batch size: %d' % opt.batch_size)
 
     # Load checkpoint if we resume from a previous training.
@@ -287,17 +315,17 @@ def main():
         checkpoint = torch.load(opt.train_from,
                                 map_location=lambda storage, loc: storage)
         model_opt = checkpoint['opt']
-        # I don't like reassigning attributes of opt: it's not clear
+        # I don't like reassigning attributes of opt: it's not clear.
         opt.start_epoch = checkpoint['epoch'] + 1
     else:
         checkpoint = None
         model_opt = opt
 
     # Load fields generated from preprocess phase.
-    fields = load_fields(train, valid, checkpoint)
+    fields = load_fields(train_dataset, valid_dataset, checkpoint)
 
     # Collect features.
-    src_features = collect_features(train, fields)
+    src_features = collect_features(fields)
     for j, feat in enumerate(src_features):
         print(' * src feature %d size = %d' % (j, len(fields[feat].vocab)))
 
@@ -310,7 +338,7 @@ def main():
     optim = build_optim(model, checkpoint)
 
     # Do training.
-    train_model(model, train, valid, fields, optim, model_opt)
+    train_model(model, train_dataset, valid_dataset, fields, optim, model_opt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**The problem**
This PR addresses the `preprocess.py` memory hogging problem. Currently it loads in the whole corpus file to create `onmt.IO.ONMTDataset`(which is subclass of `torchtext.data.Dataset`). So if the corpus file is too large, it will eat up large amount of memory(Using python generator trick for lazy load doesn't help, if `filter_pred` is not None, the dataset creation code will iterate over whole file to filter, which loads in the whole corpus too). 

**The method and implementation**
This PR adds a `max_shard_size` option, which indicates the size of a shard, and  the corpus file will be divided into shards of this size, and create `onmt.IO.ONMTDataset` separately and each dataset is written to disc as it is created to avoid this memory hogging problem. And at training time, all these datasets are loaded and coalesced into one dataset, which is transparent to users.

The implementation is almost in the `preprocess.py`, in which a `ShardedCorpusIterator` is in charge of all gory sharding works. It implements an `__iter__` interface,  and `ONMTDataset` is modified to accept `src/tgt` examples iterator(before it accepts `src/tgt` corpus file path). And every time a  `ONMTDataset` is created, the iterator is only able to iterate as many examples as the total size of these examples equals to or approximates `max_shard_size`.

If the `max_shard_size` is 0 or is larger than the size of the corpus file, then the corpus will be preprocessed  as a whole dataset.  If  the size of the corpus file is bigger than **10MB** and user doesn't specify a shard size, a warning is issued.

**User interface impact**
**None**.  The default value of `max_shard_size` is 0, which maintains the current behavior - preprocess the whole corpus file monolithically.  So users get the exact same old behavior and feel no difference if they leave the `max_shard_size` to default value. Even when user specifies a `max_shard_size`, and that's all he/she needs to do, all the rest are transparent to user. 

**Performance impact**
To test this, I manually create two corpuses.  The WMT'16 corpuses have the `train_src` of size 1.8M and `train_tgt` of size 2.1M only.  So I concatenate the corpus 10 times to create bigger corpus, which has
size of 18M and 21M, respectively.

And different `max_shard_size` is tested, result is as the figure below shows:
![figure_1-2](https://user-images.githubusercontent.com/649042/32893545-8aec1444-ca9f-11e7-8180-8e1720c6e53a.png)


As the result shows, the total time of old and new code are almost the same. 

Note the two **no sharding** lines,  which have a conspicuous peak of memory of ~900MB to ~1000MB, which is when the dataset is created.

While  note the other **shard size** lines, there are more smooth memory footprints, with the peak of memory of ~588MB,  which cuts down by ~40%, compared to the old code.

Also, a demo training is run to compare against the old code to make sure the train behavior doesn't degenerate.

**Problem to resolve**
In this PR, in the `train.py`,  I load all datasets into memory and coalesce them into one dataset, then pass to `torchtext.data.Iterator`,  this might also has memory hogging problem. But if we want to avoid this, the only way is to postpone the creation of `torchtext.data.Iterator`(because it needs a loaded dataset as its argument). However, current `torchtext` code is not designed with multiple datasets in mind, not does it take memory problem into account,  so this turned out to quite awkward to do - we need to override its `__iter__()` implementation.  So I just leave it as it is before, and I figure we should
work with `torchtext` people on this problem. 
