### PR TITLE
New tool: embeddings_to_torch

### DIFF
--- a/tools/embeddings_to_torch.py
+++ b/tools/embeddings_to_torch.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from __future__ import print_function
+from __future__ import division
+import six
+import sys
+import numpy as np
+import argparse
+import torch
+import onmt
+
+parser = argparse.ArgumentParser(description='embeddings_to_torch.py')
+
+##
+## **Preprocess Options**
+##
+
+parser.add_argument('-emb_file', required=True, help="Embeddings from this file")
+parser.add_argument('-output_file', required=True,
+                    help="Output file for the prepared data")
+parser.add_argument('-dict_file', required=True,
+                    help="Dictionary file")
+parser.add_argument('-verbose', action="store_true", default=False)
+opt = parser.parse_args()
+
+
+def get_vocabs(dict_file):
+    vocabs = torch.load(dict_file)
+    enc_vocab, dec_vocab = [vocab[1] for vocab in vocabs]
+    
+    print("From: %s" % dict_file)
+    print("\t* source vocab: %d words" % len(enc_vocab))
+    print("\t* target vocab: %d words" % len(dec_vocab))
+
+    return enc_vocab, dec_vocab
+
+def get_embeddings(file):
+    embs = dict()
+    for l in open(file, 'rb').readlines():
+        l_split = l.decode('utf8').strip().split()
+        if len(l_split) == 2:
+            continue
+        embs[l_split[0]] = [float(em) for em in l_split[1:]]
+    print("Got {} embeddings from {}".format(len(embs), file))
+
+    return embs
+
+def match_embeddings(vocab, emb):
+    dim = len(six.next(six.itervalues(emb)))
+    filtered_embeddings = np.zeros((len(vocab), dim))
+    count = {"match": 0, "miss": 0}
+    for w, w_id in vocab.stoi.items():
+        if w in emb:
+            filtered_embeddings[w_id] = emb[w]
+            count['match'] += 1
+        else:
+            if opt.verbose:
+                print(u"not found:\t{}".format(w), file=sys.stderr)
+            count['miss'] += 1
+
+    return torch.Tensor(filtered_embeddings), count
+
+def main():
+    enc_vocab, dec_vocab = get_vocabs(opt.dict_file)
+    embeddings = get_embeddings(opt.emb_file)
+
+    filtered_enc_embeddings, enc_count = match_embeddings(enc_vocab, embeddings)
+    filtered_dec_embeddings, dec_count = match_embeddings(dec_vocab, embeddings)
+
+    print("\nMatching: ")
+    match_percent  = [ _['match']/(_['match']+_['miss'])*100 for _ in [enc_count, dec_count]]
+    print("\t* enc: %d match, %d missing, (%.2f%%)" % (enc_count['match'], 
+                                                       enc_count['miss'],
+                                                       match_percent[0]))
+    print("\t* dec: %d match, %d missing, (%.2f%%)" % (dec_count['match'], 
+                                                       dec_count['miss'],
+                                                       match_percent[1]))
+
+    print("\nFiltered embeddings:")
+    print("\t* enc: ", filtered_enc_embeddings.size())
+    print("\t* dec: ", filtered_dec_embeddings.size())
+
+    enc_output_file = "%s.enc.pt" % opt.output_file
+    dec_output_file = "%s.dec.pt" % opt.output_file
+    print("\nSaving embedding as:\n\t* enc: %s\n\t* dec: %s" % (enc_output_file, dec_output_file))
+    torch.save(filtered_enc_embeddings, enc_output_file)
+    torch.save(filtered_dec_embeddings, dec_output_file)
+    print("\nDone.")
+
+if __name__ == "__main__":
+    main()

--- a/tools/embeddings_to_torch.py
+++ b/tools/embeddings_to_torch.py
@@ -7,15 +7,10 @@ import sys
 import numpy as np
 import argparse
 import torch
-import onmt
 
 parser = argparse.ArgumentParser(description='embeddings_to_torch.py')
-
-##
-## **Preprocess Options**
-##
-
-parser.add_argument('-emb_file', required=True, help="Embeddings from this file")
+parser.add_argument('-emb_file', required=True,
+                    help="Embeddings from this file")
 parser.add_argument('-output_file', required=True,
                     help="Output file for the prepared data")
 parser.add_argument('-dict_file', required=True,
@@ -27,12 +22,13 @@ opt = parser.parse_args()
 def get_vocabs(dict_file):
     vocabs = torch.load(dict_file)
     enc_vocab, dec_vocab = [vocab[1] for vocab in vocabs]
-    
+
     print("From: %s" % dict_file)
     print("\t* source vocab: %d words" % len(enc_vocab))
     print("\t* target vocab: %d words" % len(dec_vocab))
 
     return enc_vocab, dec_vocab
+
 
 def get_embeddings(file):
     embs = dict()
@@ -44,6 +40,7 @@ def get_embeddings(file):
     print("Got {} embeddings from {}".format(len(embs), file))
 
     return embs
+
 
 def match_embeddings(vocab, emb):
     dim = len(six.next(six.itervalues(emb)))
@@ -60,19 +57,23 @@ def match_embeddings(vocab, emb):
 
     return torch.Tensor(filtered_embeddings), count
 
+
 def main():
     enc_vocab, dec_vocab = get_vocabs(opt.dict_file)
     embeddings = get_embeddings(opt.emb_file)
 
-    filtered_enc_embeddings, enc_count = match_embeddings(enc_vocab, embeddings)
-    filtered_dec_embeddings, dec_count = match_embeddings(dec_vocab, embeddings)
+    filtered_enc_embeddings, enc_count = match_embeddings(enc_vocab,
+                                                          embeddings)
+    filtered_dec_embeddings, dec_count = match_embeddings(dec_vocab,
+                                                          embeddings)
 
     print("\nMatching: ")
-    match_percent  = [ _['match']/(_['match']+_['miss'])*100 for _ in [enc_count, dec_count]]
-    print("\t* enc: %d match, %d missing, (%.2f%%)" % (enc_count['match'], 
+    match_percent = [_['match'] / (_['match'] + _['miss']) * 100
+                     for _ in [enc_count, dec_count]]
+    print("\t* enc: %d match, %d missing, (%.2f%%)" % (enc_count['match'],
                                                        enc_count['miss'],
                                                        match_percent[0]))
-    print("\t* dec: %d match, %d missing, (%.2f%%)" % (dec_count['match'], 
+    print("\t* dec: %d match, %d missing, (%.2f%%)" % (dec_count['match'],
                                                        dec_count['miss'],
                                                        match_percent[1]))
 
@@ -80,12 +81,14 @@ def main():
     print("\t* enc: ", filtered_enc_embeddings.size())
     print("\t* dec: ", filtered_dec_embeddings.size())
 
-    enc_output_file = "%s.enc.pt" % opt.output_file
-    dec_output_file = "%s.dec.pt" % opt.output_file
-    print("\nSaving embedding as:\n\t* enc: %s\n\t* dec: %s" % (enc_output_file, dec_output_file))
+    enc_output_file = opt.output_file + ".enc.pt"
+    dec_output_file = opt.output_file + ".dec.pt"
+    print("\nSaving embedding as:\n\t* enc: %s\n\t* dec: %s"
+          % (enc_output_file, dec_output_file))
     torch.save(filtered_enc_embeddings, enc_output_file)
     torch.save(filtered_dec_embeddings, dec_output_file)
     print("\nDone.")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Easily plug GloVe pre-trained embedding into OpenNMT-py.    
*the script is a slightly modified version of [ylhsieh's one](https://github.com/ylhsieh/OpenNMT-py/blob/efec98f4ad3b3b16d2a23ce61aa9a9ba37182052/embeddings_to_torch.py).*

**Usage:**
```
usage: embeddings_to_torch.py [-h] -emb_file EMB_FILE -output_file OUTPUT_FILE
                              -dict_file DICT_FILE [-verbose]
```
* `emb_file`: GloVe like embedding file i.e. CSV `[word] [dim1] ... [dim_d]`
* `output_file`: a filename to save the output as [PyTorch serialized tensors](http://pytorch.org/docs/master/torch.html?highlight=save#torch.save)
* `dict_file`: dict output from OpenNMT-py preprocessing

# Example
**0) set some variables:**
```
export data="../onmt_merge/sorted_tokens/"
export root="./glove_experiment"
export glove_dir="./glove"
```
**1) get GloVe files:**
```
mkdir "$glove_dir"
wget http://nlp.stanford.edu/data/glove.6B.zip
unzip glove.6B.zip -d "$glove_dir"
```

**2) prepare data:**
```
  mkdir -p $root
  python preprocess.py \
      -train_src $data/train.src.txt \
      -train_tgt $data/train.tgt.txt \
      -valid_src $data/valid.src.txt \
      -valid_tgt $data/valid.tgt.txt \
      -save_data $root/data
```
**3) prepare embeddings:**
```
  ./tools/embeddings_to_torch.py -emb_file "$glove_dir/glove.6B.100d.txt" \
                                 -dict_file "$root/data.vocab.pt" \
                                 -output_file "$root/embeddings" 
```
**4) train using pre-trained embeddings:**
```
  python train.py -save_model $root/model \
        -batch_size 64 \
        -layers 2 \ 
        -rnn_size 200 \
        -word_vec_size 100 \
        -pre_word_vecs_enc "$root/embeddings.enc.pt" \
        -pre_word_vecs_dec "$root/embeddings.dec.pt" \
        -data $root/data
```


