### PR TITLE
Fix batch translation

### DIFF
--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -145,7 +145,7 @@ class RNNDecoderBase(nn.Module):
             )
             self._copy = True
 
-    def forward(self, input, context, state):
+    def forward(self, input, context, state, context_lengths=None):
         """
         Forward through the decoder.
         Args:
@@ -155,6 +155,7 @@ class RNNDecoderBase(nn.Module):
                         RNN of size (src_len x batch x hidden_size).
             state (FloatTensor): hidden state from the encoder RNN for
                                  initializing the decoder.
+            context_lengths (LongTensor): the source context lengths.
         Returns:
             outputs (FloatTensor): a Tensor sequence of output from the decoder
                                    of shape (len x batch x hidden_size).
@@ -171,8 +172,8 @@ class RNNDecoderBase(nn.Module):
         # END Args Check
 
         # Run the forward pass of the RNN.
-        hidden, outputs, attns, coverage = \
-            self._run_forward_pass(input, context, state)
+        hidden, outputs, attns, coverage = self._run_forward_pass(
+            input, context, state, context_lengths=context_lengths)
 
         # Update the state with the result.
         final_output = outputs[-1]
@@ -211,7 +212,7 @@ class StdRNNDecoder(RNNDecoderBase):
     Stardard RNN decoder, with Attention.
     Currently no 'coverage_attn' and 'copy_attn' support.
     """
-    def _run_forward_pass(self, input, context, state):
+    def _run_forward_pass(self, input, context, state, context_lengths=None):
         """
         Private helper for running the specific RNN forward pass.
         Must be overriden by all subclasses.
@@ -222,6 +223,7 @@ class StdRNNDecoder(RNNDecoderBase):
                         RNN of size (src_len x batch x hidden_size).
             state (FloatTensor): hidden state from the encoder RNN for
                                  initializing the decoder.
+            context_lengths (LongTensor): the source context lengths.
         Returns:
             hidden (Variable): final hidden state from the decoder.
             outputs ([FloatTensor]): an array of output of every time
@@ -256,7 +258,8 @@ class StdRNNDecoder(RNNDecoderBase):
         # Calculate the attention.
         attn_outputs, attn_scores = self.attn(
             rnn_output.transpose(0, 1).contiguous(),  # (output_len, batch, d)
-            context.transpose(0, 1)                   # (contxt_len, batch, d)
+            context.transpose(0, 1),                  # (contxt_len, batch, d)
+            context_lengths=context_lengths
         )
         attns["std"] = attn_scores
 
@@ -304,7 +307,7 @@ class InputFeedRNNDecoder(RNNDecoderBase):
     """
     Stardard RNN decoder, with Input Feed and Attention.
     """
-    def _run_forward_pass(self, input, context, state):
+    def _run_forward_pass(self, input, context, state, context_lengths=None):
         """
         See StdRNNDecoder._run_forward_pass() for description
         of arguments and return values.
@@ -338,8 +341,10 @@ class InputFeedRNNDecoder(RNNDecoderBase):
             emb_t = torch.cat([emb_t, output], 1)
 
             rnn_output, hidden = self.rnn(emb_t, hidden)
-            attn_output, attn = self.attn(rnn_output,
-                                          context.transpose(0, 1))
+            attn_output, attn = self.attn(
+                rnn_output,
+                context.transpose(0, 1),
+                context_lengths=context_lengths)
             if self.context_gate is not None:
                 output = self.context_gate(
                     emb_t, rnn_output, attn_output

--- a/onmt/Translator.py
+++ b/onmt/Translator.py
@@ -105,6 +105,7 @@ class Translator(object):
 
         # Repeat everything beam_size times.
         context = rvar(context.data)
+        context_lengths = src_lengths.repeat(beam_size)
         src = rvar(src.data)
         srcMap = rvar(batch.src_map.data)
         decStates.repeat_beam_size_times(beam_size)
@@ -145,8 +146,8 @@ class Translator(object):
             inp = inp.unsqueeze(2)
 
             # Run one step.
-            decOut, decStates, attn = \
-                self.model.decoder(inp, context, decStates)
+            decOut, decStates, attn = self.model.decoder(
+                inp, context, decStates, context_lengths=context_lengths)
             decOut = decOut.squeeze(0)
             # decOut: beam x rnn_size
 

--- a/onmt/Utils.py
+++ b/onmt/Utils.py
@@ -1,3 +1,6 @@
+import torch
+
+
 def aeq(*args):
     """
     Assert all arguments have the same value
@@ -6,6 +9,18 @@ def aeq(*args):
     first = next(arguments)
     assert all(arg == first for arg in arguments), \
         "Not all arguments have the same value: " + str(args)
+
+
+def sequence_mask(lengths, max_len=None):
+    """
+    Creates a boolean mask from sequence lengths.
+    """
+    batch_size = lengths.numel()
+    max_len = max_len or lengths.max()
+    return (torch.arange(0, max_len)
+            .type_as(lengths)
+            .repeat(batch_size, 1)
+            .lt(lengths.unsqueeze(1)))
 
 
 def use_gpu(opt):

--- a/test/test_attention.py
+++ b/test/test_attention.py
@@ -1,3 +1,33 @@
 """
 Here come the tests for attention types and their compatibility
 """
+
+import unittest
+import torch
+import onmt
+
+from torch.autograd import Variable
+
+
+class TestAttention(unittest.TestCase):
+
+    def test_masked_global_attention(self):
+        source_lengths = torch.IntTensor([7, 3, 5, 2])
+        illegal_weights_mask = torch.ByteTensor([
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 1, 1, 1, 1],
+            [0, 0, 0, 0, 0, 1, 1],
+            [0, 0, 1, 1, 1, 1, 1]])
+
+        batch_size = source_lengths.size(0)
+        dim = 20
+
+        context = Variable(torch.randn(batch_size, source_lengths.max(), dim))
+        hidden = Variable(torch.randn(batch_size, dim))
+
+        attn = onmt.modules.GlobalAttention(dim)
+
+        _, alignments = attn(hidden, context, context_lengths=source_lengths)
+        illegal_weights = alignments.masked_select(illegal_weights_mask)
+
+        self.assertEqual(0.0, illegal_weights.data.sum())

--- a/translate.py
+++ b/translate.py
@@ -24,10 +24,6 @@ opts.add_md_help_argument(parser)
 opts.translate_opts(parser)
 
 opt = parser.parse_args()
-if opt.batch_size != 1:
-    print("WARNING: -batch_size isn't supported currently, "
-          "we set it to 1 for now!")
-    opt.batch_size = 1
 
 
 def report_score(name, score_total, words_total):


### PR DESCRIPTION
These changes correctly mask illegal attention weights during translation. It could easily be extended for training when source batches with variable lengths are required but it is not applied for now.

Fixes #272.
Fixes #318.