### PR TITLE
Activate Globalscorer through options

### DIFF
--- a/onmt/Translator.py
+++ b/onmt/Translator.py
@@ -30,6 +30,10 @@ class Translator(object):
         self.model.eval()
         self.model.generator.eval()
 
+        # Length + Coverage Penalty
+        self.alpha = opt.alpha
+        self.beta = opt.beta
+
         # for debugging
         self.beam_accum = None
 
@@ -108,8 +112,7 @@ class Translator(object):
         src = rvar(src.data)
         srcMap = rvar(batch.src_map.data)
         decStates.repeat_beam_size_times(beam_size)
-        scorer = None
-        # scorer=onmt.GNMTGlobalScorer(0.3, 0.4)
+        scorer = onmt.GNMTGlobalScorer(self.alpha, self.beta)
         beam = [onmt.Beam(beam_size, n_best=self.opt.n_best,
                           cuda=self.opt.cuda,
                           vocab=self.fields["tgt"].vocab,

--- a/opts.py
+++ b/opts.py
@@ -267,6 +267,13 @@ def translate_opts(parser):
                         help="Create dynamic dictionaries")
     parser.add_argument('-share_vocab', action='store_true',
                         help="Share source and target vocabulary")
+    # Alpha and Beta values for Google Length + Coverage penalty
+    # Described here: https://arxiv.org/pdf/1609.08144.pdf, Section 7
+    parser.add_argument('-alpha', type=float, default=0.,
+                        help="""Google NMT length penalty parameter
+                        (higher = longer generation)""")
+    parser.add_argument('-beta', type=float, default=-0.,
+                        help="""Coverage penalty parameter""")
 
 
 def add_md_help_argument(parser):


### PR DESCRIPTION
We have had the GlobalScorer for a while (code is in Beam.py) that activates the Wu et al. length and coverage penalty. So far we had to manually activate it. I added two options in opts.py that we can use now. 

With this PR, the default behavior remains unchanged. 