### PR TITLE
Fix running error when there are features

### DIFF
--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -121,8 +121,8 @@ def make_features(batch, side):
     else:
         data = batch.__dict__[side]
     feat_start = side + "_feat_"
-    features = sorted(batch.__dict__[k]
-                      for k in batch.__dict__ if feat_start in k)
+    keys = sorted([k for k in batch.__dict__ if feat_start in k])
+    features = [batch.__dict__[k] for k in keys]
     levels = [data] + features
     return torch.cat([level.unsqueeze(2) for level in levels], 2)
 


### PR DESCRIPTION
When there are features (separated by |), there's RuntimeError: bool value of Variable objects containing non-empty torch.ByteTensor is ambiguous. The reason is that we cannot sort a list of torch variables (and that's not what we intended to do).