### PR TITLE
Dataset separation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - pip install -r requirements.txt
   # dependencies for im2text
   - pip install Pillow
-  - conda install torchvision
+  - conda install torchvision==0.1.8
   # dependencies for speech2text
   - sudo apt-get install -y sox libsox-dev libsox-fmt-all
   - pip install librosa git+https://github.com/pytorch/audio

--- a/onmt/IO.py
+++ b/onmt/IO.py
@@ -53,9 +53,11 @@ def collect_features(fields, side="src"):
 
 def extract_features(tokens):
     """
-    tokens: A list of tokens, where each token consists of a word,
+    Args:
+        tokens: A list of tokens, where each token consists of a word,
             optionally followed by u"￨"-delimited features.
-    returns: A sequence of words, A sequence of features, and
+    Returns:
+        A sequence of words, a sequence of features, and num of features.
     """
     if not tokens:
         return [], [], -1
@@ -68,111 +70,6 @@ def extract_features(tokens):
     words = words_and_features[0]
     features = words_and_features[1:]
     return words, features, token_size - 1
-
-
-def read_corpus_file(path, truncate, side):
-    """
-    path: location of a src or tgt file
-    truncate: maximum sequence length (0 for unlimited)
-    yields: (word, features, nfeat) triples for each line
-    """
-    with codecs.open(path, "r", "utf-8") as corpus_file:
-        for i, line in enumerate(corpus_file):
-            line = line.strip().split()
-            if truncate:
-                line = line[:truncate]
-            words, feats, n_feats = extract_features(line)
-            example_dict = {side: words, "indices": i}
-            if feats:
-                prefix = side + "_feat_"
-                example_dict.update((prefix + str(j), f)
-                                    for j, f in enumerate(feats))
-            yield example_dict, n_feats
-
-
-def read_img_file(path, src_dir, side, truncate=None):
-    """
-    path: location of a src file containing image paths
-    src_dir: location of source images
-    side: 'src' or 'tgt'
-    truncate: maximum img size ((0,0) or None for unlimited)
-    yields: a dictionary containing image data, path and index for each line
-    """
-    with codecs.open(path, "r", "utf-8") as corpus_file:
-        index = 0
-        for line in corpus_file:
-            img_path = os.path.join(src_dir, line.strip())
-            if not os.path.exists(img_path):
-                img_path = line
-            assert os.path.exists(img_path), \
-                'img path %s not found' % (line.strip())
-            img = transforms.ToTensor()(Image.open(img_path))
-            if truncate and truncate != (0, 0):
-                if not (img.size(1) <= truncate[0]
-                        and img.size(2) <= truncate[1]):
-                    continue
-            example_dict = {side: img,
-                            side+'_path': line.strip(),
-                            'indices': index}
-            index += 1
-            yield example_dict
-
-
-def read_audio_file(path, src_dir, side, sample_rate, window_size,
-                    window_stride, window, normalize_audio, truncate=None):
-    """
-    path: location of a src file containing audio paths
-    src_dir: location of source audio files
-    side: 'src' or 'tgt'
-    sample_rate: sample_rate
-    window_size: window size for spectrogram in seconds
-    window_stride: window stride for spectrogram in seconds
-    window: window type for spectrogram generation
-    normalize_audio: subtract spectrogram by mean and divide by std or not
-    truncate: maximum audio length (0 or None for unlimited)
-
-    returns: image for each line
-    """
-    with codecs.open(path, "r", "utf-8") as corpus_file:
-        index = 0
-        for line in corpus_file:
-            audio_path = os.path.join(src_dir, line.strip())
-            if not os.path.exists(audio_path):
-                audio_path = line
-            assert os.path.exists(audio_path), \
-                'audio path %s not found' % (line.strip())
-            sound, sample_rate = torchaudio.load(audio_path)
-            if truncate and truncate > 0:
-                if sound.size(0) > truncate:
-                    continue
-            assert sample_rate == sample_rate, \
-                'Sample rate of %s != -sample_rate (%d vs %d)' \
-                % (audio_path, sample_rate, sample_rate)
-            sound = sound.numpy()
-            if len(sound.shape) > 1:
-                if sound.shape[1] == 1:
-                    sound = sound.squeeze()
-                else:
-                    sound = sound.mean(axis=1)  # average multiple channels
-            n_fft = int(sample_rate * window_size)
-            win_length = n_fft
-            hop_length = int(sample_rate * window_stride)
-            # STFT
-            D = librosa.stft(sound, n_fft=n_fft, hop_length=hop_length,
-                             win_length=win_length, window=window)
-            spect, _ = librosa.magphase(D)
-            spect = np.log1p(spect)
-            spect = torch.FloatTensor(spect)
-            if normalize_audio:
-                mean = spect.mean()
-                std = spect.std()
-                spect.add_(-mean)
-                spect.div_(std)
-            example_dict = {side: spect,
-                            side + '_path': line.strip(),
-                            'indices': index}
-            index += 1
-            yield example_dict
 
 
 def merge_vocabs(vocabs, vocab_size=None):
@@ -207,10 +104,12 @@ def make_features(batch, side, data_type='text'):
         data = batch.__dict__[side][0]
     else:
         data = batch.__dict__[side]
+
     feat_start = side + "_feat_"
     keys = sorted([k for k in batch.__dict__ if feat_start in k])
     features = [batch.__dict__[k] for k in keys]
     levels = [data] + features
+
     if data_type == 'text':
         return torch.cat([level.unsqueeze(2) for level in levels], 2)
     else:
@@ -324,12 +223,47 @@ def get_fields(data_type, n_src_features, n_tgt_features):
     return fields
 
 
+def build_dataset(fields, data_type, src_path, tgt_path, src_dir=None,
+                  src_seq_length=0, tgt_seq_length=0,
+                  src_seq_length_trunc=0, tgt_seq_length_trunc=0,
+                  dynamic_dict=True, sample_rate=0,
+                  window_size=0, window_stride=0, window=None,
+                  normalize_audio=True, use_filter_pred=True):
+
+    if data_type == 'text':
+        dataset = TextDataset(fields, src_path, tgt_path,
+                              src_seq_length=src_seq_length,
+                              tgt_seq_length=tgt_seq_length,
+                              src_seq_length_trunc=src_seq_length_trunc,
+                              tgt_seq_length_trunc=tgt_seq_length_trunc,
+                              dynamic_dict=dynamic_dict,
+                              use_filter_pred=use_filter_pred)
+    elif data_type == 'img':
+        dataset = ImageDataset(fields, src_path, src_dir, tgt_path,
+                               tgt_seq_length=tgt_seq_length,
+                               tgt_seq_length_trunc=tgt_seq_length_trunc,
+                               use_filter_pred=use_filter_pred)
+
+    elif data_type == 'audio':
+        dataset = AudioDataset(fields, src_path, src_dir, tgt_path,
+                               tgt_seq_length=tgt_seq_length,
+                               tgt_seq_length_trunc=tgt_seq_length_trunc,
+                               sample_rate=sample_rate,
+                               window_size=window_size,
+                               window_stride=window_stride,
+                               window=window,
+                               normalize_audio=normalize_audio,
+                               use_filter_pred=use_filter_pred)
+
+    return dataset
+
+
 def build_vocab(train, data_type, share_vocab,
                 src_vocab_size, src_words_min_frequency,
                 tgt_vocab_size, tgt_words_min_frequency):
     """
     Args:
-        train: an ONMTDataset.
+        train: a train dataset.
         data_type: "text", "img" or "audio"?
         share_vocab(bool): share source and target vocabulary?
         src_vocab_size(int): size of the source vocabulary.
@@ -362,18 +296,23 @@ def build_vocab(train, data_type, share_vocab,
             fields["tgt"].vocab = merged_vocab
 
 
-def join_dicts(*args):
+def _join_dicts(*args):
     """
-    args: dictionaries with disjoint keys
-    returns: a single dictionary that has the union of these keys
+    Args:
+        dictionaries with disjoint keys.
+    Returns:
+        a single dictionary that has the union of these keys.
     """
     return dict(chain(*[d.items() for d in args]))
 
 
-def peek(seq):
+def _peek(seq):
     """
-    sequence: an iterator
-    returns: the first thing returned by calling next() on the iterator
+    Args:
+        seq: an iterator.
+
+    Returns:
+        the first thing returned by calling next() on the iterator
         and an iterator created by re-chaining that value to the beginning
         of the iterator.
     """
@@ -391,6 +330,119 @@ def _construct_example_fromlist(data, fields):
     return ex
 
 
+def _read_text_file(path, truncate, side):
+    """
+    Args:
+        path: location of a src or tgt file.
+        truncate: maximum sequence length (0 for unlimited).
+
+    Yields:
+        (word, features, nfeat) triples for each line.
+    """
+    with codecs.open(path, "r", "utf-8") as corpus_file:
+        for i, line in enumerate(corpus_file):
+            line = line.strip().split()
+            if truncate:
+                line = line[:truncate]
+            words, feats, n_feats = extract_features(line)
+            example_dict = {side: words, "indices": i}
+            if feats:
+                prefix = side + "_feat_"
+                example_dict.update((prefix + str(j), f)
+                                    for j, f in enumerate(feats))
+            yield example_dict, n_feats
+
+
+def _read_img_file(path, src_dir, side, truncate=None):
+    """
+    Args:
+        path: location of a src file containing image paths
+        src_dir: location of source images
+        side: 'src' or 'tgt'
+        truncate: maximum img size ((0,0) or None for unlimited)
+
+    Yields:
+        a dictionary containing image data, path and index for each line.
+    """
+    with codecs.open(path, "r", "utf-8") as corpus_file:
+        index = 0
+        for line in corpus_file:
+            img_path = os.path.join(src_dir, line.strip())
+            if not os.path.exists(img_path):
+                img_path = line
+            assert os.path.exists(img_path), \
+                'img path %s not found' % (line.strip())
+            img = transforms.ToTensor()(Image.open(img_path))
+            if truncate and truncate != (0, 0):
+                if not (img.size(1) <= truncate[0]
+                        and img.size(2) <= truncate[1]):
+                    continue
+            example_dict = {side: img,
+                            side+'_path': line.strip(),
+                            'indices': index}
+            index += 1
+            yield example_dict
+
+
+def _read_audio_file(path, src_dir, side, sample_rate, window_size,
+                     window_stride, window, normalize_audio, truncate=None):
+    """
+    Args:
+        path: location of a src file containing audio paths.
+        src_dir: location of source audio files.
+        side: 'src' or 'tgt'.
+        sample_rate: sample_rate.
+        window_size: window size for spectrogram in seconds.
+        window_stride: window stride for spectrogram in seconds.
+        window: window type for spectrogram generation.
+        normalize_audio: subtract spectrogram by mean and divide by std or not
+        truncate: maximum audio length (0 or None for unlimited).
+
+    Yields:
+        image for each line.
+    """
+    with codecs.open(path, "r", "utf-8") as corpus_file:
+        index = 0
+        for line in corpus_file:
+            audio_path = os.path.join(src_dir, line.strip())
+            if not os.path.exists(audio_path):
+                audio_path = line
+            assert os.path.exists(audio_path), \
+                'audio path %s not found' % (line.strip())
+            sound, sample_rate = torchaudio.load(audio_path)
+            if truncate and truncate > 0:
+                if sound.size(0) > truncate:
+                    continue
+            assert sample_rate == sample_rate, \
+                'Sample rate of %s != -sample_rate (%d vs %d)' \
+                % (audio_path, sample_rate, sample_rate)
+            sound = sound.numpy()
+            if len(sound.shape) > 1:
+                if sound.shape[1] == 1:
+                    sound = sound.squeeze()
+                else:
+                    sound = sound.mean(axis=1)  # average multiple channels
+            n_fft = int(sample_rate * window_size)
+            win_length = n_fft
+            hop_length = int(sample_rate * window_stride)
+            # STFT
+            D = librosa.stft(sound, n_fft=n_fft, hop_length=hop_length,
+                             win_length=win_length, window=window)
+            spect, _ = librosa.magphase(D)
+            spect = np.log1p(spect)
+            spect = torch.FloatTensor(spect)
+            if normalize_audio:
+                mean = spect.mean()
+                std = spect.std()
+                spect.add_(-mean)
+                spect.div_(std)
+            example_dict = {side: spect,
+                            side + '_path': line.strip(),
+                            'indices': index}
+            index += 1
+            yield example_dict
+
+
 class OrderedIterator(torchtext.data.Iterator):
     def create_batches(self):
         if self.train:
@@ -405,161 +457,24 @@ class OrderedIterator(torchtext.data.Iterator):
                 self.batches.append(sorted(b, key=self.sort_key))
 
 
-class ONMTDataset(torchtext.data.Dataset):
+class ONMTDatasetBase(torchtext.data.Dataset):
     """
-    Defines a dataset for machine translation.
-    An ONMTDataset is a collection that supports iteration over its
-    examples. The parent class supports indexing as well, but future
-    developments here may make that difficult (lazy iteration over
-    examples because of large datasets, for example).
-    """
+    A dataset basically supports iteration over all the examples
+    it contains. We currently have 3 datasets inheriting this base
+    for 3 types of corpus respectively: "text", "img", "audio".
 
-    def sort_key(self, ex):
-        "Sort in reverse size order"
-        if self.data_type == 'text':
-            return -len(ex.src)
-        elif self.data_type == 'img':
-            return (-ex.src.size(2), -ex.src.size(1))
-        elif self.data_type == 'audio':
-            return -ex.src.size(1)
+    Internally it initializes an `torchtext.data.Dataset` object with
+    the following attributes:
 
-    def __init__(self, data_type, src_path, tgt_path, fields,
-                 src_seq_length=0, tgt_seq_length=0,
-                 src_seq_length_trunc=0, tgt_seq_length_trunc=0,
-                 use_filter_pred=True, dynamic_dict=True,
-                 src_dir=None, sample_rate=0, window_size=0,
-                 window_stride=0, window=None,
-                 normalize_audio=True, **kwargs):
-        """
-        Create a translation dataset given paths and fields.
-
-        src_path: location of source-side data
-        tgt_path: location of target-side data or None. If should be the
-            same length as the source-side data if it exists, but
-            at present this is not checked.
-        fields: a dictionary. keys are things like 'src', 'tgt', 'src_map',
-            and 'alignment'
-        src_dir: source directory for storing images or audio.
-
-        Initializes an ONMTDataset object with the following attributes:
-        self.examples (might be a generator, might be a list, hard to say):
-            A sequence of torchtext Example objects.
-        self.fields (dict):
-            A dictionary associating str keys with Field objects. Does not
+     `examples`: a sequence of `torchtext.data.Example` objects.
+     `fields`: a dictionary associating str keys with Field objects. Does not
             necessarily have the same keys as the input fields.
-
-        A dataset basically supports iteration over all the examples it
-        contains.
-        """
-
-        self.data_type = data_type
-
-        if self.data_type == "text":
-            # self.src_vocabs: mutated in dynamic_dict, used in
-            # collapse_copy_scores and in Translator.py
-            self.src_vocabs = []
-            src_truncate = src_seq_length_trunc
-
-            src_examples = read_corpus_file(src_path, src_truncate, "src")
-            (_, src_feats), src_examples = peek(src_examples)
-            src_examples = (ex for ex, nfeats in src_examples)
-            self.n_src_feats = src_feats
-        elif self.data_type == "img":
-            assert (src_dir is not None) and os.path.exists(src_dir),\
-                   'src_dir must be a valid directory if data_type is img'
-            global Image, transforms
-            from PIL import Image
-            from torchvision import transforms
-
-            src_examples = read_img_file(src_path, src_dir, "src")
-            self.n_src_feats = 0
-        elif self.data_type == "audio":
-            assert (src_dir is not None) and os.path.exists(src_dir),\
-                   """src_dir must be a valid directory
-                   if data_type is audio"""
-            global torchaudio, librosa, np
-            import torchaudio
-            import librosa
-            import numpy as np
-
-            self.sample_rate = sample_rate
-            self.window_size = window_size
-            self.window_stride = window_stride
-            self.window = window
-            self.normalize_audio = normalize_audio
-            src_examples = read_audio_file(src_path, src_dir, "src",
-                                           sample_rate, window_size,
-                                           window_stride, window,
-                                           normalize_audio)
-            self.n_src_feats = 0
-
-        # if tgt_path exists, then we need to do the same thing as we did
-        # for the source data
-        if tgt_path is not None:
-            tgt_truncate = tgt_seq_length_trunc
-            tgt_examples = read_corpus_file(tgt_path, tgt_truncate, "tgt")
-            (_, tgt_feats), tgt_examples = peek(tgt_examples)
-            tgt_examples = (ex for ex, nfeats in tgt_examples)
-            self.n_tgt_feats = tgt_feats
-        else:
-            self.n_tgt_feats = 0
-            tgt_examples = None
-
-        # examples: one for each src line or (src, tgt) line pair.
-        # Each element is a dictionary whose keys represent at minimum
-        # the src tokens and their indices and potentially also the
-        # src and tgt features and alignment information.
-        if tgt_examples is not None:
-            examples = (join_dicts(src, tgt)
-                        for src, tgt in zip(src_examples, tgt_examples))
-        else:
-            examples = src_examples
-
-        if self.data_type == "text":
-            if dynamic_dict:
-                examples = self.dynamic_dict(examples)
-
-        # Peek at the first to see which fields are used.
-        ex, examples = peek(examples)
-        keys = ex.keys()
-
-        fields = [(k, fields[k]) if k in fields else (k, None)
-                  for k in keys]
-        example_values = ([ex[k] for k in keys] for ex in examples)
-        out_examples = (_construct_example_fromlist(ex_values, fields)
-                        for ex_values in example_values)
-
-        def filter_pred(example):
-            if data_type == 'text':
-                return 0 < len(example.src) <= src_seq_length \
-                   and 0 < len(example.tgt) <= tgt_seq_length
-            else:
-                if tgt_examples is not None:
-                    return 0 < len(example.tgt) <= tgt_seq_length
-                else:
-                    return True
-
-        super(ONMTDataset, self).__init__(
-            out_examples,
-            fields,
-            filter_pred if use_filter_pred else lambda x: True
+    """
+    def __init__(self, *args, **kwargs):
+        examples, fields, filter_pred = self._process_corpus(*args, **kwargs)
+        super(ONMTDatasetBase, self).__init__(
+            examples, fields, filter_pred
         )
-
-    def dynamic_dict(self, examples):
-        for example in examples:
-            src = example["src"]
-            src_vocab = torchtext.vocab.Vocab(Counter(src))
-            self.src_vocabs.append(src_vocab)
-            # mapping source tokens to indices in the dynamic dict
-            src_map = torch.LongTensor([src_vocab.stoi[w] for w in src])
-            example["src_map"] = src_map
-
-            if "tgt" in example:
-                tgt = example["tgt"]
-                mask = torch.LongTensor(
-                        [0] + [src_vocab.stoi[w] for w in tgt] + [0])
-                example["alignment"] = mask
-            yield example
 
     def __getstate__(self):
         return self.__dict__
@@ -569,7 +484,7 @@ class ONMTDataset(torchtext.data.Dataset):
 
     def __reduce_ex__(self, proto):
         "This is a hack. Something is broken with torch pickle."
-        return super(ONMTDataset, self).__reduce_ex__()
+        return super(ONMTDatasetBase, self).__reduce_ex__()
 
     def collapse_copy_scores(self, scores, batch, tgt_vocab):
         """
@@ -588,3 +503,276 @@ class ONMTDataset(torchtext.data.Dataset):
                     scores[:, b, ti] += scores[:, b, offset + i]
                     scores[:, b, offset + i].fill_(1e-20)
         return scores
+
+
+class TextDataset(ONMTDatasetBase):
+    """ Dataset for data_type=='text' """
+
+    def sort_key(self, ex):
+        "Sort using the size of source example."
+        return -len(ex.src)
+
+    def _process_corpus(self, fields, src_path, tgt_path,
+                        src_seq_length=0, tgt_seq_length=0,
+                        src_seq_length_trunc=0, tgt_seq_length_trunc=0,
+                        dynamic_dict=True, use_filter_pred=True):
+        """
+        Build Example objects, Field objects, and filter_pred function
+        from text corpus.
+
+        Args:
+            fields: a dictionary of Field objects. Keys are like 'src',
+                    'tgt', 'src_map', and 'alignment'.
+            src_path: location of source-side data.
+            tgt_path: location of target-side data or None. If should be the
+                      same length as the source-side data if it exists.
+            src_seq_length: maximum source sequence length.
+            tgt_seq_length: maximum target sequence length.
+            src_seq_length_trunc: truncated source sequence length.
+            tgt_seq_length_trunc: truncated target sequence length.
+            dynamic_dict: create dynamic dictionaries?
+            use_filter_pred: use a custom filter predicate to filter examples?
+
+        Returns:
+            constructed tuple of Examples objects, Field objects, filter_pred.
+        """
+        self.data_type = 'text'
+
+        # self.src_vocabs: mutated in dynamic_dict, used in
+        # collapse_copy_scores and in Translator.py
+        self.src_vocabs = []
+
+        src_examples = _read_text_file(src_path, src_seq_length_trunc, "src")
+        (_, src_feats), src_examples = _peek(src_examples)
+        src_examples = (ex for ex, nfeats in src_examples)
+        self.n_src_feats = src_feats
+
+        # If tgt_path exists, then we need to do the same thing as we did
+        # for the source data
+        if tgt_path is not None:
+            tgt_examples = _read_text_file(tgt_path, tgt_seq_length_trunc,
+                                           "tgt")
+            (_, tgt_feats), tgt_examples = _peek(tgt_examples)
+            tgt_examples = (ex for ex, nfeats in tgt_examples)
+            self.n_tgt_feats = tgt_feats
+        else:
+            tgt_examples = None
+            self.n_tgt_feats = 0
+
+        # examples: one for each src line or (src, tgt) line pair.
+        # Each element is a dictionary whose keys represent at minimum
+        # the src tokens and their indices and potentially also the
+        # src and tgt features and alignment information.
+        if tgt_examples is not None:
+            examples = (_join_dicts(src, tgt)
+                        for src, tgt in zip(src_examples, tgt_examples))
+        else:
+            examples = src_examples
+
+        if dynamic_dict:
+            examples = self._dynamic_dict(examples)
+
+        # Peek at the first to see which fields are used.
+        ex, examples = _peek(examples)
+        keys = ex.keys()
+
+        out_fields = [(k, fields[k]) if k in fields else (k, None)
+                      for k in keys]
+        example_values = ([ex[k] for k in keys] for ex in examples)
+        out_examples = (_construct_example_fromlist(ex_values, out_fields)
+                        for ex_values in example_values)
+
+        def filter_pred(example):
+            return 0 < len(example.src) <= src_seq_length \
+               and 0 < len(example.tgt) <= tgt_seq_length
+
+        filter_pred = filter_pred if use_filter_pred else lambda x: True
+
+        return out_examples, out_fields, filter_pred
+
+    def _dynamic_dict(self, examples):
+        for example in examples:
+            src = example["src"]
+            src_vocab = torchtext.vocab.Vocab(Counter(src))
+            self.src_vocabs.append(src_vocab)
+            # Mapping source tokens to indices in the dynamic dict.
+            src_map = torch.LongTensor([src_vocab.stoi[w] for w in src])
+            example["src_map"] = src_map
+
+            if "tgt" in example:
+                tgt = example["tgt"]
+                mask = torch.LongTensor(
+                        [0] + [src_vocab.stoi[w] for w in tgt] + [0])
+                example["alignment"] = mask
+            yield example
+
+
+class ImageDataset(ONMTDatasetBase):
+    """ Dataset for data_type=='img' """
+
+    def sort_key(self, ex):
+        "Sort using the size of the image."
+        return (-ex.src.size(2), -ex.src.size(1))
+
+    def _process_corpus(self, fields, src_path, src_dir, tgt_path,
+                        tgt_seq_length=0, tgt_seq_length_trunc=0,
+                        use_filter_pred=True):
+        """
+        Build Example objects, Field objects, and filter_pred function
+        from image corpus.
+
+        Args:
+            fields: a dictionary of Field objects. Keys are like 'src',
+                    'tgt', 'src_map', and 'alignment'.
+            src_path: location of a src file containing image paths
+            src_dir: location of source images
+            tgt_path: location of target-side data or None.
+            tgt_seq_length: maximum target sequence length.
+            tgt_seq_length_trunc: truncated target sequence length.
+            use_filter_pred: use a custom filter predicate to filter examples?
+
+        Returns:
+            constructed tuple of Examples objects, Field objects, filter_pred.
+        """
+        assert (src_dir is not None) and os.path.exists(src_dir),\
+            'src_dir must be a valid directory if data_type is img'
+
+        self.data_type = 'img'
+
+        global Image, transforms
+        from PIL import Image
+        from torchvision import transforms
+
+        src_examples = _read_img_file(src_path, src_dir, "src")
+        self.n_src_feats = 0
+
+        if tgt_path is not None:
+            tgt_examples = _read_text_file(tgt_path, tgt_seq_length_trunc,
+                                           "tgt")
+            (_, tgt_feats), tgt_examples = _peek(tgt_examples)
+            tgt_examples = (ex for ex, nfeats in tgt_examples)
+            self.n_tgt_feats = tgt_feats
+        else:
+            tgt_examples = None
+            self.n_tgt_feats = 0
+
+        if tgt_examples is not None:
+            examples = (_join_dicts(src, tgt)
+                        for src, tgt in zip(src_examples, tgt_examples))
+        else:
+            examples = src_examples
+
+        # Peek at the first to see which fields are used.
+        ex, examples = _peek(examples)
+        keys = ex.keys()
+
+        out_fields = [(k, fields[k]) if k in fields else (k, None)
+                      for k in keys]
+        example_values = ([ex[k] for k in keys] for ex in examples)
+        out_examples = (_construct_example_fromlist(ex_values, out_fields)
+                        for ex_values in example_values)
+
+        def filter_pred(example):
+            if tgt_examples is not None:
+                return 0 < len(example.tgt) <= tgt_seq_length
+            else:
+                return True
+
+        filter_pred = filter_pred if use_filter_pred else lambda x: True
+
+        return out_examples, out_fields, filter_pred
+
+
+class AudioDataset(ONMTDatasetBase):
+    """ Dataset for data_type=='audio' """
+
+    def sort_key(self, ex):
+        "Sort using the size of the audio corpus."
+        return -ex.src.size(1)
+
+    def _process_corpus(self, fields, src_path, src_dir, tgt_path,
+                        tgt_seq_length=0, tgt_seq_length_trunc=0,
+                        sample_rate=0, window_size=0,
+                        window_stride=0, window=None, normalize_audio=True,
+                        use_filter_pred=True):
+        """
+        Build Example objects, Field objects, and filter_pred function
+        from audio corpus.
+
+        Args:
+            fields: a dictionary of Field objects. Keys are like 'src',
+                    'tgt', 'src_map', and 'alignment'.
+            src_path: location of a src file containing audio paths.
+            src_dir: location of source audio file.
+            tgt_path: location of target-side data or None.
+            tgt_seq_length: maximum target sequence length.
+            tgt_seq_length_trunc: truncated target sequence length.
+            sample_rate: sample rate.
+            window_size: window size for spectrogram in seconds.
+            window_stride: window stride for spectrogram in seconds.
+            window: indow type for spectrogram generation.
+            normalize_audio: subtract spectrogram by mean and divide
+                             by std or not.
+            use_filter_pred: use a custom filter predicate to filter
+                             examples?
+
+        Returns:
+            constructed tuple of Examples objects, Field objects, filter_pred.
+        """
+        assert (src_dir is not None) and os.path.exists(src_dir),\
+            "src_dir must be a valid directory if data_type is audio"
+
+        self.data_type = 'audio'
+
+        global torchaudio, librosa, np
+        import torchaudio
+        import librosa
+        import numpy as np
+
+        self.sample_rate = sample_rate
+        self.window_size = window_size
+        self.window_stride = window_stride
+        self.window = window
+        self.normalize_audio = normalize_audio
+
+        src_examples = _read_audio_file(src_path, src_dir, "src",
+                                        sample_rate, window_size,
+                                        window_stride, window,
+                                        normalize_audio)
+        self.n_src_feats = 0
+
+        if tgt_path is not None:
+            tgt_examples = _read_text_file(tgt_path, tgt_seq_length_trunc,
+                                           "tgt")
+            (_, tgt_feats), tgt_examples = _peek(tgt_examples)
+            tgt_examples = (ex for ex, nfeats in tgt_examples)
+            self.n_tgt_feats = tgt_feats
+        else:
+            self.n_tgt_feats = 0
+            tgt_examples = None
+
+        if tgt_examples is not None:
+            examples = (_join_dicts(src, tgt)
+                        for src, tgt in zip(src_examples, tgt_examples))
+        else:
+            examples = src_examples
+
+        # Peek at the first to see which fields are used.
+        ex, examples = _peek(examples)
+        keys = ex.keys()
+
+        out_fields = [(k, fields[k]) if k in fields else (k, None)
+                      for k in keys]
+        example_values = ([ex[k] for k in keys] for ex in examples)
+        out_examples = (_construct_example_fromlist(ex_values, out_fields)
+                        for ex_values in example_values)
+
+        def filter_pred(example):
+            if tgt_examples is not None:
+                return 0 < len(example.tgt) <= tgt_seq_length
+            else:
+                return True
+
+        filter_pred = filter_pred if use_filter_pred else lambda x: True
+
+        return out_examples, out_fields, filter_pred

--- a/opts.py
+++ b/opts.py
@@ -100,7 +100,33 @@ def model_opts(parser):
 
 
 def preprocess_opts(parser):
-    # Dictionary Options
+    # Data options
+    parser.add_argument('-data_type', default="text",
+                        help="""Type of the source input.
+                        Options are [text|img].""")
+
+    parser.add_argument('-train_src', required=True,
+                        help="Path to the training source data")
+    parser.add_argument('-train_tgt', required=True,
+                        help="Path to the training target data")
+    parser.add_argument('-valid_src', required=True,
+                        help="Path to the validation source data")
+    parser.add_argument('-valid_tgt', required=True,
+                        help="Path to the validation target data")
+
+    parser.add_argument('-src_dir', default="",
+                        help="Source directory for image or audio files.")
+
+    parser.add_argument('-save_data', required=True,
+                        help="Output file for the prepared data")
+
+    # Dictionary options, for text corpus
+    parser.add_argument('-src_vocab',
+                        help="Path to an existing source vocabulary")
+    parser.add_argument('-tgt_vocab',
+                        help="Path to an existing target vocabulary")
+    parser.add_argument('-features_vocabs_prefix', type=str, default='',
+                        help="Path prefix to existing features vocabularies")
     parser.add_argument('-src_vocab_size', type=int, default=50000,
                         help="Size of the source vocabulary")
     parser.add_argument('-tgt_vocab_size', type=int, default=50000,
@@ -109,7 +135,12 @@ def preprocess_opts(parser):
     parser.add_argument('-src_words_min_frequency', type=int, default=0)
     parser.add_argument('-tgt_words_min_frequency', type=int, default=0)
 
-    # Truncation options
+    parser.add_argument('-dynamic_dict', action='store_true',
+                        help="Create dynamic dictionaries")
+    parser.add_argument('-share_vocab', action='store_true',
+                        help="Share source and target vocabulary")
+
+    # Truncation options, for text corpus
     parser.add_argument('-src_seq_length', type=int, default=50,
                         help="Maximum source sequence length")
     parser.add_argument('-src_seq_length_trunc', type=int, default=0,
@@ -118,17 +149,6 @@ def preprocess_opts(parser):
                         help="Maximum target sequence length to keep.")
     parser.add_argument('-tgt_seq_length_trunc', type=int, default=0,
                         help="Truncate target sequence length.")
-
-    # Data processing options
-    parser.add_argument('-shuffle', type=int, default=1,
-                        help="Shuffle data")
-    parser.add_argument('-lower', action='store_true', help='lowercase data')
-
-    # Options most relevant to summarization
-    parser.add_argument('-dynamic_dict', action='store_true',
-                        help="Create dynamic dictionaries")
-    parser.add_argument('-share_vocab', action='store_true',
-                        help="Share source and target vocabulary")
 
     # Options most relevant to speech
     parser.add_argument('-sample_rate', type=int, default=16000,
@@ -139,6 +159,15 @@ def preprocess_opts(parser):
                         help="Window stride for spectrogram in seconds.")
     parser.add_argument('-window', default='hamming',
                         help="Window type for spectrogram generation.")
+
+    # Data processing options
+    parser.add_argument('-shuffle', type=int, default=1,
+                        help="Shuffle data")
+    parser.add_argument('-lower', action='store_true', help='lowercase data')
+    parser.add_argument('-seed', type=int, default=3435,
+                        help="Random seed")
+    parser.add_argument('-report_every', type=int, default=100000,
+                        help="Report status every this many sentences")
 
 
 def train_opts(parser):

--- a/preprocess.py
+++ b/preprocess.py
@@ -9,35 +9,53 @@ import onmt
 import onmt.IO
 import opts
 
-parser = argparse.ArgumentParser(
-    description='preprocess.py',
-    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-opts.add_md_help_argument(parser)
-opts.preprocess_opts(parser)
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='preprocess.py',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
-opt = parser.parse_args()
-torch.manual_seed(opt.seed)
+    opts.add_md_help_argument(parser)
+    opts.preprocess_opts(parser)
+
+    opt = parser.parse_args()
+    torch.manual_seed(opt.seed)
+
+    return opt
+
+
+def get_num_features(side, opt):
+    """ Peek one line and get number of features of it.
+        (All lines must have same number of features).
+    """
+    assert side in ["src", "tgt"]
+
+    # Only "text" corpus has srouce-side features.
+    if side == "src":
+        data_file = opt.train_src if opt.data_type == "text" else None
+    else:
+        # side == "tgt"
+        data_file = opt.train_tgt
+
+    if data_file is not None:
+        with codecs.open(data_file, "r", "utf-8") as df:
+            f_line = df.readline().strip().split()
+            _, _, n_features = onmt.IO.extract_features(f_line)
+    else:
+        n_features = 0
+
+    return n_features
 
 
 def main():
-    print('Preparing training ...')
-    if opt.data_type == 'text':
-        with codecs.open(opt.train_src, "r", "utf-8") as src_file:
-            src_line = src_file.readline().strip().split()
-            _, _, n_src_features = onmt.IO.extract_features(src_line)
-    elif opt.data_type == 'img':
-        n_src_features = 0
-    elif opt.data_type == 'audio':
-        n_src_features = 0
+    opt = parse_args()
 
-    with codecs.open(opt.train_tgt, "r", "utf-8") as tgt_file:
-        tgt_line = tgt_file.readline().strip().split()
-        _, _, n_tgt_features = onmt.IO.extract_features(tgt_line)
-
+    print('Preparing for training ...')
+    n_src_features = get_num_features('src', opt)
+    n_tgt_features = get_num_features('tgt', opt)
     fields = onmt.IO.get_fields(opt.data_type, n_src_features, n_tgt_features)
 
-    print("Building Training...")
+    print("Building training data...")
     train = onmt.IO.ONMTDataset(opt.data_type,
                                 opt.train_src, opt.train_tgt, fields,
                                 opt.src_seq_length, opt.tgt_seq_length,
@@ -49,10 +67,15 @@ def main():
                                 window_size=opt.window_size,
                                 window_stride=opt.window_stride,
                                 window=opt.window, normalize_audio=True)
-    print("Building Vocab...")
-    onmt.IO.build_vocab(train, opt)
 
-    print("Building Valid...")
+    print("Building vocabulary...")
+    onmt.IO.build_vocab(train, opt.data_type, opt.share_vocab,
+                        opt.src_vocab_size,
+                        opt.src_words_min_frequency,
+                        opt.tgt_vocab_size,
+                        opt.tgt_words_min_frequency)
+
+    print("Building validation data...")
     valid = onmt.IO.ONMTDataset(opt.data_type,
                                 opt.valid_src, opt.valid_tgt, fields,
                                 opt.src_seq_length, opt.tgt_seq_length,
@@ -64,8 +87,8 @@ def main():
                                 window_size=opt.window_size,
                                 window_stride=opt.window_stride,
                                 window=opt.window, normalize_audio=True)
-    print("Saving train/valid/fields")
 
+    print("Saving train/valid/vocab...")
     # Can't save fields, so remove/reconstruct at training time.
     torch.save(onmt.IO.save_vocab(fields),
                open(opt.save_data + '.vocab.pt', 'wb'))

--- a/preprocess.py
+++ b/preprocess.py
@@ -12,40 +12,8 @@ import opts
 parser = argparse.ArgumentParser(
     description='preprocess.py',
     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
 opts.add_md_help_argument(parser)
-
-
-# **Preprocess Options**
-parser.add_argument('-config', help="Read options from this file")
-
-parser.add_argument('-data_type', default="text",
-                    help="Type of the source input. Options are [text|img].")
-parser.add_argument('-src_dir', default="",
-                    help="Source directory for image or audio files.")
-
-parser.add_argument('-train_src', required=True,
-                    help="Path to the training source data")
-parser.add_argument('-train_tgt', required=True,
-                    help="Path to the training target data")
-parser.add_argument('-valid_src', required=True,
-                    help="Path to the validation source data")
-parser.add_argument('-valid_tgt', required=True,
-                    help="Path to the validation target data")
-
-parser.add_argument('-save_data', required=True,
-                    help="Output file for the prepared data")
-
-parser.add_argument('-src_vocab',
-                    help="Path to an existing source vocabulary")
-parser.add_argument('-tgt_vocab',
-                    help="Path to an existing target vocabulary")
-parser.add_argument('-features_vocabs_prefix', type=str, default='',
-                    help="Path prefix to existing features vocabularies")
-parser.add_argument('-seed', type=int, default=3435,
-                    help="Random seed")
-parser.add_argument('-report_every', type=int, default=100000,
-                    help="Report status every this many sentences")
-
 opts.preprocess_opts(parser)
 
 opt = parser.parse_args()

--- a/preprocess.py
+++ b/preprocess.py
@@ -47,6 +47,32 @@ def get_num_features(side, opt):
     return n_features
 
 
+def build_dataset(corpus_type, fields, opt):
+    assert corpus_type in ['train', 'valid']
+
+    if corpus_type == 'train':
+        src_corpus = opt.train_src
+        tgt_corpus = opt.train_tgt
+    else:
+        src_corpus = opt.valid_src
+        tgt_corpus = opt.valid_tgt
+
+    dataset = onmt.IO.build_dataset(
+                fields, opt.data_type, src_corpus, tgt_corpus,
+                src_dir=opt.src_dir,
+                src_seq_length=opt.src_seq_length,
+                tgt_seq_length=opt.tgt_seq_length,
+                src_seq_length_trunc=opt.src_seq_length_trunc,
+                tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
+                dynamic_dict=opt.dynamic_dict,
+                sample_rate=opt.sample_rate,
+                window_size=opt.window_size,
+                window_stride=opt.window_stride,
+                window=opt.window)
+
+    return dataset
+
+
 def main():
     opt = parse_args()
 
@@ -56,18 +82,7 @@ def main():
     fields = onmt.IO.get_fields(opt.data_type, n_src_features, n_tgt_features)
 
     print("Building training data...")
-    train = onmt.IO.build_dataset(
-                fields, opt.data_type, opt.train_src, opt.train_tgt,
-                src_dir=opt.src_dir,
-                src_seq_length=opt.src_seq_length,
-                tgt_seq_length=opt.tgt_seq_length,
-                src_seq_length_trunc=opt.src_seq_length_trunc,
-                tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
-                dynamic_dict=opt.dynamic_dict,
-                sample_rate=opt.sample_rate,
-                window_size=opt.window_size,
-                window_stride=opt.window_stride,
-                window=opt.window)
+    train = build_dataset('train', fields, opt)
 
     print("Building vocabulary...")
     onmt.IO.build_vocab(train, opt.data_type, opt.share_vocab,
@@ -77,18 +92,7 @@ def main():
                         opt.tgt_words_min_frequency)
 
     print("Building validation data...")
-    valid = onmt.IO.build_dataset(
-                fields, opt.data_type, opt.valid_src, opt.valid_tgt,
-                src_dir=opt.src_dir,
-                src_seq_length=opt.src_seq_length,
-                tgt_seq_length=opt.tgt_seq_length,
-                src_seq_length_trunc=opt.src_seq_length_trunc,
-                tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
-                dynamic_dict=opt.dynamic_dict,
-                sample_rate=opt.sample_rate,
-                window_size=opt.window_size,
-                window_stride=opt.window_stride,
-                window=opt.window)
+    valid = build_dataset('valid', fields, opt)
 
     print("Saving train/valid/vocab...")
     # Can't save fields, so remove/reconstruct at training time.

--- a/preprocess.py
+++ b/preprocess.py
@@ -56,17 +56,18 @@ def main():
     fields = onmt.IO.get_fields(opt.data_type, n_src_features, n_tgt_features)
 
     print("Building training data...")
-    train = onmt.IO.ONMTDataset(opt.data_type,
-                                opt.train_src, opt.train_tgt, fields,
-                                opt.src_seq_length, opt.tgt_seq_length,
-                                src_seq_length_trunc=opt.src_seq_length_trunc,
-                                tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
-                                dynamic_dict=opt.dynamic_dict,
-                                src_dir=opt.src_dir,
-                                sample_rate=opt.sample_rate,
-                                window_size=opt.window_size,
-                                window_stride=opt.window_stride,
-                                window=opt.window, normalize_audio=True)
+    train = onmt.IO.build_dataset(
+                fields, opt.data_type, opt.train_src, opt.train_tgt,
+                src_dir=opt.src_dir,
+                src_seq_length=opt.src_seq_length,
+                tgt_seq_length=opt.tgt_seq_length,
+                src_seq_length_trunc=opt.src_seq_length_trunc,
+                tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
+                dynamic_dict=opt.dynamic_dict,
+                sample_rate=opt.sample_rate,
+                window_size=opt.window_size,
+                window_stride=opt.window_stride,
+                window=opt.window)
 
     print("Building vocabulary...")
     onmt.IO.build_vocab(train, opt.data_type, opt.share_vocab,
@@ -76,17 +77,18 @@ def main():
                         opt.tgt_words_min_frequency)
 
     print("Building validation data...")
-    valid = onmt.IO.ONMTDataset(opt.data_type,
-                                opt.valid_src, opt.valid_tgt, fields,
-                                opt.src_seq_length, opt.tgt_seq_length,
-                                src_seq_length_trunc=opt.src_seq_length_trunc,
-                                tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
-                                dynamic_dict=opt.dynamic_dict,
-                                src_dir=opt.src_dir,
-                                sample_rate=opt.sample_rate,
-                                window_size=opt.window_size,
-                                window_stride=opt.window_stride,
-                                window=opt.window, normalize_audio=True)
+    valid = onmt.IO.build_dataset(
+                fields, opt.data_type, opt.valid_src, opt.valid_tgt,
+                src_dir=opt.src_dir,
+                src_seq_length=opt.src_seq_length,
+                tgt_seq_length=opt.tgt_seq_length,
+                src_seq_length_trunc=opt.src_seq_length_trunc,
+                tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
+                dynamic_dict=opt.dynamic_dict,
+                sample_rate=opt.sample_rate,
+                window_size=opt.window_size,
+                window_stride=opt.window_stride,
+                window=opt.window)
 
     print("Saving train/valid/vocab...")
     # Can't save fields, so remove/reconstruct at training time.

--- a/test/pull_request_chk.sh
+++ b/test/pull_request_chk.sh
@@ -11,6 +11,8 @@ TEST_DIR="$PROJECT_ROOT/test"
 clean_up()
 {
     rm ${LOG_FILE}
+    rm -rf /tmp/im2text
+    rm -rf /tm/speech
 }
 trap clean_up SIGINT SIGQUIT SIGKILL
 
@@ -21,10 +23,39 @@ error_exit()
     exit 1
 }
 
+environment_prepare()
+{
+  # Download img2text corpus
+  wget -q -O /tmp/im2text.tgz http://lstm.seas.harvard.edu/latex/im2text_small.tgz
+  tar zxf /tmp/im2text.tgz -C /tmp/
+  head /tmp/im2text/src-train.txt > /tmp/im2text/src-train-head.txt
+  head /tmp/im2text/tgt-train.txt > /tmp/im2text/tgt-train-head.txt
+  head /tmp/im2text/src-val.txt > /tmp/im2text/src-val-head.txt
+  head /tmp/im2text/tgt-val.txt > /tmp/im2text/tgt-val-head.txt
+
+  wget -q -O /tmp/test_model_speech.pt http://lstm.seas.harvard.edu/latex/test_model_speech.pt
+
+  # Download speech2text corpus
+  wget -q -O /tmp/speech.tgz http://lstm.seas.harvard.edu/latex/speech.tgz
+  tar zxf /tmp/speech.tgz -C /tmp/
+  head /tmp/speech/src-train.txt > /tmp/speech/src-train-head.txt
+  head /tmp/speech/tgt-train.txt > /tmp/speech/tgt-train-head.txt
+  head /tmp/speech/src-val.txt > /tmp/speech/src-val-head.txt
+  head /tmp/speech/tgt-val.txt > /tmp/speech/tgt-val-head.txt
+
+  wget -q -O /tmp/test_model_im2text.pt http://lstm.seas.harvard.edu/latex/test_model_im2text.pt
+}
 
 # flake8 check
 echo -n "[+] Doing flake8 check..."
 python -m flake8  >> ${LOG_FILE} 2>&1
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
+
+
+# Environment prepartion
+echo -n "[+] Preparing for test..."
+environment_prepare
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
 
@@ -36,8 +67,12 @@ python -m unittest discover >> ${LOG_FILE} 2>&1
 echo "Succeeded" | tee -a ${LOG_FILE}
 
 
+#
 # Preprocess test
-echo -n "[+] Doing preprocess test..."
+#
+echo "[+] Doing preprocess test..."
+
+echo -n "  [+] Testing NMT preprocessing..."
 python preprocess.py -train_src ${DATA_DIR}/src-train.txt \
 		     -train_tgt ${DATA_DIR}/tgt-train.txt \
 		     -valid_src ${DATA_DIR}/src-val.txt \
@@ -48,17 +83,68 @@ python preprocess.py -train_src ${DATA_DIR}/src-train.txt \
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
 
+echo -n "  [+] Testing img2text preprocessing..."
+python preprocess.py -data_type img \
+		     -src_dir /tmp/im2text/images \
+		     -train_src /tmp/im2text/src-train.txt \
+		     -train_tgt /tmp/im2text/tgt-train.txt \
+		     -valid_src /tmp/im2text/src-val.txt \
+		     -valid_tgt /tmp/im2text/tgt-val.txt \
+		     -save_data /tmp/im2text/data  >> ${LOG_FILE} 2>&1
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
 
+echo -n "  [+] Testing speech2text preprocessing..."
+python preprocess.py -data_type audio \
+		     -src_dir /tmp/speech/an4_dataset \
+		     -train_src /tmp/speech/src-train.txt \
+		     -train_tgt /tmp/speech/tgt-train.txt \
+		     -valid_src /tmp/speech/src-val.txt \
+		     -valid_tgt /tmp/speech/tgt-val.txt \
+		     -save_data /tmp/speech/data  >> ${LOG_FILE} 2>&1
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
+
+
+#
 # Translation test
-echo -n "[+] Doing translation test..."
+#
+echo "[+] Doing translation test..."
+
+echo -n "  [+] Testing NMT translation..."
 head ${DATA_DIR}/src-test.txt > /tmp/src-test.txt
 python translate.py -model ${TEST_DIR}/test_model.pt -src /tmp/src-test.txt -verbose >> ${LOG_FILE} 2>&1
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
 
+echo -n "  [+] Testing img2text translation..."
+head /tmp/im2text/src-val.txt > /tmp/im2text/src-val-head.txt
+head /tmp/im2text/tgt-val.txt > /tmp/im2text/tgt-val-head.txt
+python translate.py -data_type img \
+	            -src_dir /tmp/im2text/images \
+		    -model /tmp/test_model_im2text.pt \
+		    -src /tmp/im2text/src-val-head.txt \
+		    -tgt /tmp/im2text/tgt-val-head.txt \
+		    -verbose -out /tmp/im2text/trans  >> ${LOG_FILE} 2>&1
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
 
-# Train + Translation test
-echo -n "[+] Doing preprocess + train + translation test..."
+echo -n "  [+] Testing speech2text translation..."
+head /tmp/speech/src-val.txt > /tmp/speech/src-val-head.txt
+head /tmp/speech/tgt-val.txt > /tmp/speech/tgt-val-head.txt
+python translate.py -data_type audio \
+	            -src_dir /tmp/speech/an4_dataset \
+		    -model /tmp/test_model_speech.pt \
+		    -src /tmp/speech/src-val-head.txt \
+		    -tgt /tmp/speech/tgt-val-head.txt \
+		    -verbose -out /tmp/speech/trans  >> ${LOG_FILE} 2>&1
+diff /tmp/speech/tgt-val-head.txt /tmp/speech/trans
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
+
+
+# NMT Preprocess + Train + Translation test
+echo -n "[+] Doing NMT {preprocess + train + translation} test..."
 head ${DATA_DIR}/src-val.txt > /tmp/src-val.txt
 head ${DATA_DIR}/tgt-val.txt > /tmp/tgt-val.txt
 python preprocess.py -train_src /tmp/src-val.txt \
@@ -81,4 +167,40 @@ diff ${DATA_DIR}/morph/tgt.valid /tmp/trans
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
 
+
+echo -n "[+] Doing im2text {preprocess + train} test..."
+head /tmp/im2text/src-val.txt > /tmp/im2text/src-val-head.txt
+head /tmp/im2text/tgt-val.txt > /tmp/im2text/tgt-val-head.txt
+python preprocess.py -data_type img \
+	             -src_dir /tmp/im2text/images \
+		     -train_src /tmp/im2text/src-val-head.txt \
+		     -train_tgt /tmp/im2text/tgt-val-head.txt \
+		     -valid_src /tmp/im2text/src-val-head.txt \
+		     -valid_tgt /tmp/im2text/tgt-val-head.txt \
+		     -save_data /tmp/im2text/q  >> ${LOG_FILE} 2>&1
+python train.py -model_type img \
+	        -data /tmp/im2text/q -rnn_size 2 -batch_size 10 \
+		-word_vec_size 5 -report_every 5 -rnn_size 10 -epochs 1  >> ${LOG_FILE} 2>&1
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
+
+
+echo -n "[+] Doing speech2text {preprocess + train} test..."
+head /tmp/speech/src-val.txt > /tmp/speech/src-val-head.txt
+head /tmp/speech/tgt-val.txt > /tmp/speech/tgt-val-head.txt
+python preprocess.py -data_type audio \
+	             -src_dir /tmp/speech/an4_dataset \
+		     -train_src /tmp/speech/src-val-head.txt \
+		     -train_tgt /tmp/speech/tgt-val-head.txt \
+		     -valid_src /tmp/speech/src-val-head.txt \
+		     -valid_tgt /tmp/speech/tgt-val-head.txt \
+		     -save_data /tmp/speech/q  >> ${LOG_FILE} 2>&1
+python train.py -model_type audio \
+	        -data /tmp/speech/q -rnn_size 2 -batch_size 10 \
+		-word_vec_size 5 -report_every 5 -rnn_size 10 -epochs 1  >> ${LOG_FILE} 2>&1
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
+
+
+# Finally, clean up
 clean_up

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -1,11 +1,12 @@
 import argparse
 import copy
 import unittest
-import onmt
-import opts
+from collections import Counter
+
 import torchtext
 
-from collections import Counter
+import onmt
+import opts
 
 
 parser = argparse.ArgumentParser(description='preprocess.py')
@@ -32,15 +33,18 @@ class TestData(unittest.TestCase):
     def dataset_build(self, opt):
         fields = onmt.IO.get_fields("text", 0, 0)
 
-        train = onmt.IO.ONMTDataset(
-            opt.data_type, opt.train_src, opt.train_tgt, fields,
-            opt.src_seq_length, opt.tgt_seq_length,
-            src_seq_length_trunc=opt.src_seq_length_trunc,
-            tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
-            dynamic_dict=opt.dynamic_dict,
-            src_dir=opt.src_dir, sample_rate=opt.sample_rate,
-            window_size=opt.window_size, window_stride=opt.window_stride,
-            window=opt.window)
+        train = onmt.IO.build_dataset(
+                    fields, opt.data_type, opt.train_src, opt.train_tgt,
+                    src_dir=opt.src_dir,
+                    src_seq_length=opt.src_seq_length,
+                    tgt_seq_length=opt.tgt_seq_length,
+                    src_seq_length_trunc=opt.src_seq_length_trunc,
+                    tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
+                    dynamic_dict=opt.dynamic_dict,
+                    sample_rate=opt.sample_rate,
+                    window_size=opt.window_size,
+                    window_stride=opt.window_stride,
+                    window=opt.window)
 
         onmt.IO.build_vocab(train, opt.data_type, opt.share_vocab,
                             opt.src_vocab_size,
@@ -48,14 +52,17 @@ class TestData(unittest.TestCase):
                             opt.tgt_vocab_size,
                             opt.tgt_words_min_frequency)
 
-        onmt.IO.ONMTDataset(
-            opt.data_type, opt.valid_src, opt.valid_tgt, fields,
-            opt.src_seq_length, opt.tgt_seq_length,
+        onmt.IO.build_dataset(
+            fields, opt.data_type, opt.valid_src, opt.valid_tgt,
+            src_dir=opt.src_dir,
+            src_seq_length=opt.src_seq_length,
+            tgt_seq_length=opt.tgt_seq_length,
             src_seq_length_trunc=opt.src_seq_length_trunc,
             tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
             dynamic_dict=opt.dynamic_dict,
-            src_dir=opt.src_dir, sample_rate=opt.sample_rate,
-            window_size=opt.window_size, window_stride=opt.window_stride,
+            sample_rate=opt.sample_rate,
+            window_size=opt.window_size,
+            window_stride=opt.window_stride,
             window=opt.window)
 
     def test_merge_vocab(self):

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -11,13 +11,17 @@ from collections import Counter
 parser = argparse.ArgumentParser(description='preprocess.py')
 opts.preprocess_opts(parser)
 
-opt = parser.parse_known_args()[0]
 
-opt.data_type = 'text'
-opt.train_src = 'data/src-train.txt'
-opt.train_tgt = 'data/tgt-train.txt'
-opt.valid_src = 'data/src-val.txt'
-opt.valid_tgt = 'data/tgt-val.txt'
+default_opts = [
+    '-data_type', 'text',
+    '-train_src', 'data/src-train.txt',
+    '-train_tgt', 'data/tgt-train.txt',
+    '-valid_src', 'data/src-val.txt',
+    '-valid_tgt', 'data/tgt-val.txt',
+    '-save_data', 'data/save'
+]
+
+opt = parser.parse_known_args(default_opts)[0]
 
 
 class TestData(unittest.TestCase):

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -7,6 +7,7 @@ import torchtext
 
 import onmt
 import opts
+import preprocess
 
 
 parser = argparse.ArgumentParser(description='preprocess.py')
@@ -33,18 +34,7 @@ class TestData(unittest.TestCase):
     def dataset_build(self, opt):
         fields = onmt.IO.get_fields("text", 0, 0)
 
-        train = onmt.IO.build_dataset(
-                    fields, opt.data_type, opt.train_src, opt.train_tgt,
-                    src_dir=opt.src_dir,
-                    src_seq_length=opt.src_seq_length,
-                    tgt_seq_length=opt.tgt_seq_length,
-                    src_seq_length_trunc=opt.src_seq_length_trunc,
-                    tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
-                    dynamic_dict=opt.dynamic_dict,
-                    sample_rate=opt.sample_rate,
-                    window_size=opt.window_size,
-                    window_stride=opt.window_stride,
-                    window=opt.window)
+        train = preprocess.build_dataset('train', fields, opt)
 
         onmt.IO.build_vocab(train, opt.data_type, opt.share_vocab,
                             opt.src_vocab_size,
@@ -52,18 +42,7 @@ class TestData(unittest.TestCase):
                             opt.tgt_vocab_size,
                             opt.tgt_words_min_frequency)
 
-        onmt.IO.build_dataset(
-            fields, opt.data_type, opt.valid_src, opt.valid_tgt,
-            src_dir=opt.src_dir,
-            src_seq_length=opt.src_seq_length,
-            tgt_seq_length=opt.tgt_seq_length,
-            src_seq_length_trunc=opt.src_seq_length_trunc,
-            tgt_seq_length_trunc=opt.tgt_seq_length_trunc,
-            dynamic_dict=opt.dynamic_dict,
-            sample_rate=opt.sample_rate,
-            window_size=opt.window_size,
-            window_stride=opt.window_stride,
-            window=opt.window)
+        preprocess.build_dataset('valid', fields, opt)
 
     def test_merge_vocab(self):
         va = torchtext.vocab.Vocab(Counter('abbccc'))

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -42,7 +42,11 @@ class TestData(unittest.TestCase):
             window_size=opt.window_size, window_stride=opt.window_stride,
             window=opt.window)
 
-        onmt.IO.build_vocab(train, opt)
+        onmt.IO.build_vocab(train, opt.data_type, opt.share_vocab,
+                            opt.src_vocab_size,
+                            opt.src_words_min_frequency,
+                            opt.tgt_vocab_size,
+                            opt.tgt_words_min_frequency)
 
         onmt.IO.ONMTDataset(
             opt.data_type, opt.valid_src, opt.valid_tgt, fields,

--- a/translate.py
+++ b/translate.py
@@ -53,14 +53,14 @@ def main():
         import json
         translator.initBeamAccum()
 
-    data = onmt.IO.ONMTDataset(opt.data_type,
-                               opt.src, opt.tgt, translator.fields,
-                               src_dir=opt.src_dir,
-                               sample_rate=opt.sample_rate,
-                               window_size=opt.window_size,
-                               window_stride=opt.window_stride,
-                               window=opt.window,
-                               use_filter_pred=False)
+    data = onmt.IO.build_dataset(translator.fields, opt.data_type,
+                                 opt.src, opt.tgt,
+                                 src_dir=opt.src_dir,
+                                 sample_rate=opt.sample_rate,
+                                 window_size=opt.window_size,
+                                 window_stride=opt.window_stride,
+                                 window=opt.window,
+                                 use_filter_pred=False)
     data_type = data.data_type
 
     test_data = onmt.IO.OrderedIterator(


### PR DESCRIPTION
As #380 is merged, the `ONMTDataset` is becoming unwieldy to read and maintain, and it also has conflict with the preprocess sharding work in  #384.

This PR just factors out the giant `ONMTDataset`  into `TextDataset`, `ImageDataset`, and `AudioDataset` (all are subclasses of `ONMTDatasetBase`), and I also factors out the preprocess skeleton, with some handy helper functions added.  I also cleans up `onmt/IO.py` a little bit,  with some docs updated/added.  

Besides, `test/pull_request_chk.sh` is updated to include the `im2text` and `speech2text` tests.

