### PR TITLE
Fix tools/embeddings_to_torch.py for #470

### DIFF
--- a/tools/embeddings_to_torch.py
+++ b/tools/embeddings_to_torch.py
@@ -21,7 +21,7 @@ opt = parser.parse_args()
 
 def get_vocabs(dict_file):
     vocabs = torch.load(dict_file)
-    enc_vocab, dec_vocab = [vocab[1] for vocab in vocabs]
+    enc_vocab, dec_vocab = vocabs[0][1], vocabs[-1][1]
 
     print("From: %s" % dict_file)
     print("\t* source vocab: %d words" % len(enc_vocab))


### PR DESCRIPTION
Try to fix #470.

When there exist some word features, the list `vocabs` will contain more than 2 elements. Only the first one and the last one are "word" vocabulary and can be matched with a pre-trained "word" embedding model.

Anyway, not sure whether this is a good way to fix it.
Using pre-trained embedding for word features such as POS tag is also quite reasonable.
Saving encoder, each word feature, and decoder vocabulary separately can be a better solution, though this requires running the script for (# vocabularies) times.