### PR TITLE
Further IO refactoring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
 install:
   - python setup.py install
 
+# Please also add tests to `test/pull_request_chk.sh`.
 script:
   - wget -O /tmp/im2text.tgz http://lstm.seas.harvard.edu/latex/im2text_small.tgz; tar zxf /tmp/im2text.tgz -C /tmp/; head /tmp/im2text/src-train.txt > /tmp/im2text/src-train-head.txt; head /tmp/im2text/tgt-train.txt > /tmp/im2text/tgt-train-head.txt; head /tmp/im2text/src-val.txt > /tmp/im2text/src-val-head.txt; head /tmp/im2text/tgt-val.txt > /tmp/im2text/tgt-val-head.txt
   - wget -O /tmp/speech.tgz http://lstm.seas.harvard.edu/latex/speech.tgz; tar zxf /tmp/speech.tgz -C /tmp/; head /tmp/speech/src-train.txt > /tmp/speech/src-train-head.txt; head /tmp/speech/tgt-train.txt > /tmp/speech/tgt-train-head.txt; head /tmp/speech/src-val.txt > /tmp/speech/src-val-head.txt; head /tmp/speech/tgt-val.txt > /tmp/speech/tgt-val-head.txt

--- a/onmt/io/AudioDataset.py
+++ b/onmt/io/AudioDataset.py
@@ -6,8 +6,7 @@ import os
 import torch
 import torchtext
 
-from onmt.io.IO import ONMTDatasetBase, \
-                        PAD_WORD, BOS_WORD, EOS_WORD
+from onmt.io.DatasetBase import ONMTDatasetBase, PAD_WORD, BOS_WORD, EOS_WORD
 
 
 class AudioDataset(ONMTDatasetBase):

--- a/onmt/io/AudioDataset.py
+++ b/onmt/io/AudioDataset.py
@@ -82,21 +82,49 @@ class AudioDataset(ONMTDatasetBase):
         return -ex.src.size(1)
 
     @staticmethod
+    def make_audio_examples_nfeats_tpl(path, audio_dir,
+                                       sample_rate, window_size,
+                                       window_stride, window,
+                                       normalize_audio, truncate=None):
+        """
+        Args:
+            path (str): location of a src file containing audio paths.
+            audio_dir (str): location of source audio files.
+            sample_rate (int): sample_rate.
+            window_size (float) : window size for spectrogram in seconds.
+            window_stride (float): window stride for spectrogram in seconds.
+            window (str): window type for spectrogram generation.
+            normalize_audio (bool): subtract spectrogram by mean and divide
+                by std or not.
+            truncate (int): maximum audio length (0 or None for unlimited).
+
+        Returns:
+            (example_dict iterator, num_feats) tuple
+        """
+        examples_iter = AudioDataset.read_audio_file(
+                path, audio_dir, "src", sample_rate,
+                window_size, window_stride, window,
+                normalize_audio, truncate)
+        num_feats = 0  # Source side(audio) has no features.
+
+        return (examples_iter, num_feats)
+
+    @staticmethod
     def read_audio_file(path, src_dir, side, sample_rate, window_size,
                         window_stride, window, normalize_audio,
                         truncate=None):
         """
         Args:
-            path: location of a src file containing audio paths.
-            src_dir: location of source audio files.
-            side: 'src' or 'tgt'.
-            sample_rate: sample_rate.
-            window_size: window size for spectrogram in seconds.
-            window_stride: window stride for spectrogram in seconds.
-            window: window type for spectrogram generation.
-            normalize_audio: subtract spectrogram by mean and divide
-            by std or not
-            truncate: maximum audio length (0 or None for unlimited).
+            path (str): location of a src file containing audio paths.
+            src_dir (str): location of source audio files.
+            side (str): 'src' or 'tgt'.
+            sample_rate (int): sample_rate.
+            window_size (float) : window size for spectrogram in seconds.
+            window_stride (float): window stride for spectrogram in seconds.
+            window (str): window type for spectrogram generation.
+            normalize_audio (bool): subtract spectrogram by mean and divide
+                by std or not.
+            truncate (int): maximum audio length (0 or None for unlimited).
 
         Yields:
             a dictionary containing audio data for each line.

--- a/onmt/io/AudioDataset.py
+++ b/onmt/io/AudioDataset.py
@@ -7,34 +7,32 @@ from onmt.io.IO import ONMTDatasetBase, _join_dicts, _peek, \
 class AudioDataset(ONMTDatasetBase):
     """ Dataset for data_type=='audio'
 
-        Build Example objects, Field objects, and filter_pred function
+        Build `Example` objects, `Field` objects, and filter_pred function
         from audio corpus.
 
         Args:
-            fields: a dictionary of Field objects.
-            src_examples_iter: preprocessed source example_dict iterator.
-            tgt_examples_iter: preprocessed target example_dict iterator.
-            num_src_feats: number of source side features.
-            num_tgt_feats: number of target side features.
-            tgt_seq_length: maximum target sequence length.
-            sample_rate: sample rate.
-            window_size: window size for spectrogram in seconds.
-            window_stride: window stride for spectrogram in seconds.
-            window: indow type for spectrogram generation.
-            normalize_audio: subtract spectrogram by mean and divide
-                             by std or not.
-            use_filter_pred: use a custom filter predicate to filter
-                             examples?
-
+            fields (dict): a dictionary of `torchtext.data.Field`.
+            src_examples_iter (dict iter): preprocessed source example
+                dictionary iterator.
+            tgt_examples_iter (dict iter): preprocessed target example
+                dictionary iterator.
+            num_src_feats (int): number of source side features.
+            num_tgt_feats (int): number of target side features.
+            tgt_seq_length (int): maximum target sequence length.
+            sample_rate (int): sample rate.
+            window_size (float): window size for spectrogram in seconds.
+            window_stride (float): window stride for spectrogram in seconds.
+            window (str): window type for spectrogram generation.
+            normalize_audio (bool): subtract spectrogram by mean and divide
+                by std or not.
+            use_filter_pred (bool): use a custom filter predicate to filter
+                out examples?
     """
-    def sort_key(self, ex):
-        return -ex.src.size(1)
-
-    def _process_corpus(self, fields, src_examples_iter, tgt_examples_iter,
-                        num_src_feats=0, num_tgt_feats=0,
-                        tgt_seq_length=0, sample_rate=0,
-                        window_size=0, window_stride=0, window=None,
-                        normalize_audio=True, use_filter_pred=True):
+    def __init__(self, fields, src_examples_iter, tgt_examples_iter,
+                 num_src_feats=0, num_tgt_feats=0,
+                 tgt_seq_length=0, sample_rate=0,
+                 window_size=0.0, window_stride=0.0, window=None,
+                 normalize_audio=True, use_filter_pred=True):
         self.data_type = 'audio'
 
         self.sample_rate = sample_rate
@@ -70,4 +68,9 @@ class AudioDataset(ONMTDatasetBase):
 
         filter_pred = filter_pred if use_filter_pred else lambda x: True
 
-        return out_examples, out_fields, filter_pred
+        super(AudioDataset, self).__init__(
+            out_examples, out_fields, filter_pred
+        )
+
+    def sort_key(self, ex):
+        return -ex.src.size(1)

--- a/onmt/io/AudioDataset.py
+++ b/onmt/io/AudioDataset.py
@@ -226,3 +226,26 @@ class AudioDataset(ONMTDatasetBase):
             sequential=False)
 
         return fields
+
+    @staticmethod
+    def get_num_features(corpus_file, side):
+        """
+        For audio corpus, source side is in form of audio, thus
+        no feature; while target side is in form of text, thus
+        we can extract its text features.
+
+        Args:
+            corpus_file (str): file path to get the features.
+            side (str): 'src' or 'tgt'.
+
+        Returns:
+            number of features on `side`.
+        """
+        if side == 'src':
+            num_feats = 0
+        else:
+            with codecs.open(corpus_file, "r", "utf-8") as cf:
+                f_line = cf.readline().strip().split()
+                _, _, num_feats = AudioDataset.extract_text_features(f_line)
+
+        return num_feats

--- a/onmt/io/AudioDataset.py
+++ b/onmt/io/AudioDataset.py
@@ -2,9 +2,12 @@
 
 import codecs
 import os
-import torch
 
-from onmt.io.IO import ONMTDatasetBase
+import torch
+import torchtext
+
+from onmt.io.IO import ONMTDatasetBase, \
+                        PAD_WORD, BOS_WORD, EOS_WORD
 
 
 class AudioDataset(ONMTDatasetBase):
@@ -154,3 +157,73 @@ class AudioDataset(ONMTDatasetBase):
                 index += 1
 
                 yield example_dict
+
+    @staticmethod
+    def get_fields(n_src_features, n_tgt_features):
+        """
+        Args:
+            n_src_features: the number of source features to
+                create `torchtext.data.Field` for.
+            n_tgt_features: the number of target features to
+                create `torchtext.data.Field` for.
+
+        Returns:
+            A dictionary whose keys are strings and whose values
+            are the corresponding Field objects.
+        """
+        fields = {}
+
+        def make_audio(data, _):
+            nfft = data[0].size(0)
+            t = max([t.size(1) for t in data])
+            sounds = torch.zeros(len(data), 1, nfft, t)
+            for i, spect in enumerate(data):
+                sounds[i, :, :, 0:spect.size(1)] = spect
+            return sounds
+
+        fields["src"] = torchtext.data.Field(
+            use_vocab=False, tensor_type=torch.FloatTensor,
+            postprocessing=make_audio, sequential=False)
+
+        for j in range(n_src_features):
+            fields["src_feat_"+str(j)] = \
+                torchtext.data.Field(pad_token=PAD_WORD)
+
+        fields["tgt"] = torchtext.data.Field(
+            init_token=BOS_WORD, eos_token=EOS_WORD,
+            pad_token=PAD_WORD)
+
+        for j in range(n_tgt_features):
+            fields["tgt_feat_"+str(j)] = \
+                torchtext.data.Field(init_token=BOS_WORD, eos_token=EOS_WORD,
+                                     pad_token=PAD_WORD)
+
+        def make_src(data, _):
+            src_size = max([t.size(0) for t in data])
+            src_vocab_size = max([t.max() for t in data]) + 1
+            alignment = torch.zeros(src_size, len(data), src_vocab_size)
+            for i, sent in enumerate(data):
+                for j, t in enumerate(sent):
+                    alignment[j, i, t] = 1
+            return alignment
+
+        fields["src_map"] = torchtext.data.Field(
+            use_vocab=False, tensor_type=torch.FloatTensor,
+            postprocessing=make_src, sequential=False)
+
+        def make_tgt(data, _):
+            tgt_size = max([t.size(0) for t in data])
+            alignment = torch.zeros(tgt_size, len(data)).long()
+            for i, sent in enumerate(data):
+                alignment[:sent.size(0), i] = sent
+            return alignment
+
+        fields["alignment"] = torchtext.data.Field(
+            use_vocab=False, tensor_type=torch.LongTensor,
+            postprocessing=make_tgt, sequential=False)
+
+        fields["indices"] = torchtext.data.Field(
+            use_vocab=False, tensor_type=torch.LongTensor,
+            sequential=False)
+
+        return fields

--- a/onmt/io/AudioDataset.py
+++ b/onmt/io/AudioDataset.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from onmt.io.IO import ONMTDatasetBase, _join_dicts, _peek, \
-                       _construct_example_fromlist
+from onmt.io.IO import ONMTDatasetBase
 
 
 class AudioDataset(ONMTDatasetBase):
@@ -45,19 +44,20 @@ class AudioDataset(ONMTDatasetBase):
         self.n_tgt_feats = num_tgt_feats
 
         if tgt_examples_iter is not None:
-            examples_iter = (_join_dicts(src, tgt) for src, tgt in
+            examples_iter = (self._join_dicts(src, tgt) for src, tgt in
                              zip(src_examples_iter, tgt_examples_iter))
         else:
             examples_iter = src_examples_iter
 
         # Peek at the first to see which fields are used.
-        ex, examples_iter = _peek(examples_iter)
+        ex, examples_iter = self._peek(examples_iter)
         keys = ex.keys()
 
         out_fields = [(k, fields[k]) if k in fields else (k, None)
                       for k in keys]
         example_values = ([ex[k] for k in keys] for ex in examples_iter)
-        out_examples = (_construct_example_fromlist(ex_values, out_fields)
+        out_examples = (self._construct_example_fromlist(
+                            ex_values, out_fields)
                         for ex_values in example_values)
 
         def filter_pred(example):

--- a/onmt/io/AudioDataset.py
+++ b/onmt/io/AudioDataset.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
 
+import codecs
+import os
+import torch
+
 from onmt.io.IO import ONMTDatasetBase
 
 
@@ -74,3 +78,79 @@ class AudioDataset(ONMTDatasetBase):
 
     def sort_key(self, ex):
         return -ex.src.size(1)
+
+    @staticmethod
+    def read_audio_file(path, src_dir, side, sample_rate, window_size,
+                        window_stride, window, normalize_audio,
+                        truncate=None):
+        """
+        Args:
+            path: location of a src file containing audio paths.
+            src_dir: location of source audio files.
+            side: 'src' or 'tgt'.
+            sample_rate: sample_rate.
+            window_size: window size for spectrogram in seconds.
+            window_stride: window stride for spectrogram in seconds.
+            window: window type for spectrogram generation.
+            normalize_audio: subtract spectrogram by mean and divide
+            by std or not
+            truncate: maximum audio length (0 or None for unlimited).
+
+        Yields:
+            a dictionary containing audio data for each line.
+        """
+        assert (src_dir is not None) and os.path.exists(src_dir),\
+            "src_dir must be a valid directory if data_type is audio"
+
+        global torchaudio, librosa, np
+        import torchaudio
+        import librosa
+        import numpy as np
+
+        with codecs.open(path, "r", "utf-8") as corpus_file:
+            index = 0
+            for line in corpus_file:
+                audio_path = os.path.join(src_dir, line.strip())
+                if not os.path.exists(audio_path):
+                    audio_path = line
+
+                assert os.path.exists(audio_path), \
+                    'audio path %s not found' % (line.strip())
+
+                sound, sample_rate = torchaudio.load(audio_path)
+                if truncate and truncate > 0:
+                    if sound.size(0) > truncate:
+                        continue
+
+                assert sample_rate == sample_rate, \
+                    'Sample rate of %s != -sample_rate (%d vs %d)' \
+                    % (audio_path, sample_rate, sample_rate)
+
+                sound = sound.numpy()
+                if len(sound.shape) > 1:
+                    if sound.shape[1] == 1:
+                        sound = sound.squeeze()
+                    else:
+                        sound = sound.mean(axis=1)  # average multiple channels
+
+                n_fft = int(sample_rate * window_size)
+                win_length = n_fft
+                hop_length = int(sample_rate * window_stride)
+                # STFT
+                d = librosa.stft(sound, n_fft=n_fft, hop_length=hop_length,
+                                 win_length=win_length, window=window)
+                spect, _ = librosa.magphase(d)
+                spect = np.log1p(spect)
+                spect = torch.FloatTensor(spect)
+                if normalize_audio:
+                    mean = spect.mean()
+                    std = spect.std()
+                    spect.add_(-mean)
+                    spect.div_(std)
+
+                example_dict = {side: spect,
+                                side + '_path': line.strip(),
+                                'indices': index}
+                index += 1
+
+                yield example_dict

--- a/onmt/io/DatasetBase.py
+++ b/onmt/io/DatasetBase.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*-
+
+from itertools import chain
+import torchtext
+from onmt.Utils import aeq
+
+
+PAD_WORD = '<blank>'
+UNK = 0
+BOS_WORD = '<s>'
+EOS_WORD = '</s>'
+
+
+class ONMTDatasetBase(torchtext.data.Dataset):
+    """
+    A dataset basically supports iteration over all the examples
+    it contains. We currently have 3 datasets inheriting this base
+    for 3 types of corpus respectively: "text", "img", "audio".
+
+    Internally it initializes an `torchtext.data.Dataset` object with
+    the following attributes:
+
+     `examples`: a sequence of `torchtext.data.Example` objects.
+     `fields`: a dictionary associating str keys with `torchtext.data.Field`
+        objects, and not necessarily having the same keys as the input fields.
+    """
+    def __getstate__(self):
+        return self.__dict__
+
+    def __setstate__(self, d):
+        self.__dict__.update(d)
+
+    def __reduce_ex__(self, proto):
+        "This is a hack. Something is broken with torch pickle."
+        return super(ONMTDatasetBase, self).__reduce_ex__()
+
+    def collapse_copy_scores(self, scores, batch, tgt_vocab):
+        """
+        Given scores from an expanded dictionary
+        corresponeding to a batch, sums together copies,
+        with a dictionary word when it is ambigious.
+        """
+        offset = len(tgt_vocab)
+        for b in range(batch.batch_size):
+            index = batch.indices.data[b]
+            src_vocab = self.src_vocabs[index]
+            for i in range(1, len(src_vocab)):
+                sw = src_vocab.itos[i]
+                ti = tgt_vocab.stoi[sw]
+                if ti != 0:
+                    scores[:, b, ti] += scores[:, b, offset + i]
+                    scores[:, b, offset + i].fill_(1e-20)
+        return scores
+
+    @staticmethod
+    def coalesce_datasets(datasets):
+        """Coalesce all dataset instances. """
+        final = datasets[0]
+        for d in datasets[1:]:
+            # `src_vocabs` is a list of `torchtext.vocab.Vocab`.
+            # Each sentence transforms into on Vocab.
+            # Coalesce them into one big list.
+            final.src_vocabs += d.src_vocabs
+
+            # All datasets have same number of features.
+            aeq(final.n_src_feats, d.n_src_feats)
+            aeq(final.n_tgt_feats, d.n_tgt_feats)
+
+            # `examples` is a list of `torchtext.data.Example`.
+            # Coalesce them into one big list.
+            final.examples += d.examples
+
+            # All datasets have same fields, no need to update.
+
+        return final
+
+    # Below are helper functions for intra-class use only.
+
+    def _join_dicts(self, *args):
+        """
+        Args:
+            dictionaries with disjoint keys.
+
+        Returns:
+            a single dictionary that has the union of these keys.
+        """
+        return dict(chain(*[d.items() for d in args]))
+
+    def _peek(self, seq):
+        """
+        Args:
+            seq: an iterator.
+
+        Returns:
+            the first thing returned by calling next() on the iterator
+            and an iterator created by re-chaining that value to the beginning
+            of the iterator.
+        """
+        first = next(seq)
+        return first, chain([first], seq)
+
+    def _construct_example_fromlist(self, data, fields):
+        """
+        Args:
+            data: the data to be set as the value of the attributes of
+                the to-be-created `Example`, associating with respective
+                `Field` objects with same key.
+            fields: a dict of `torchtext.data.Field` objects. The keys
+                are attributes of the to-be-created `Example`.
+
+        Returns:
+            the created `Example` object.
+        """
+        ex = torchtext.data.Example()
+        for (name, field), val in zip(fields, data):
+            if field is not None:
+                setattr(ex, name, field.preprocess(val))
+            else:
+                setattr(ex, name, val)
+        return ex

--- a/onmt/io/DatasetBase.py
+++ b/onmt/io/DatasetBase.py
@@ -74,6 +74,30 @@ class ONMTDatasetBase(torchtext.data.Dataset):
 
         return final
 
+    @staticmethod
+    def extract_text_features(tokens):
+        """
+        Args:
+            tokens: A list of tokens, where each token consists of a word,
+                optionally followed by u"￨"-delimited features.
+        Returns:
+            A sequence of words, a sequence of features, and num of features.
+        """
+        if not tokens:
+            return [], [], -1
+
+        split_tokens = [token.split(u"￨") for token in tokens]
+        split_tokens = [token for token in split_tokens if token[0]]
+        token_size = len(split_tokens[0])
+
+        assert all(len(token) == token_size for token in split_tokens), \
+            "all words must have the same number of features"
+        words_and_features = list(zip(*split_tokens))
+        words = words_and_features[0]
+        features = words_and_features[1:]
+
+        return words, features, token_size - 1
+
     # Below are helper functions for intra-class use only.
 
     def _join_dicts(self, *args):

--- a/onmt/io/IO.py
+++ b/onmt/io/IO.py
@@ -270,16 +270,16 @@ def _make_examples_nfeats_tpl(data_type, src_path, src_dir,
                 src_path, src_seq_length_trunc, "src")
 
     elif data_type == 'img':
-        src_examples_iter = \
-            ImageDataset.read_img_file(src_path, src_dir, "src")
-        num_src_feats = 0  # Source side(img) has no features.
+        src_examples_iter, num_src_feats = \
+            ImageDataset.make_image_examples_nfeats_tpl(
+                src_path, src_dir)
 
     elif data_type == 'audio':
-        src_examples_iter = AudioDataset.read_audio_file(
-                    src_path, src_dir, "src", sample_rate,
-                    window_size, window_stride, window,
-                    normalize_audio)
-        num_src_feats = 0  # Source side(audio) has no features.
+        src_examples_iter, num_src_feats = \
+            AudioDataset.make_audio_examples_nfeats_tpl(
+                src_path, src_dir, sample_rate,
+                window_size, window_stride, window,
+                normalize_audio)
 
     return src_examples_iter, num_src_feats
 

--- a/onmt/io/IO.py
+++ b/onmt/io/IO.py
@@ -1,19 +1,16 @@
 # -*- coding: utf-8 -*-
 
 from collections import Counter, defaultdict
-from itertools import chain, count
+from itertools import count
 
 import torch
 import torchtext.data
 import torchtext.vocab
 
-from onmt.Utils import aeq
-
-
-PAD_WORD = '<blank>'
-UNK = 0
-BOS_WORD = '<s>'
-EOS_WORD = '</s>'
+from onmt.io.DatasetBase import PAD_WORD, BOS_WORD, EOS_WORD
+from onmt.io.TextDataset import TextDataset
+from onmt.io.ImageDataset import ImageDataset
+from onmt.io.AudioDataset import AudioDataset
 
 
 def _getstate(self):
@@ -42,9 +39,6 @@ def get_fields(data_type, n_src_features, n_tgt_features):
         A dictionary whose keys are strings and whose values are the
         corresponding Field objects.
     """
-    # Hide this import inside to avoid circular dependency problem.
-    from onmt.io import TextDataset, ImageDataset, AudioDataset
-
     if data_type == 'text':
         return TextDataset.get_fields(n_src_features, n_tgt_features)
     elif data_type == 'img':
@@ -109,9 +103,6 @@ def get_num_features(data_type, corpus_file, side):
         number of features on `side`.
     """
     assert side in ["src", "tgt"]
-
-    # Hide this import inside to avoid circular dependency problem.
-    from onmt.io import TextDataset
 
     # For target side, all 'data_type' are in form of text.
     if side == 'tgt':
@@ -186,9 +177,6 @@ def build_dataset(fields, data_type, src_path, tgt_path, src_dir=None,
                   dynamic_dict=True, sample_rate=0,
                   window_size=0, window_stride=0, window=None,
                   normalize_audio=True, use_filter_pred=True):
-
-    # Hide this import inside to avoid circular dependency problem.
-    from onmt.io import TextDataset, ImageDataset, AudioDataset
 
     # Build src/tgt examples iterator from corpus files, also extract
     # number of features.
@@ -279,9 +267,6 @@ def _make_examples_nfeats_tpl(data_type, src_path, src_dir,
     on source side for different 'data_type'.
     """
 
-    # Hide this import inside to avoid circular dependency problem.
-    from onmt.io import TextDataset, ImageDataset, AudioDataset
-
     if data_type == 'text':
         src_examples_iter, num_src_feats = \
             TextDataset.make_text_examples_nfeats_tpl(
@@ -314,112 +299,3 @@ class OrderedIterator(torchtext.data.Iterator):
             for b in torchtext.data.batch(self.data(), self.batch_size,
                                           self.batch_size_fn):
                 self.batches.append(sorted(b, key=self.sort_key))
-
-
-class ONMTDatasetBase(torchtext.data.Dataset):
-    """
-    A dataset basically supports iteration over all the examples
-    it contains. We currently have 3 datasets inheriting this base
-    for 3 types of corpus respectively: "text", "img", "audio".
-
-    Internally it initializes an `torchtext.data.Dataset` object with
-    the following attributes:
-
-     `examples`: a sequence of `torchtext.data.Example` objects.
-     `fields`: a dictionary associating str keys with `torchtext.data.Field`
-        objects, and not necessarily having the same keys as the input fields.
-    """
-    def __getstate__(self):
-        return self.__dict__
-
-    def __setstate__(self, d):
-        self.__dict__.update(d)
-
-    def __reduce_ex__(self, proto):
-        "This is a hack. Something is broken with torch pickle."
-        return super(ONMTDatasetBase, self).__reduce_ex__()
-
-    def collapse_copy_scores(self, scores, batch, tgt_vocab):
-        """
-        Given scores from an expanded dictionary
-        corresponeding to a batch, sums together copies,
-        with a dictionary word when it is ambigious.
-        """
-        offset = len(tgt_vocab)
-        for b in range(batch.batch_size):
-            index = batch.indices.data[b]
-            src_vocab = self.src_vocabs[index]
-            for i in range(1, len(src_vocab)):
-                sw = src_vocab.itos[i]
-                ti = tgt_vocab.stoi[sw]
-                if ti != 0:
-                    scores[:, b, ti] += scores[:, b, offset + i]
-                    scores[:, b, offset + i].fill_(1e-20)
-        return scores
-
-    @staticmethod
-    def coalesce_datasets(datasets):
-        """Coalesce all dataset instances. """
-        final = datasets[0]
-        for d in datasets[1:]:
-            # `src_vocabs` is a list of `torchtext.vocab.Vocab`.
-            # Each sentence transforms into on Vocab.
-            # Coalesce them into one big list.
-            final.src_vocabs += d.src_vocabs
-
-            # All datasets have same number of features.
-            aeq(final.n_src_feats, d.n_src_feats)
-            aeq(final.n_tgt_feats, d.n_tgt_feats)
-
-            # `examples` is a list of `torchtext.data.Example`.
-            # Coalesce them into one big list.
-            final.examples += d.examples
-
-            # All datasets have same fields, no need to update.
-
-        return final
-
-    # Below are helper functions for intra-class use only.
-
-    def _join_dicts(self, *args):
-        """
-        Args:
-            dictionaries with disjoint keys.
-
-        Returns:
-            a single dictionary that has the union of these keys.
-        """
-        return dict(chain(*[d.items() for d in args]))
-
-    def _peek(self, seq):
-        """
-        Args:
-            seq: an iterator.
-
-        Returns:
-            the first thing returned by calling next() on the iterator
-            and an iterator created by re-chaining that value to the beginning
-            of the iterator.
-        """
-        first = next(seq)
-        return first, chain([first], seq)
-
-    def _construct_example_fromlist(self, data, fields):
-        """
-        Args:
-            data: the data to be set as the value of the attributes of
-                the to-be-created `Example`, associating with respective
-                `Field` objects with same key.
-            fields: a dict of `torchtext.data.Field` objects. The keys
-                are attributes of the to-be-created `Example`.
-
-        Returns:
-            the created `Example` object.
-        """
-        ex = torchtext.data.Example()
-        for (name, field), val in zip(fields, data):
-            if field is not None:
-                setattr(ex, name, field.preprocess(val))
-            else:
-                setattr(ex, name, val)
-        return ex

--- a/onmt/io/IO.py
+++ b/onmt/io/IO.py
@@ -104,15 +104,12 @@ def get_num_features(data_type, corpus_file, side):
     """
     assert side in ["src", "tgt"]
 
-    # For target side, all 'data_type' are in form of text.
-    if side == 'tgt':
-        return TextDataset.get_num_features(corpus_file)
-
-    # For source side, 'img' and 'audio' don't have features.
-    if data_type == 'img' or data_type == 'audio':
-        return 0
-    elif data_type == 'text':
-        return TextDataset.get_num_features(corpus_file)
+    if data_type == 'text':
+        return TextDataset.get_num_features(corpus_file, side)
+    elif data_type == 'img':
+        return ImageDataset.get_num_features(corpus_file, side)
+    elif data_type == 'audio':
+        return AudioDataset.get_num_features(corpus_file, side)
 
 
 def make_features(batch, side, data_type='text'):

--- a/onmt/io/IO.py
+++ b/onmt/io/IO.py
@@ -559,15 +559,9 @@ class ONMTDatasetBase(torchtext.data.Dataset):
     the following attributes:
 
      `examples`: a sequence of `torchtext.data.Example` objects.
-     `fields`: a dictionary associating str keys with Field objects. Does not
-            necessarily have the same keys as the input fields.
+     `fields`: a dictionary associating str keys with `torchtext.data.Field`
+        objects, and not necessarily having the same keys as the input fields.
     """
-    def __init__(self, *args, **kwargs):
-        examples, fields, filter_pred = self._process_corpus(*args, **kwargs)
-        super(ONMTDatasetBase, self).__init__(
-            examples, fields, filter_pred
-        )
-
     def __getstate__(self):
         return self.__dict__
 

--- a/onmt/io/ImageDataset.py
+++ b/onmt/io/ImageDataset.py
@@ -180,3 +180,26 @@ class ImageDataset(ONMTDatasetBase):
             sequential=False)
 
         return fields
+
+    @staticmethod
+    def get_num_features(corpus_file, side):
+        """
+        For image corpus, source side is in form of image, thus
+        no feature; while target side is in form of text, thus
+        we can extract its text features.
+
+        Args:
+            corpus_file (str): file path to get the features.
+            side (str): 'src' or 'tgt'.
+
+        Returns:
+            number of features on `side`.
+        """
+        if side == 'src':
+            num_feats = 0
+        else:
+            with codecs.open(corpus_file, "r", "utf-8") as cf:
+                f_line = cf.readline().strip().split()
+                _, _, num_feats = ImageDataset.extract_text_features(f_line)
+
+        return num_feats

--- a/onmt/io/ImageDataset.py
+++ b/onmt/io/ImageDataset.py
@@ -6,8 +6,7 @@ import os
 import torch
 import torchtext
 
-from onmt.io.IO import ONMTDatasetBase, \
-                        PAD_WORD, BOS_WORD, EOS_WORD
+from onmt.io.DatasetBase import ONMTDatasetBase, PAD_WORD, BOS_WORD, EOS_WORD
 
 
 class ImageDataset(ONMTDatasetBase):

--- a/onmt/io/ImageDataset.py
+++ b/onmt/io/ImageDataset.py
@@ -69,12 +69,27 @@ class ImageDataset(ONMTDatasetBase):
         return (-ex.src.size(2), -ex.src.size(1))
 
     @staticmethod
+    def make_image_examples_nfeats_tpl(path, img_dir):
+        """
+        Args:
+            path (str): location of a src file containing image paths
+            src_dir (str): location of source images
+
+        Returns:
+            (example_dict iterator, num_feats) tuple
+        """
+        examples_iter = ImageDataset.read_img_file(path, img_dir, 'src')
+        num_feats = 0  # Source side(img) has no features.
+
+        return (examples_iter, num_feats)
+
+    @staticmethod
     def read_img_file(path, src_dir, side, truncate=None):
         """
         Args:
-            path: location of a src file containing image paths
-            src_dir: location of source images
-            side: 'src' or 'tgt'
+            path (str): location of a src file containing image paths
+            src_dir (str): location of source images
+            side (str): 'src' or 'tgt'
             truncate: maximum img size ((0,0) or None for unlimited)
 
         Yields:

--- a/onmt/io/ImageDataset.py
+++ b/onmt/io/ImageDataset.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from onmt.io.IO import ONMTDatasetBase, _join_dicts, _peek, \
-                       _construct_example_fromlist
+from onmt.io.IO import ONMTDatasetBase
 
 
 class ImageDataset(ONMTDatasetBase):
@@ -31,19 +30,20 @@ class ImageDataset(ONMTDatasetBase):
         self.n_tgt_feats = num_tgt_feats
 
         if tgt_examples_iter is not None:
-            examples_iter = (_join_dicts(src, tgt) for src, tgt in
+            examples_iter = (self._join_dicts(src, tgt) for src, tgt in
                              zip(src_examples_iter, tgt_examples_iter))
         else:
             examples_iter = src_examples_iter
 
         # Peek at the first to see which fields are used.
-        ex, examples_iter = _peek(examples_iter)
+        ex, examples_iter = self._peek(examples_iter)
         keys = ex.keys()
 
         out_fields = [(k, fields[k]) if k in fields else (k, None)
                       for k in keys]
         example_values = ([ex[k] for k in keys] for ex in examples_iter)
-        out_examples = (_construct_example_fromlist(ex_values, out_fields)
+        out_examples = (self._construct_example_fromlist(
+                            ex_values, out_fields)
                         for ex_values in example_values)
 
         def filter_pred(example):

--- a/onmt/io/ImageDataset.py
+++ b/onmt/io/ImageDataset.py
@@ -7,26 +7,24 @@ from onmt.io.IO import ONMTDatasetBase, _join_dicts, _peek, \
 class ImageDataset(ONMTDatasetBase):
     """ Dataset for data_type=='img'
 
-        Build Example objects, Field objects, and filter_pred function
+        Build `Example` objects, `Field` objects, and filter_pred function
         from image corpus.
 
         Args:
-            fields: a dictionary of Field objects.
-            src_examples_iter: preprocessed source example_dict iterator.
-            tgt_examples_iter: preprocessed target example_dict iterator.
-            num_src_feats: number of source side features.
-            num_tgt_feats: number of target side features.
-            tgt_seq_length: maximum target sequence length.
-            use_filter_pred: use a custom filter predicate to filter examples?
+            fields (dict): a dictionary of `torchtext.data.Field`.
+            src_examples_iter (dict iter): preprocessed source example
+                dictionary iterator.
+            tgt_examples_iter (dict iter): preprocessed target example
+                dictionary iterator.
+            num_src_feats (int): number of source side features.
+            num_tgt_feats (int): number of target side features.
+            tgt_seq_length (int): maximum target sequence length.
+            use_filter_pred (bool): use a custom filter predicate to filter
+                out examples?
     """
-
-    def sort_key(self, ex):
-        "Sort using the size of the image."
-        return (-ex.src.size(2), -ex.src.size(1))
-
-    def _process_corpus(self, fields, src_examples_iter, tgt_examples_iter,
-                        num_src_feats=0, num_tgt_feats=0,
-                        tgt_seq_length=0, use_filter_pred=True):
+    def __init__(self, fields, src_examples_iter, tgt_examples_iter,
+                 num_src_feats=0, num_tgt_feats=0,
+                 tgt_seq_length=0, use_filter_pred=True):
         self.data_type = 'img'
 
         self.n_src_feats = num_src_feats
@@ -56,4 +54,10 @@ class ImageDataset(ONMTDatasetBase):
 
         filter_pred = filter_pred if use_filter_pred else lambda x: True
 
-        return out_examples, out_fields, filter_pred
+        super(ImageDataset, self).__init__(
+            out_examples, out_fields, filter_pred
+        )
+
+    def sort_key(self, ex):
+        "Sort using the size of the image."
+        return (-ex.src.size(2), -ex.src.size(1))

--- a/onmt/io/TextDataset.py
+++ b/onmt/io/TextDataset.py
@@ -15,29 +15,28 @@ from onmt.io.IO import ONMTDatasetBase, _join_dicts, _peek,\
 class TextDataset(ONMTDatasetBase):
     """ Dataset for data_type=='text'
 
-        Build Example objects, Field objects, and filter_pred function
+        Build `Example` objects, `Field` objects, and filter_pred function
         from text corpus.
 
         Args:
-            fields: a dictionary of Field objects. Keys are like 'src',
-                    'tgt', 'src_map', and 'alignment'.
-            src_examples_iter: preprocessed source example_dict iterator.
-            tgt_examples_iter: preprocessed target example_dict iterator.
-            num_src_feats: number of source side features.
-            num_tgt_feats: number of target side features.
-            src_seq_length: maximum source sequence length.
-            tgt_seq_length: maximum target sequence length.
-            dynamic_dict: create dynamic dictionaries?
-            use_filter_pred: use a custom filter predicate to filter examples?
+            fields (dict): a dictionary of `torchtext.data.Field`.
+                Keys are like 'src', 'tgt', 'src_map', and 'alignment'.
+            src_examples_iter (dict iter): preprocessed source example
+                dictionary iterator.
+            tgt_examples_iter (dict iter): preprocessed target example
+                dictionary iterator.
+            num_src_feats (int): number of source side features.
+            num_tgt_feats (int): number of target side features.
+            src_seq_length (int): maximum source sequence length.
+            tgt_seq_length (int): maximum target sequence length.
+            dynamic_dict (bool): create dynamic dictionaries?
+            use_filter_pred (bool): use a custom filter predicate to filter
+                out examples?
     """
-
-    def sort_key(self, ex):
-        return -len(ex.src)
-
-    def _process_corpus(self, fields, src_examples_iter, tgt_examples_iter,
-                        num_src_feats=0, num_tgt_feats=0,
-                        src_seq_length=0, tgt_seq_length=0,
-                        dynamic_dict=True, use_filter_pred=True):
+    def __init__(self, fields, src_examples_iter, tgt_examples_iter,
+                 num_src_feats=0, num_tgt_feats=0,
+                 src_seq_length=0, tgt_seq_length=0,
+                 dynamic_dict=True, use_filter_pred=True):
         self.data_type = 'text'
 
         # self.src_vocabs: mutated in dynamic_dict, used in
@@ -75,7 +74,12 @@ class TextDataset(ONMTDatasetBase):
 
         filter_pred = filter_pred if use_filter_pred else lambda x: True
 
-        return out_examples, out_fields, filter_pred
+        super(TextDataset, self).__init__(
+            out_examples, out_fields, filter_pred
+        )
+
+    def sort_key(self, ex):
+        return -len(ex.src)
 
     def _dynamic_dict(self, examples_iter):
         for example in examples_iter:

--- a/onmt/io/TextDataset.py
+++ b/onmt/io/TextDataset.py
@@ -10,7 +10,8 @@ import torch
 import torchtext
 
 from onmt.Utils import aeq
-from onmt.io.IO import ONMTDatasetBase, extract_features
+from onmt.io.IO import ONMTDatasetBase, extract_features, \
+                        PAD_WORD, BOS_WORD, EOS_WORD
 
 
 class TextDataset(ONMTDatasetBase):
@@ -130,6 +131,68 @@ class TextDataset(ONMTDatasetBase):
                     example_dict.update((prefix + str(j), f)
                                         for j, f in enumerate(feats))
                 yield example_dict, n_feats
+
+    @staticmethod
+    def get_fields(n_src_features, n_tgt_features):
+        """
+        Args:
+            n_src_features (int): the number of source features to
+                create `torchtext.data.Field` for.
+            n_tgt_features (int): the number of target features to
+                create `torchtext.data.Field` for.
+
+        Returns:
+            A dictionary whose keys are strings and whose values
+            are the corresponding Field objects.
+        """
+        fields = {}
+
+        fields["src"] = torchtext.data.Field(
+            pad_token=PAD_WORD,
+            include_lengths=True)
+
+        for j in range(n_src_features):
+            fields["src_feat_"+str(j)] = \
+                torchtext.data.Field(pad_token=PAD_WORD)
+
+        fields["tgt"] = torchtext.data.Field(
+            init_token=BOS_WORD, eos_token=EOS_WORD,
+            pad_token=PAD_WORD)
+
+        for j in range(n_tgt_features):
+            fields["tgt_feat_"+str(j)] = \
+                torchtext.data.Field(init_token=BOS_WORD, eos_token=EOS_WORD,
+                                     pad_token=PAD_WORD)
+
+        def make_src(data, _):
+            src_size = max([t.size(0) for t in data])
+            src_vocab_size = max([t.max() for t in data]) + 1
+            alignment = torch.zeros(src_size, len(data), src_vocab_size)
+            for i, sent in enumerate(data):
+                for j, t in enumerate(sent):
+                    alignment[j, i, t] = 1
+            return alignment
+
+        fields["src_map"] = torchtext.data.Field(
+            use_vocab=False, tensor_type=torch.FloatTensor,
+            postprocessing=make_src, sequential=False)
+
+        def make_tgt(data, _):
+            tgt_size = max([t.size(0) for t in data])
+            alignment = torch.zeros(tgt_size, len(data)).long()
+            for i, sent in enumerate(data):
+                alignment[:sent.size(0), i] = sent
+            return alignment
+
+        fields["alignment"] = torchtext.data.Field(
+            use_vocab=False, tensor_type=torch.LongTensor,
+            postprocessing=make_tgt, sequential=False)
+
+        fields["indices"] = torchtext.data.Field(
+            use_vocab=False, tensor_type=torch.LongTensor,
+            sequential=False)
+
+        return fields
 
     # Below are helper functions for intra-class use only.self.
     def _dynamic_dict(self, examples_iter):

--- a/onmt/io/TextDataset.py
+++ b/onmt/io/TextDataset.py
@@ -197,31 +197,7 @@ class TextDataset(ONMTDatasetBase):
         return fields
 
     @staticmethod
-    def extract_text_features(tokens):
-        """
-        Args:
-            tokens: A list of tokens, where each token consists of a word,
-                optionally followed by u"￨"-delimited features.
-        Returns:
-            A sequence of words, a sequence of features, and num of features.
-        """
-        if not tokens:
-            return [], [], -1
-
-        split_tokens = [token.split(u"￨") for token in tokens]
-        split_tokens = [token for token in split_tokens if token[0]]
-        token_size = len(split_tokens[0])
-
-        assert all(len(token) == token_size for token in split_tokens), \
-            "all words must have the same number of features"
-        words_and_features = list(zip(*split_tokens))
-        words = words_and_features[0]
-        features = words_and_features[1:]
-
-        return words, features, token_size - 1
-
-    @staticmethod
-    def get_num_features(corpus_file):
+    def get_num_features(corpus_file, side):
         """
         Peek one line and get number of features of it.
         (All lines must have same number of features).
@@ -230,6 +206,7 @@ class TextDataset(ONMTDatasetBase):
 
         Args:
             corpus_file (str): file path to get the features.
+            side (str): 'src' or 'tgt'.
 
         Returns:
             number of features on `side`.

--- a/onmt/io/TextDataset.py
+++ b/onmt/io/TextDataset.py
@@ -10,8 +10,7 @@ import torch
 import torchtext
 
 from onmt.Utils import aeq
-from onmt.io.IO import ONMTDatasetBase, \
-                        PAD_WORD, BOS_WORD, EOS_WORD
+from onmt.io.DatasetBase import ONMTDatasetBase, PAD_WORD, BOS_WORD, EOS_WORD
 
 
 class TextDataset(ONMTDatasetBase):

--- a/onmt/io/TextDataset.py
+++ b/onmt/io/TextDataset.py
@@ -81,12 +81,19 @@ class TextDataset(ONMTDatasetBase):
         )
 
     def sort_key(self, ex):
+        """ Sort using length of source sentences. """
         return -len(ex.src)
 
     @staticmethod
     def make_text_examples_nfeats_tpl(path, truncate, side):
         """
-        Process the text corpus into (example_dict iterator, num_feats) tuple.
+        Args:
+            path (str): location of a src or tgt file.
+            truncate (int): maximum sequence length (0 for unlimited).
+            side (str): "src" or "tgt".
+
+        Returns:
+            (example_dict iterator, num_feats) tuple.
         """
         assert side in ['src', 'tgt']
 
@@ -111,9 +118,9 @@ class TextDataset(ONMTDatasetBase):
     def read_text_file(path, truncate, side):
         """
         Args:
-            path: location of a src or tgt file.
-            truncate: maximum sequence length (0 for unlimited).
-            side: "src" or "tgt".
+            path (str): location of a src or tgt file.
+            truncate (int): maximum sequence length (0 for unlimited).
+            side (str): "src" or "tgt".
 
         Yields:
             (word, features, nfeat) triples for each line.

--- a/onmt/io/__init__.py
+++ b/onmt/io/__init__.py
@@ -1,9 +1,10 @@
-from onmt.io.IO import PAD_WORD, BOS_WORD, EOS_WORD, UNK, ONMTDatasetBase, \
-                       collect_feature_vocabs, make_features, \
+from onmt.io.IO import collect_feature_vocabs, make_features, \
                        collect_features, get_num_features, \
                        load_fields_from_vocab, get_fields, \
                        save_fields_to_vocab, build_dataset, \
                        build_vocab, merge_vocabs, OrderedIterator
+from onmt.io.DatasetBase import ONMTDatasetBase, PAD_WORD, BOS_WORD, \
+                                EOS_WORD, UNK
 from onmt.io.TextDataset import TextDataset, ShardedTextCorpusIterator
 from onmt.io.ImageDataset import ImageDataset
 from onmt.io.AudioDataset import AudioDataset

--- a/onmt/io/__init__.py
+++ b/onmt/io/__init__.py
@@ -1,6 +1,6 @@
 from onmt.io.IO import PAD_WORD, BOS_WORD, EOS_WORD, UNK, ONMTDatasetBase, \
                        collect_feature_vocabs, make_features, \
-                       collect_features, extract_features, \
+                       collect_features, get_num_features, \
                        load_fields_from_vocab, get_fields, \
                        save_fields_to_vocab, build_dataset, \
                        build_vocab, merge_vocabs, OrderedIterator
@@ -11,7 +11,7 @@ from onmt.io.AudioDataset import AudioDataset
 
 __all__ = [PAD_WORD, BOS_WORD, EOS_WORD, UNK, ONMTDatasetBase,
            collect_feature_vocabs, make_features,
-           collect_features, extract_features,
+           collect_features, get_num_features,
            load_fields_from_vocab, get_fields,
            save_fields_to_vocab, build_dataset,
            build_vocab, merge_vocabs, OrderedIterator,

--- a/preprocess.py
+++ b/preprocess.py
@@ -46,7 +46,7 @@ def get_num_features(side, opt):
 
 
 def build_save_text_dataset_in_shards(src_corpus, tgt_corpus, fields,
-                                      corpus_type, opt, save=True):
+                                      corpus_type, opt):
     '''
     Divide the big corpus into shards, and build dataset seperately.
     This is currently only for data_type=='text'.
@@ -96,12 +96,11 @@ def build_save_text_dataset_in_shards(src_corpus, tgt_corpus, fields,
                 dynamic_dict=opt.dynamic_dict)
         ret_list.append(dataset)
 
-        if save:
-            # We save fields in vocab.pt seperately, so make it empty.
-            dataset.fields = []
-            pt_file = "{:s}.{:s}.{:d}.pt".format(
-                    opt.save_data, corpus_type, index)
-            torch.save(dataset, pt_file)
+        # We save fields in vocab.pt seperately, so make it empty.
+        dataset.fields = []
+        pt_file = "{:s}.{:s}.{:d}.pt".format(
+                opt.save_data, corpus_type, index)
+        torch.save(dataset, pt_file)
 
     if index == 1:
         # Only one shard, strip the index in the filename.
@@ -110,7 +109,7 @@ def build_save_text_dataset_in_shards(src_corpus, tgt_corpus, fields,
     return ret_list
 
 
-def build_save_dataset(corpus_type, fields, opt, save=True):
+def build_save_dataset(corpus_type, fields, opt):
     assert corpus_type in ['train', 'valid']
 
     if corpus_type == 'train':
@@ -124,7 +123,7 @@ def build_save_dataset(corpus_type, fields, opt, save=True):
     if opt.data_type == 'text':
         return build_save_text_dataset_in_shards(
                 src_corpus, tgt_corpus, fields,
-                corpus_type, opt, save)
+                corpus_type, opt)
 
     # For data_type == 'img' or 'audio', currently we don't do
     # preprocess sharding. We only build a monolithic dataset.
@@ -143,16 +142,15 @@ def build_save_dataset(corpus_type, fields, opt, save=True):
                 window_stride=opt.window_stride,
                 window=opt.window)
 
-    if save:
-        # We save fields in vocab.pt seperately, so make it empty.
-        dataset.fields = []
-        pt_file = "{:s}.{:s}.pt".format(opt.save_data, corpus_type)
-        torch.save(dataset, pt_file)
+    # We save fields in vocab.pt seperately, so make it empty.
+    dataset.fields = []
+    pt_file = "{:s}.{:s}.pt".format(opt.save_data, corpus_type)
+    torch.save(dataset, pt_file)
 
     return [dataset]
 
 
-def build_save_vocab(train_dataset, fields, opt, save=True):
+def build_save_vocab(train_dataset, fields, opt):
     # We've empty'ed each dataset's `fields` attribute
     # when saving datasets, so restore them.
     for train in train_dataset:
@@ -164,10 +162,9 @@ def build_save_vocab(train_dataset, fields, opt, save=True):
                         opt.tgt_vocab_size,
                         opt.tgt_words_min_frequency)
 
-    if save:
-        # Can't save fields, so remove/reconstruct at training time.
-        vocab_file = opt.save_data + '.vocab.pt'
-        torch.save(onmt.io.save_fields_to_vocab(fields), vocab_file)
+    # Can't save fields, so remove/reconstruct at training time.
+    vocab_file = opt.save_data + '.vocab.pt'
+    torch.save(onmt.io.save_fields_to_vocab(fields), vocab_file)
 
 
 def main():

--- a/preprocess.py
+++ b/preprocess.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import argparse
-import codecs
 import os
 import glob
 import sys
@@ -42,26 +41,8 @@ def parse_args():
 
 
 def get_num_features(side, opt):
-    """ Peek one line and get number of features of it.
-        (All lines must have same number of features).
-    """
-    assert side in ["src", "tgt"]
-
-    # Only "text" corpus has srouce-side features.
-    if side == "src":
-        data_file = opt.train_src if opt.data_type == "text" else None
-    else:
-        # side == "tgt"
-        data_file = opt.train_tgt
-
-    if data_file is not None:
-        with codecs.open(data_file, "r", "utf-8") as df:
-            f_line = df.readline().strip().split()
-            _, _, n_features = onmt.io.extract_features(f_line)
-    else:
-        n_features = 0
-
-    return n_features
+    corpus_file = opt.train_src if side == "src" else opt.train_tgt
+    return onmt.io.get_num_features(opt.data_type, corpus_file, side)
 
 
 def build_save_text_dataset_in_shards(src_corpus, tgt_corpus, fields,

--- a/preprocess.py
+++ b/preprocess.py
@@ -40,11 +40,6 @@ def parse_args():
     return opt
 
 
-def get_num_features(side, opt):
-    corpus_file = opt.train_src if side == "src" else opt.train_tgt
-    return onmt.io.get_num_features(opt.data_type, corpus_file, side)
-
-
 def build_save_text_dataset_in_shards(src_corpus, tgt_corpus, fields,
                                       corpus_type, opt):
     '''
@@ -171,9 +166,9 @@ def main():
     opt = parse_args()
 
     print('Preparing for training ...')
-    n_src_features = get_num_features('src', opt)
-    n_tgt_features = get_num_features('tgt', opt)
-    fields = onmt.io.get_fields(opt.data_type, n_src_features, n_tgt_features)
+    src_nfeats = onmt.io.get_num_features(opt.data_type, opt.train_src, 'src')
+    tgt_nfeats = onmt.io.get_num_features(opt.data_type, opt.train_tgt, 'tgt')
+    fields = onmt.io.get_fields(opt.data_type, src_nfeats, tgt_nfeats)
 
     print("Building & saving training data...")
     train_datasets = build_save_dataset('train', fields, opt)

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -1,6 +1,8 @@
 import argparse
 import copy
 import unittest
+import glob
+import os
 from collections import Counter
 
 import torchtext
@@ -15,13 +17,15 @@ parser = argparse.ArgumentParser(description='preprocess.py')
 opts.preprocess_opts(parser)
 
 
+SAVE_DATA_PREFIX = 'data/test_preprocess'
+
 default_opts = [
     '-data_type', 'text',
     '-train_src', 'data/src-train.txt',
     '-train_tgt', 'data/tgt-train.txt',
     '-valid_src', 'data/src-val.txt',
     '-valid_tgt', 'data/tgt-val.txt',
-    '-save_data', 'data/save'
+    '-save_data', SAVE_DATA_PREFIX
 ]
 
 opt = parser.parse_known_args(default_opts)[0]
@@ -35,12 +39,15 @@ class TestData(unittest.TestCase):
     def dataset_build(self, opt):
         fields = onmt.io.get_fields("text", 0, 0)
 
-        trains = preprocess.build_save_dataset('train', fields,
-                                               opt, save=False)
+        trains = preprocess.build_save_dataset('train', fields, opt)
 
-        preprocess.build_save_vocab(trains, fields, opt, save=False)
+        preprocess.build_save_vocab(trains, fields, opt)
 
-        preprocess.build_save_dataset('valid', fields, opt, save=False)
+        preprocess.build_save_dataset('valid', fields, opt)
+
+        # Remove the generated *pt files.
+        for pt in glob.glob(SAVE_DATA_PREFIX + '*.pt'):
+            os.remove(pt)
 
     def test_merge_vocab(self):
         va = torchtext.vocab.Vocab(Counter('abbccc'))


### PR DESCRIPTION
This PR addresses #466.

Basically, after this further refactoring, the `IO.py` now just acts as a dispatcher and delegates work to specific `*Dataset`'s static methods.

Furthermore, I create a new `onmt/io/DatasetBase.py` to lodge `ONMTDatasetBase`, which could avoid the import circular dependency problem between `IO.py` and `*Dataset.py` ( Before this, `*Dataset` uses `IO.py`'s `ONMTDatasetBase`,  while `IO.py` uses `*Dataset.py`'s `*Dataset`, which will create a circular import problem).  And this separation seems good, it naturally de-entangles things and exposes more cleanup opportunities.