### PR TITLE
FIX Warning OF pytorch-0.3.0: Implicit dimension choice for softmax

### DIFF
--- a/onmt/modules/CopyGenerator.py
+++ b/onmt/modules/CopyGenerator.py
@@ -88,7 +88,7 @@ class CopyGenerator(nn.Module):
         # Original probabilities.
         logits = self.linear(hidden)
         logits[:, self.tgt_dict.stoi[onmt.io.PAD_WORD]] = -float('inf')
-        prob = F.softmax(logits)
+        prob = F.softmax(logits, dim=1)
 
         # Probability of copying p(z=1) batch.
         copy = F.sigmoid(self.linear_copy(hidden))

--- a/onmt/modules/GlobalAttention.py
+++ b/onmt/modules/GlobalAttention.py
@@ -77,7 +77,7 @@ class GlobalAttention(nn.Module):
         out_bias = self.attn_type == "mlp"
         self.linear_out = nn.Linear(dim*2, dim, bias=out_bias)
 
-        self.sm = nn.Softmax()
+        self.sm = nn.Softmax(dim=1)
         self.tanh = nn.Tanh()
 
         if coverage:


### PR DESCRIPTION
It has been deprecated. Change the call to include dim=X as an argument.