### PR TITLE
Add a Bleu/Rouge report during translation

### DIFF
--- a/docs/source/options/translate.md
+++ b/docs/source/options/translate.md
@@ -82,3 +82,13 @@ Window stride for spectrogram in seconds
 
 * **-window [hamming]** 
 Window type for spectrogram generation
+
+### **Score**:
+* **-report_bleu []**
+Report bleu score after translation by calling tools/multi-bleu.perl
+on command line.
+
+* **-report_rouge []**
+Report Report rouge 1/2/3/L/SU4 score after translation by calling
+tools/multi-bleu.perl on command line. Use pyrouge as backend. Scores may be
+slightly different with those by calling files2rouge.

--- a/opts.py
+++ b/opts.py
@@ -359,6 +359,10 @@ def translate_opts(parser):
     group.add_argument('-output', default='pred.txt',
                        help="""Path to output the predictions (each line will
                        be the decoded sequence""")
+    group.add_argument('-report_bleu', action='store_true',
+                       help="Report Bleu Score After Translation")
+    group.add_argument('-report_rouge', action='store_true',
+                       help="Report Rouge 1/2/3/L/SU4 Score After Translation")
 
     # Options most relevant to summarization.
     group.add_argument('-dynamic_dict', action='store_true',

--- a/opts.py
+++ b/opts.py
@@ -360,7 +360,7 @@ def translate_opts(parser):
                        help="""Path to output the predictions (each line will
                        be the decoded sequence""")
     group.add_argument('-report_bleu', action='store_true',
-                       help="""Report bleu score after translation, 
+                       help="""Report bleu score after translation,
                        call tools/multi-bleu.perl on command line""")
     group.add_argument('-report_rouge', action='store_true',
                        help="""Report rouge 1/2/3/L/SU4 score after translation

--- a/opts.py
+++ b/opts.py
@@ -360,9 +360,11 @@ def translate_opts(parser):
                        help="""Path to output the predictions (each line will
                        be the decoded sequence""")
     group.add_argument('-report_bleu', action='store_true',
-                       help="Report Bleu Score After Translation")
+                       help="""Report bleu score after translation, 
+                       call tools/multi-bleu.perl on command line""")
     group.add_argument('-report_rouge', action='store_true',
-                       help="Report Rouge 1/2/3/L/SU4 Score After Translation")
+                       help="""Report rouge 1/2/3/L/SU4 score after translation
+                       call tools/test_rouge.py on command line""")
 
     # Options most relevant to summarization.
     group.add_argument('-dynamic_dict', action='store_true',

--- a/requirements.opt.txt
+++ b/requirements.opt.txt
@@ -3,3 +3,4 @@ torchvision
 librosa
 Pillow
 git+https://github.com/pytorch/audio
+pyrouge

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ six
 tqdm
 torchtext==0.1.1
 future
-pyrouge

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ six
 tqdm
 torchtext==0.1.1
 future
+pyrouge

--- a/tools/test_rouge.py
+++ b/tools/test_rouge.py
@@ -1,0 +1,46 @@
+import argparse
+import os
+import time
+import pyrouge
+import shutil
+
+
+def test_rouge(cand_file, ref_file):
+    f_cand = open(cand_file, encoding="utf-8")
+    f_ref = open(ref_file, encoding="utf-8")
+    current_time = time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime())
+    tmp_dir = ".rouge-tmp-{}".format(current_time)
+    if not os.path.isdir(tmp_dir):
+        os.mkdir(tmp_dir)
+        os.mkdir(tmp_dir + "/candidate")
+        os.mkdir(tmp_dir + "/reference")
+    for i, line in enumerate(f_cand):
+        with open(tmp_dir + "/candidate/cand.{}.txt".format(str(i).zfill(3)), "w", encoding="utf-8") as f:
+            f.write(line)
+    for i, line in enumerate(f_ref):
+        with open(tmp_dir + "/reference/ref.{}.txt".format(str(i).zfill(3)), "w", encoding="utf-8") as f:
+            f.write(line)
+    f_cand.close()
+    f_ref.close()
+    r = pyrouge.Rouge155()
+    r.model_dir = tmp_dir + "/reference/"
+    r.system_dir = tmp_dir + "/candidate/"
+    r.model_filename_pattern = 'ref.#ID#.txt'
+    r.system_filename_pattern = 'cand.(\d+).txt'
+    rouge_results = r.convert_and_evaluate()
+    results_dict = r.output_to_dict(rouge_results)
+
+    shutil.rmtree(tmp_dir)
+    return results_dict
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-c', type=str, default="candidate.txt", help='candidate file')
+    parser.add_argument('-r', type=str, default="reference.txt", help='reference file')
+    args = parser.parse_args()
+    results_dict = test_rouge(args.c, args.r)
+    print(">> ROUGE(1/2/3/L/SU4): {:.2f}/{:.2f}/{:.2f}/{:.2f}/{:.2f}".format(
+        results_dict["rouge_1_f_score"] * 100, results_dict["rouge_2_f_score"] * 100,
+        results_dict["rouge_3_f_score"] * 100, results_dict["rouge_l_f_score"] * 100,
+        results_dict["rouge_su*_f_score"] * 100))

--- a/tools/test_rouge.py
+++ b/tools/test_rouge.py
@@ -15,10 +15,12 @@ def test_rouge(cand_file, ref_file):
         os.mkdir(tmp_dir + "/candidate")
         os.mkdir(tmp_dir + "/reference")
     for i, line in enumerate(f_cand):
-        with open(tmp_dir + "/candidate/cand.{}.txt".format(str(i).zfill(3)), "w", encoding="utf-8") as f:
+        with open(tmp_dir + "/candidate/cand.{}.txt".format(
+                str(i).zfill(3)), "w", encoding="utf-8") as f:
             f.write(line)
     for i, line in enumerate(f_ref):
-        with open(tmp_dir + "/reference/ref.{}.txt".format(str(i).zfill(3)), "w", encoding="utf-8") as f:
+        with open(tmp_dir + "/reference/ref.{}.txt".format(
+                str(i).zfill(3)), "w", encoding="utf-8") as f:
             f.write(line)
     f_cand.close()
     f_ref.close()
@@ -36,11 +38,15 @@ def test_rouge(cand_file, ref_file):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('-c', type=str, default="candidate.txt", help='candidate file')
-    parser.add_argument('-r', type=str, default="reference.txt", help='reference file')
+    parser.add_argument('-c', type=str, default="candidate.txt",
+                        help='candidate file')
+    parser.add_argument('-r', type=str, default="reference.txt",
+                        help='reference file')
     args = parser.parse_args()
     results_dict = test_rouge(args.c, args.r)
     print(">> ROUGE(1/2/3/L/SU4): {:.2f}/{:.2f}/{:.2f}/{:.2f}/{:.2f}".format(
-        results_dict["rouge_1_f_score"] * 100, results_dict["rouge_2_f_score"] * 100,
-        results_dict["rouge_3_f_score"] * 100, results_dict["rouge_l_f_score"] * 100,
+        results_dict["rouge_1_f_score"] * 100,
+        results_dict["rouge_2_f_score"] * 100,
+        results_dict["rouge_3_f_score"] * 100,
+        results_dict["rouge_l_f_score"] * 100,
         results_dict["rouge_su*_f_score"] * 100))

--- a/tools/test_rouge.py
+++ b/tools/test_rouge.py
@@ -1,3 +1,4 @@
+# -*- encoding: utf-8 -*-
 import argparse
 import os
 import time
@@ -10,30 +11,38 @@ def test_rouge(cand_file, ref_file):
     f_ref = open(ref_file, encoding="utf-8")
     current_time = time.strftime('%Y-%m-%d-%H-%M-%S', time.localtime())
     tmp_dir = ".rouge-tmp-{}".format(current_time)
-    if not os.path.isdir(tmp_dir):
-        os.mkdir(tmp_dir)
-        os.mkdir(tmp_dir + "/candidate")
-        os.mkdir(tmp_dir + "/reference")
-    for i, line in enumerate(f_cand):
-        with open(tmp_dir + "/candidate/cand.{}.txt".format(
-                str(i).zfill(3)), "w", encoding="utf-8") as f:
-            f.write(line)
-    for i, line in enumerate(f_ref):
-        with open(tmp_dir + "/reference/ref.{}.txt".format(
-                str(i).zfill(3)), "w", encoding="utf-8") as f:
-            f.write(line)
-    f_cand.close()
-    f_ref.close()
-    r = pyrouge.Rouge155()
-    r.model_dir = tmp_dir + "/reference/"
-    r.system_dir = tmp_dir + "/candidate/"
-    r.model_filename_pattern = 'ref.#ID#.txt'
-    r.system_filename_pattern = 'cand.(\d+).txt'
-    rouge_results = r.convert_and_evaluate()
-    results_dict = r.output_to_dict(rouge_results)
-
-    shutil.rmtree(tmp_dir)
-    return results_dict
+    try:
+        if not os.path.isdir(tmp_dir):
+            os.mkdir(tmp_dir)
+            os.mkdir(tmp_dir + "/candidate")
+            os.mkdir(tmp_dir + "/reference")
+        candidates = [line.strip() for line in f_cand]
+        references = [line.strip() for line in f_ref]
+        assert len(candidates) == len(references)
+        cnt = len(candidates)
+        for i in range(cnt):
+            if len(references[i]) < 1:
+                continue
+            with open(tmp_dir + "/candidate/cand.{}.txt".format(i), "w",
+                      encoding="utf-8") as f:
+                f.write(candidates[i])
+            with open(tmp_dir + "/reference/ref.{}.txt".format(i), "w",
+                      encoding="utf-8") as f:
+                f.write(references[i])
+        f_cand.close()
+        f_ref.close()
+        r = pyrouge.Rouge155()
+        r.model_dir = tmp_dir + "/reference/"
+        r.system_dir = tmp_dir + "/candidate/"
+        r.model_filename_pattern = 'ref.#ID#.txt'
+        r.system_filename_pattern = 'cand.(\d+).txt'
+        rouge_results = r.convert_and_evaluate()
+        results_dict = r.output_to_dict(rouge_results)
+        return results_dict
+    finally:
+        pass
+        if os.path.isdir(tmp_dir):
+            shutil.rmtree(tmp_dir)
 
 
 if __name__ == "__main__":

--- a/translate.py
+++ b/translate.py
@@ -111,15 +111,12 @@ def main():
         print(">> " + res.strip())
 
     def report_rouge():
-        from tools.test_rouge import test_rouge
-        results_dict = test_rouge(opt.output, opt.tgt)
-        print("\n>> ROUGE(1/2/3/L/SU4): "
-              "{:.2f}/{:.2f}/{:.2f}/{:.2f}/{:.2f}".format(
-                results_dict["rouge_1_f_score"] * 100,
-                results_dict["rouge_2_f_score"] * 100,
-                results_dict["rouge_3_f_score"] * 100,
-                results_dict["rouge_l_f_score"] * 100,
-                results_dict["rouge_su*_f_score"] * 100))
+        import subprocess
+        res = subprocess.check_output(
+            "python tools/test_rouge.py -r %s -c %s" % (opt.tgt, opt.output),
+            shell=True).decode("utf-8")
+        print(res.strip())
+
 
     report_score('PRED', pred_score_total, pred_words_total)
     if opt.tgt:

--- a/translate.py
+++ b/translate.py
@@ -25,6 +25,29 @@ opts.translate_opts(parser)
 opt = parser.parse_args()
 
 
+def _report_score(name, score_total, words_total):
+    print("%s AVG SCORE: %.4f, %s PPL: %.4f" % (
+        name, score_total / words_total,
+        name, math.exp(-score_total / words_total)))
+
+
+def _report_bleu():
+    import subprocess
+    print()
+    res = subprocess.check_output(
+        "perl tools/multi-bleu.perl %s < %s" % (opt.tgt, opt.output),
+        shell=True).decode("utf-8")
+    print(">> " + res.strip())
+
+
+def _report_rouge():
+    import subprocess
+    res = subprocess.check_output(
+        "python tools/test_rouge.py -r %s -c %s" % (opt.tgt, opt.output),
+        shell=True).decode("utf-8")
+    print(res.strip())
+
+
 def main():
     dummy_parser = argparse.ArgumentParser(description='train.py')
     opts.model_opts(dummy_parser)
@@ -97,33 +120,13 @@ def main():
                 output = trans.log(sent_number)
                 os.write(1, output.encode('utf-8'))
 
-    def report_score(name, score_total, words_total):
-        print("%s AVG SCORE: %.4f, %s PPL: %.4f" % (
-            name, score_total / words_total,
-            name, math.exp(-score_total/words_total)))
-
-    def report_bleu():
-        import subprocess
-        print()
-        res = subprocess.check_output(
-            "perl tools/multi-bleu.perl %s < %s" % (opt.tgt, opt.output),
-            shell=True).decode("utf-8")
-        print(">> " + res.strip())
-
-    def report_rouge():
-        import subprocess
-        res = subprocess.check_output(
-            "python tools/test_rouge.py -r %s -c %s" % (opt.tgt, opt.output),
-            shell=True).decode("utf-8")
-        print(res.strip())
-
-    report_score('PRED', pred_score_total, pred_words_total)
+    _report_score('PRED', pred_score_total, pred_words_total)
     if opt.tgt:
-        report_score('GOLD', gold_score_total, gold_words_total)
+        _report_score('GOLD', gold_score_total, gold_words_total)
         if opt.report_bleu:
-            report_bleu()
+            _report_bleu()
         if opt.report_rouge:
-            report_rouge()
+            _report_rouge()
 
     if opt.dump_beam:
         import json

--- a/translate.py
+++ b/translate.py
@@ -117,7 +117,6 @@ def main():
             shell=True).decode("utf-8")
         print(res.strip())
 
-
     report_score('PRED', pred_score_total, pred_words_total)
     if opt.tgt:
         report_score('GOLD', gold_score_total, gold_words_total)

--- a/translate.py
+++ b/translate.py
@@ -105,18 +105,21 @@ def main():
     def report_bleu():
         import subprocess
         print()
-        res = subprocess.check_output("perl tools/multi-bleu.perl %s < %s" % (opt.tgt, opt.output),
-                                      shell=True).decode("utf-8")
+        res = subprocess.check_output(
+            "perl tools/multi-bleu.perl %s < %s" % (opt.tgt, opt.output),
+            shell=True).decode("utf-8")
         print(">> " + res.strip())
 
     def report_rouge():
         from tools.test_rouge import test_rouge
         results_dict = test_rouge(opt.output, opt.tgt)
-        print("\n>> ROUGE(1/2/3/L/SU4): {:.2f}/{:.2f}/{:.2f}/{:.2f}/{:.2f}".format(
-            results_dict["rouge_1_f_score"] * 100, results_dict["rouge_2_f_score"] * 100,
-            results_dict["rouge_3_f_score"] * 100, results_dict["rouge_l_f_score"] * 100,
-            results_dict["rouge_su*_f_score"] * 100))
-        pass
+        print("\n>> ROUGE(1/2/3/L/SU4): "
+              "{:.2f}/{:.2f}/{:.2f}/{:.2f}/{:.2f}".format(
+                results_dict["rouge_1_f_score"] * 100,
+                results_dict["rouge_2_f_score"] * 100,
+                results_dict["rouge_3_f_score"] * 100,
+                results_dict["rouge_l_f_score"] * 100,
+                results_dict["rouge_su*_f_score"] * 100))
 
     report_score('PRED', pred_score_total, pred_words_total)
     if opt.tgt:

--- a/translate.py
+++ b/translate.py
@@ -102,9 +102,29 @@ def main():
             name, score_total / words_total,
             name, math.exp(-score_total/words_total)))
 
+    def report_bleu():
+        import subprocess
+        print()
+        res = subprocess.check_output("perl tools/multi-bleu.perl %s < %s" % (opt.tgt, opt.output),
+                                      shell=True).decode("utf-8")
+        print(">> " + res.strip())
+
+    def report_rouge():
+        from tools.test_rouge import test_rouge
+        results_dict = test_rouge(opt.output, opt.tgt)
+        print("\n>> ROUGE(1/2/3/L/SU4): {:.2f}/{:.2f}/{:.2f}/{:.2f}/{:.2f}".format(
+            results_dict["rouge_1_f_score"] * 100, results_dict["rouge_2_f_score"] * 100,
+            results_dict["rouge_3_f_score"] * 100, results_dict["rouge_l_f_score"] * 100,
+            results_dict["rouge_su*_f_score"] * 100))
+        pass
+
     report_score('PRED', pred_score_total, pred_words_total)
     if opt.tgt:
         report_score('GOLD', gold_score_total, gold_words_total)
+        if opt.report_bleu:
+            report_bleu()
+        if opt.report_rouge:
+            report_rouge()
 
     if opt.dump_beam:
         import json


### PR DESCRIPTION
Hi, I find it's tedious to run perl scripts to test bleu after I run ```python translate.py```,  and I also find the 'Example: Summarization' uses files2rouge, which cannot be set up in my python3 environment. So I insert ```report_bleu``` and ```report_rouge``` (which depends on pyrouge) into ```translate.py```. For testing rouge  I write a simple script(```tools/ test_rouge.py```) to use pyrouge. And the last thing is that I add -report_bleu & -report_rouge in ```opts.py```