### PR TITLE
Minimum prediction length at translation time

### DIFF
--- a/onmt/translate/Translator.py
+++ b/onmt/translate/Translator.py
@@ -27,7 +27,7 @@ class Translator(object):
                  beam_size, n_best=1,
                  max_length=100,
                  global_scorer=None, copy_attn=False, cuda=False,
-                 beam_trace=False):
+                 beam_trace=False, min_length=0):
         self.model = model
         self.fields = fields
         self.n_best = n_best
@@ -36,6 +36,7 @@ class Translator(object):
         self.copy_attn = copy_attn
         self.beam_size = beam_size
         self.cuda = cuda
+        self.min_length = min_length
 
         # for debugging
         self.beam_accum = None
@@ -72,7 +73,8 @@ class Translator(object):
                                     global_scorer=self.global_scorer,
                                     pad=vocab.stoi[onmt.io.PAD_WORD],
                                     eos=vocab.stoi[onmt.io.EOS_WORD],
-                                    bos=vocab.stoi[onmt.io.BOS_WORD])
+                                    bos=vocab.stoi[onmt.io.BOS_WORD],
+                                    min_length=self.min_length)
                 for __ in range(batch_size)]
 
         # Help functions for working with beams and batches

--- a/opts.py
+++ b/opts.py
@@ -375,6 +375,8 @@ def translate_opts(parser):
     group = parser.add_argument_group('Beam')
     group.add_argument('-beam_size',  type=int, default=5,
                        help='Beam size')
+    group.add_argument('-min_length', type=int, default=0,
+                        help='Minimum prediction length')
 
     # Alpha and Beta values for Google Length + Coverage penalty
     # Described here: https://arxiv.org/pdf/1609.08144.pdf, Section 7

--- a/opts.py
+++ b/opts.py
@@ -376,7 +376,11 @@ def translate_opts(parser):
     group.add_argument('-beam_size',  type=int, default=5,
                        help='Beam size')
     group.add_argument('-min_length', type=int, default=0,
-                        help='Minimum prediction length')
+                       help='Minimum prediction length')
+    group.add_argument('-max_length', type=int, default=100,
+                       help='Maximum prediction length.')
+    group.add_argument('-max_sent_length', action=DeprecateAction,
+                       help="Deprecated, use `-max_length` instead")
 
     # Alpha and Beta values for Google Length + Coverage penalty
     # Described here: https://arxiv.org/pdf/1609.08144.pdf, Section 7
@@ -385,8 +389,6 @@ def translate_opts(parser):
                         (higher = longer generation)""")
     group.add_argument('-beta', type=float, default=-0.,
                        help="""Coverage penalty parameter""")
-    group.add_argument('-max_sent_length', type=int, default=100,
-                       help='Maximum sentence length.')
     group.add_argument('-replace_unk', action="store_true",
                        help="""Replace the generated UNK tokens with the
                        source token that had highest attention weight. If

--- a/translate.py
+++ b/translate.py
@@ -87,7 +87,7 @@ def main():
                                            beam_size=opt.beam_size,
                                            n_best=opt.n_best,
                                            global_scorer=scorer,
-                                           max_length=opt.max_sent_length,
+                                           max_length=opt.max_length,
                                            copy_attn=model_opt.copy_attn,
                                            cuda=opt.cuda,
                                            beam_trace=opt.dump_beam != "",

--- a/translate.py
+++ b/translate.py
@@ -90,7 +90,8 @@ def main():
                                            max_length=opt.max_sent_length,
                                            copy_attn=model_opt.copy_attn,
                                            cuda=opt.cuda,
-                                           beam_trace=opt.dump_beam != "")
+                                           beam_trace=opt.dump_beam != "",
+                                           min_length=opt.min_length)
     builder = onmt.translate.TranslationBuilder(
         data, translator.fields,
         opt.n_best, opt.replace_unk, opt.tgt)


### PR DESCRIPTION
As we discussed in https://github.com/OpenNMT/OpenNMT-py/issues/457 we may want to force a minimum length for prediction by manually decreasing eos score for decoding step < min_length.

I set the option default on 0.