### PR TITLE
Fix preprocess sharding and implement train side lazy dataset load

### DIFF
--- a/onmt/Trainer.py
+++ b/onmt/Trainer.py
@@ -199,6 +199,9 @@ class Trainer(object):
                 self.optim.step()
 
         for i, batch_ in enumerate(self.train_iter):
+            cur_dataset = self.train_iter.get_cur_dataset()
+            self.train_loss.cur_dataset = cur_dataset
+
             truebatch.append(batch_)
             accum += 1
             if self.normalization is "tokens":
@@ -243,6 +246,9 @@ class Trainer(object):
         stats = Statistics()
 
         for batch in self.valid_iter:
+            cur_dataset = self.valid_iter.get_cur_dataset()
+            self.valid_loss.cur_dataset = cur_dataset
+
             src = onmt.io.make_features(batch, 'src', self.data_type)
             if self.data_type == 'text':
                 _, src_lengths = batch.src

--- a/onmt/io/DatasetBase.py
+++ b/onmt/io/DatasetBase.py
@@ -46,23 +46,9 @@ class ONMTDatasetBase(torchtext.data.Dataset):
         self.fields = dict([(k, f) for (k, f) in fields.items()
                            if k in self.examples[0].__dict__])
 
-    def collapse_copy_scores(self, scores, batch, tgt_vocab):
-        """
-        Given scores from an expanded dictionary
-        corresponeding to a batch, sums together copies,
-        with a dictionary word when it is ambigious.
-        """
-        offset = len(tgt_vocab)
-        for b in range(batch.batch_size):
-            index = batch.indices.data[b]
-            src_vocab = self.src_vocabs[index]
-            for i in range(1, len(src_vocab)):
-                sw = src_vocab.itos[i]
-                ti = tgt_vocab.stoi[sw]
-                if ti != 0:
-                    scores[:, b, ti] += scores[:, b, offset + i]
-                    scores[:, b, offset + i].fill_(1e-20)
-        return scores
+    def get_src_vocabs(self):
+        # Only when src side is in text form, dataset has `src_vocabs`.
+        return getattr(self, 'src_vocabs', None)
 
     @staticmethod
     def coalesce_datasets(datasets):

--- a/onmt/io/DatasetBase.py
+++ b/onmt/io/DatasetBase.py
@@ -46,10 +46,6 @@ class ONMTDatasetBase(torchtext.data.Dataset):
         self.fields = dict([(k, f) for (k, f) in fields.items()
                            if k in self.examples[0].__dict__])
 
-    def get_src_vocabs(self):
-        # Only when src side is in text form, dataset has `src_vocabs`.
-        return getattr(self, 'src_vocabs', None)
-
     @staticmethod
     def coalesce_datasets(datasets):
         """Coalesce all dataset instances. """

--- a/onmt/io/IO.py
+++ b/onmt/io/IO.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from collections import Counter, defaultdict
+from collections import Counter, defaultdict, OrderedDict
 from itertools import count
 
 import torch
@@ -216,12 +216,21 @@ def build_dataset(fields, data_type, src_path, tgt_path, src_dir=None,
     return dataset
 
 
-def build_vocab(train_datasets, data_type, share_vocab,
+def _build_field_vocab(field, counter, **kwargs):
+    specials = list(OrderedDict.fromkeys(
+        tok for tok in [field.unk_token, field.pad_token, field.init_token,
+                        field.eos_token]
+        if tok is not None))
+    field.vocab = field.vocab_cls(counter, specials=specials, **kwargs)
+
+
+def build_vocab(train_dataset_files, fields, data_type, share_vocab,
                 src_vocab_size, src_words_min_frequency,
                 tgt_vocab_size, tgt_words_min_frequency):
     """
     Args:
-        train_datasets: a list of train dataset.
+        train_dataset_files: a list of train dataset pt file.
+        fields (dict): fields to build vocab for.
         data_type: "text", "img" or "audio"?
         share_vocab(bool): share source and target vocabulary?
         src_vocab_size(int): size of the source vocabulary.
@@ -234,23 +243,48 @@ def build_vocab(train_datasets, data_type, share_vocab,
     Returns:
         Dict of Fields
     """
-    # All datasets have same fields, get the first one is OK.
-    fields = train_datasets[0].fields
+    counter = {}
+    for k in fields:
+        counter[k] = Counter()
 
-    fields["tgt"].build_vocab(*train_datasets, max_size=tgt_vocab_size,
-                              min_freq=tgt_words_min_frequency)
-    for j in range(train_datasets[0].n_tgt_feats):
-        fields["tgt_feat_" + str(j)].build_vocab(*train_datasets)
+    for path in train_dataset_files:
+        dataset = torch.load(path)
+        for ex in dataset.examples:
+            for k in fields:
+                val = getattr(ex, k, None)
+                if val is not None and not fields[k].sequential:
+                    val = [val]
+                    counter[k].update(val)
+
+    _build_field_vocab(fields["tgt"], counter["tgt"],
+                       max_size=tgt_vocab_size,
+                       min_freq=tgt_words_min_frequency)
+    print(" * tgt vocab size: %d." % len(fields["tgt"].vocab))
+
+    # All datasets have same num of n_tgt_features,
+    # getting the last one is OK.
+    for j in range(dataset.n_tgt_feats):
+        key = "tgt_feat_" + str(j)
+        _build_field_vocab(fields[key], counter[key])
+        print(" * %s vocab size: %d." % (key, len(fields[key].vocab)))
 
     if data_type == 'text':
-        fields["src"].build_vocab(*train_datasets, max_size=src_vocab_size,
-                                  min_freq=src_words_min_frequency)
-        for j in range(train_datasets[0].n_src_feats):
-            fields["src_feat_" + str(j)].build_vocab(*train_datasets)
+        _build_field_vocab(fields["src"], counter["src"],
+                           max_size=src_vocab_size,
+                           min_freq=src_words_min_frequency)
+        print(" * src vocab size: %d." % len(fields["src"].vocab))
+
+        # All datasets have same num of n_src_features,
+        # getting the last one is OK.
+        for j in range(dataset.n_src_feats):
+            key = "src_feat_" + str(j)
+            _build_field_vocab(fields[key], counter[key])
+            print(" * %s vocab size: %d." % (key, len(fields[key].vocab)))
 
         # Merge the input and output vocabularies.
         if share_vocab:
             # `tgt_vocab_size` is ignored when sharing vocabularies
+            print(" * merging src and tgt vocab...")
             merged_vocab = merge_vocabs(
                 [fields["src"].vocab, fields["tgt"].vocab],
                 vocab_size=src_vocab_size)

--- a/onmt/modules/CopyGenerator.py
+++ b/onmt/modules/CopyGenerator.py
@@ -135,12 +135,12 @@ class CopyGeneratorLossCompute(onmt.Loss.LossComputeBase):
     """
     Copy Generator Loss Computation.
     """
-    def __init__(self, generator, tgt_vocab, dataset,
+    def __init__(self, generator, tgt_vocab, src_vocabs,
                  force_copy, eps=1e-20):
         super(CopyGeneratorLossCompute, self).__init__(
             generator, tgt_vocab)
 
-        self.dataset = dataset
+        self.src_vocabs = src_vocabs
         self.force_copy = force_copy
         self.criterion = CopyGeneratorCriterion(len(tgt_vocab), force_copy,
                                                 self.padding_idx)
@@ -177,9 +177,9 @@ class CopyGeneratorLossCompute(onmt.Loss.LossComputeBase):
         loss = self.criterion(scores, align, target)
 
         scores_data = scores.data.clone()
-        scores_data = self.dataset.collapse_copy_scores(
+        scores_data = onmt.io.TextDataset.collapse_copy_scores(
                 self._unbottle(scores_data, batch.batch_size),
-                batch, self.tgt_vocab)
+                batch, self.tgt_vocab, self.src_vocabs)
         scores_data = self._bottle(scores_data)
 
         # Correct target copy token instead of <unk>

--- a/onmt/modules/CopyGenerator.py
+++ b/onmt/modules/CopyGenerator.py
@@ -135,12 +135,14 @@ class CopyGeneratorLossCompute(onmt.Loss.LossComputeBase):
     """
     Copy Generator Loss Computation.
     """
-    def __init__(self, generator, tgt_vocab, src_vocabs,
+    def __init__(self, generator, tgt_vocab,
                  force_copy, eps=1e-20):
         super(CopyGeneratorLossCompute, self).__init__(
             generator, tgt_vocab)
 
-        self.src_vocabs = src_vocabs
+        # We lazily load datasets when there are more than one, so postpone
+        # the setting of cur_dataset.
+        self.cur_dataset = None
         self.force_copy = force_copy
         self.criterion = CopyGeneratorCriterion(len(tgt_vocab), force_copy,
                                                 self.padding_idx)
@@ -179,7 +181,7 @@ class CopyGeneratorLossCompute(onmt.Loss.LossComputeBase):
         scores_data = scores.data.clone()
         scores_data = onmt.io.TextDataset.collapse_copy_scores(
                 self._unbottle(scores_data, batch.batch_size),
-                batch, self.tgt_vocab, self.src_vocabs)
+                batch, self.tgt_vocab, self.cur_dataset.src_vocabs)
         scores_data = self._bottle(scores_data)
 
         # Correct target copy token instead of <unk>

--- a/test/test_preprocess.py
+++ b/test/test_preprocess.py
@@ -39,9 +39,9 @@ class TestData(unittest.TestCase):
     def dataset_build(self, opt):
         fields = onmt.io.get_fields("text", 0, 0)
 
-        trains = preprocess.build_save_dataset('train', fields, opt)
+        train_data_files = preprocess.build_save_dataset('train', fields, opt)
 
-        preprocess.build_save_vocab(trains, opt)
+        preprocess.build_save_vocab(train_data_files, fields, opt)
 
         preprocess.build_save_dataset('valid', fields, opt)
 

--- a/train.py
+++ b/train.py
@@ -133,7 +133,7 @@ def make_valid_data_iter(valid_dataset, opt):
                 train=False, sort=False, sort_within_batch=True)
 
 
-def make_loss_compute(model, tgt_vocab, dataset, opt):
+def make_loss_compute(model, tgt_vocab, src_vocabs, opt):
     """
     This returns user-defined LossCompute object, which is used to
     compute loss in train/validate process. You can implement your
@@ -141,7 +141,7 @@ def make_loss_compute(model, tgt_vocab, dataset, opt):
     """
     if opt.copy_attn:
         compute = onmt.modules.CopyGeneratorLossCompute(
-            model.generator, tgt_vocab, dataset, opt.copy_attn_force)
+            model.generator, tgt_vocab, src_vocabs, opt.copy_attn_force)
     else:
         compute = onmt.Loss.NMTLossCompute(
             model.generator, tgt_vocab,
@@ -160,9 +160,9 @@ def train_model(model, train_dataset, valid_dataset,
     valid_iter = make_valid_data_iter(valid_dataset, opt)
 
     train_loss = make_loss_compute(model, fields["tgt"].vocab,
-                                   train_dataset, opt)
+                                   train_dataset.get_src_vocabs(), opt)
     valid_loss = make_loss_compute(model, fields["tgt"].vocab,
-                                   valid_dataset, opt)
+                                   valid_dataset.get_src_vocabs(), opt)
 
     trunc_size = opt.truncated_decoder  # Badly named...
     shard_size = opt.max_generator_batches

--- a/train.py
+++ b/train.py
@@ -135,6 +135,13 @@ class DatasetLazyIter(object):
                 for batch in self.cur_iter:
                     yield batch
 
+    def __len__(self):
+        # We return the len of cur_dataset, otherwise we need to load
+        # all datasets to determine the real len, which loses the benefit
+        # of lazy loading.
+        assert self.cur_iter is not None
+        return len(self.cur_iter)
+
     def get_cur_dataset(self):
         return self.cur_dataset
 

--- a/train.py
+++ b/train.py
@@ -7,6 +7,7 @@ import glob
 import os
 import sys
 import random
+from itertools import chain
 
 import torch
 import torch.nn as nn
@@ -97,43 +98,85 @@ def report_func(epoch, batch, num_batches,
     return report_stats
 
 
-def make_train_data_iter(train_dataset, opt):
+class DatasetLazyIter(object):
+    """ An Ordered Dataset Iterator, supporting multiple datasets,
+        and lazy loading.
+
+    Args:
+        datsets (list): a list of datasets, which are lazily loaded.
+        fields (dict): fields dict for the datasets.
+        batch_size (int): batch size.
+        batch_size_fn: custom batch process function.
+        device: the GPU device.
+        is_train (bool): train or valid?
     """
-    This returns user-defined train data iterator for the trainer
+    def __init__(self, datasets, fields, batch_size, batch_size_fn,
+                 device, is_train):
+        self.datasets = datasets
+        self.fields = fields
+        self.batch_size = batch_size
+        self.batch_size_fn = batch_size_fn
+        self.device = device
+        self.is_train = is_train
+
+        self.cur_iter = self._next_dataset_iterator()
+        # We have at least one dataset.
+        assert self.cur_iter is not None
+
+    def __iter__(self):
+        try:
+            for batch in self.cur_iter:
+                yield batch
+        except StopIteration:
+            self.cur_iter = self._next_dataset_iterator()
+            if self.cur_iter is None:
+                raise StopIteration
+            else:
+                for batch in self.cur_iter:
+                    yield batch
+
+    def get_cur_dataset(self):
+        return self.cur_dataset
+
+    def _next_dataset_iterator(self):
+        try:
+            self.cur_dataset = next(self.datasets)
+        except StopIteration:
+            return None
+
+        # We clear `fields` when saving, restore when loading.
+        self.cur_dataset.fields = self.fields
+
+        # Sort batch by decreasing lengths of sentence required by pytorch.
+        # sort=False means "Use dataset's sortkey instead of iterator's".
+        return onmt.io.OrderedIterator(
+                dataset=self.cur_dataset, batch_size=self.batch_size,
+                batch_size_fn=self.batch_size_fn,
+                device=self.device, train=self.is_train,
+                sort=False, sort_within_batch=True,
+                repeat=False)
+
+
+def make_dataset_iter(datasets, fields, opt, is_train=True):
+    """
+    This returns user-defined train/validate data iterator for the trainer
     to iterate over during each train epoch. We implement simple
     ordered iterator strategy here, but more sophisticated strategy
     like curriculum learning is ok too.
     """
-    # Sort batch by decreasing lengths of sentence required by pytorch.
-    # sort=False means "Use dataset's sortkey instead of iterator's".
+    batch_size = opt.batch_size if is_train else opt.valid_batch_size
     batch_size_fn = None
-    if opt.batch_type == "tokens":
+    if is_train and opt.batch_type == "tokens":
         def batch_size_fn(new, count, sofar):
             return sofar + len(new.tgt) + 1
 
-    return onmt.io.OrderedIterator(
-                dataset=train_dataset, batch_size=opt.batch_size,
-                batch_size_fn=batch_size_fn,
-                device=opt.gpuid[0] if opt.gpuid else -1,
-                sort=False, sort_within_batch=True, repeat=False)
+    device = opt.gpuid[0] if opt.gpuid else -1
+
+    return DatasetLazyIter(datasets, fields, batch_size, batch_size_fn,
+                           device, is_train)
 
 
-def make_valid_data_iter(valid_dataset, opt):
-    """
-    This returns user-defined validate data iterator for the trainer
-    to iterate over during each validate epoch. We implement simple
-    ordered iterator strategy here, but more sophisticated strategy
-    is ok too.
-    """
-    # Sort batch by decreasing lengths of sentence required by pytorch.
-    # sort=False means "Use dataset's sortkey instead of iterator's".
-    return onmt.io.OrderedIterator(
-                dataset=valid_dataset, batch_size=opt.valid_batch_size,
-                device=opt.gpuid[0] if opt.gpuid else -1,
-                train=False, sort=False, sort_within_batch=True)
-
-
-def make_loss_compute(model, tgt_vocab, src_vocabs, opt):
+def make_loss_compute(model, tgt_vocab, opt):
     """
     This returns user-defined LossCompute object, which is used to
     compute loss in train/validate process. You can implement your
@@ -141,7 +184,7 @@ def make_loss_compute(model, tgt_vocab, src_vocabs, opt):
     """
     if opt.copy_attn:
         compute = onmt.modules.CopyGeneratorLossCompute(
-            model.generator, tgt_vocab, src_vocabs, opt.copy_attn_force)
+            model.generator, tgt_vocab, opt.copy_attn_force)
     else:
         compute = onmt.Loss.NMTLossCompute(
             model.generator, tgt_vocab,
@@ -153,20 +196,18 @@ def make_loss_compute(model, tgt_vocab, src_vocabs, opt):
     return compute
 
 
-def train_model(model, train_dataset, valid_dataset,
-                fields, optim, model_opt):
+def train_model(model, train_datasets, valid_datasets,
+                fields, optim, data_type, model_opt):
 
-    train_iter = make_train_data_iter(train_dataset, opt)
-    valid_iter = make_valid_data_iter(valid_dataset, opt)
+    train_iter = make_dataset_iter(train_datasets, fields, opt)
+    valid_iter = make_dataset_iter(valid_datasets, fields, opt,
+                                   is_train=False)
 
-    train_loss = make_loss_compute(model, fields["tgt"].vocab,
-                                   train_dataset.get_src_vocabs(), opt)
-    valid_loss = make_loss_compute(model, fields["tgt"].vocab,
-                                   valid_dataset.get_src_vocabs(), opt)
+    train_loss = make_loss_compute(model, fields["tgt"].vocab, opt)
+    valid_loss = make_loss_compute(model, fields["tgt"].vocab, opt)
 
     trunc_size = opt.truncated_decoder  # Badly named...
     shard_size = opt.max_generator_batches
-    data_type = train_dataset.data_type
 
     trainer = onmt.Trainer(model, train_iter, valid_iter,
                            train_loss, valid_loss, optim,
@@ -220,45 +261,43 @@ def tally_parameters(model):
     print('decoder: ', dec)
 
 
-def load_dataset(data_type):
-    assert data_type in ["train", "valid"]
+def lazily_load_dataset(corpus_type):
+    """
+    Dataset generator. Don't do extra stuff here, like printing,
+    because they will be postponed to the first loading time.
 
-    print("Loading %s data from '%s'" % (data_type, opt.data))
+    Args:
+        corpus_type: 'train' or 'valid'
+    Returns:
+        A list of dataset, the dataset(s) are lazily loaded.
+    """
+    assert corpus_type in ["train", "valid"]
 
-    pts = glob.glob(opt.data + '.' + data_type + '.[0-9]*.pt')
+    def lazy_dataset_loader(pt_file, corpus_type):
+        dataset = torch.load(pt_file)
+        print('Loading %s dataset from %s, number of examples: %d' %
+              (corpus_type, pt_file, len(dataset)))
+        return dataset
+
+    # Sort the glob output by file name (by increasing indexes).
+    pts = sorted(glob.glob(opt.data + '.' + corpus_type + '.[0-9]*.pt'))
     if pts:
-        # Multiple onmt.io.*Dataset's, coalesce all.
-        # torch.load loads them imemediately, which might eat up
-        # too much memory. A lazy load would be better, but later
-        # when we create data iterator, it still requires these
-        # data to be loaded. So it seams we don't have a good way
-        # to avoid this now.
-        datasets = []
         for pt in pts:
-            datasets.append(torch.load(pt))
-        dataset = onmt.io.ONMTDatasetBase.coalesce_datasets(datasets)
+            yield lazy_dataset_loader(pt, corpus_type)
     else:
         # Only one onmt.io.*Dataset, simple!
-        dataset = torch.load(opt.data + '.' + data_type + '.pt')
-
-    print(' * number of %s sentences: %d' % (data_type, len(dataset)))
-
-    return dataset
+        pt = opt.data + '.' + corpus_type + '.pt'
+        yield lazy_dataset_loader(pt, corpus_type)
 
 
-def load_fields(train_dataset, valid_dataset, checkpoint):
-    data_type = train_dataset.data_type
+def load_fields(dataset, data_type, checkpoint):
 
     fields = onmt.io.load_fields_from_vocab(
                 torch.load(opt.data + '.vocab.pt'), data_type)
     fields = dict([(k, f) for (k, f) in fields.items()
-                  if k in train_dataset.examples[0].__dict__])
+                  if k in dataset.examples[0].__dict__])
 
-    # We save fields in vocab.pt, so assign them back to dataset here.
-    train_dataset.fields = fields
-    valid_dataset.fields = fields
-
-    if opt.train_from:
+    if checkpoint is not None:
         print('Loading vocab from checkpoint at %s.' % opt.train_from)
         fields = onmt.io.load_fields_from_vocab(
                     checkpoint['vocab'], data_type)
@@ -302,7 +341,6 @@ def build_optim(model, checkpoint):
         optim.optimizer.load_state_dict(
             checkpoint['optim'].optimizer.state_dict())
     else:
-        # what members of opt does Optim need?
         optim = onmt.Optim(
             opt.optim, opt.learning_rate, opt.max_grad_norm,
             lr_decay=opt.learning_rate_decay,
@@ -321,10 +359,17 @@ def build_optim(model, checkpoint):
 
 def main():
 
-    # Load train and validate data.
-    train_dataset = load_dataset("train")
-    valid_dataset = load_dataset("valid")
+    # Lazily load a list of train/validate dataset.
+    print("Lazily loading train/validate datasets from '%s'" % opt.data)
+    train_datasets = lazily_load_dataset("train")
+    valid_datasets = lazily_load_dataset("valid")
     print(' * maximum batch size: %d' % opt.batch_size)
+
+    # Peek the fisrt dataset to determine the data_type.
+    # (This will load the first dataset.)
+    first_dataset = next(train_datasets)
+    train_datasets = chain([first_dataset], train_datasets)
+    data_type = first_dataset.data_type
 
     # Load checkpoint if we resume from a previous training.
     if opt.train_from:
@@ -339,7 +384,7 @@ def main():
         model_opt = opt
 
     # Load fields generated from preprocess phase.
-    fields = load_fields(train_dataset, valid_dataset, checkpoint)
+    fields = load_fields(first_dataset, data_type, checkpoint)
 
     # Report src/tgt features.
     collect_report_features(fields)
@@ -353,7 +398,8 @@ def main():
     optim = build_optim(model, checkpoint)
 
     # Do training.
-    train_model(model, train_dataset, valid_dataset, fields, optim, model_opt)
+    train_model(model, train_datasets, valid_datasets,
+                fields, optim, data_type, model_opt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

This PR is supposed to supersede #504.

It does two things:

 - fix the preprocess sharding memory issue, as is done in #504.
 - implement train side lazy dataset load, but keeping the interface as the same, and making the code easy to read.

**Changes for train side lazy dataset load:**

- `load_dataset()`  now actually just return dataset lazy loader, and dataset is loaded when really needed.
- `load_fields()` now literally loads `fields`, setting it to dataset is postponed to the point when dataset is loaded.
- A new `make_dataset_iter()`, which hides the facts of multiple datasets , and lazily load dataset and creates `DatasetLazyIter` for each dataset.
- `Trainer` code is almost the same as old, except:
  - `train_loss/valid_loss`'s `dataset` attribute is also lazily set to current dataset on each iteration.