### PR TITLE
Speedup for copy_attn

### DIFF
--- a/onmt/ModelConstructor.py
+++ b/onmt/ModelConstructor.py
@@ -97,7 +97,8 @@ def make_decoder(opt, embeddings):
                                    opt.context_gate,
                                    opt.copy_attn,
                                    opt.dropout,
-                                   embeddings)
+                                   embeddings,
+                                   opt.reuse_attn)
     else:
         return StdRNNDecoder(opt.rnn_type, opt.brnn,
                              opt.dec_layers, opt.rnn_size,
@@ -106,7 +107,8 @@ def make_decoder(opt, embeddings):
                              opt.context_gate,
                              opt.copy_attn,
                              opt.dropout,
-                             embeddings)
+                             embeddings,
+                             opt.reuse_attn)
 
 
 def load_test_model(opt, dummy_opt):

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -190,7 +190,8 @@ class RNNDecoderBase(nn.Module):
     def __init__(self, rnn_type, bidirectional_encoder, num_layers,
                  hidden_size, attn_type="general",
                  coverage_attn=False, context_gate=None,
-                 copy_attn=False, dropout=0.0, embeddings=None):
+                 copy_attn=False, dropout=0.0, embeddings=None,
+                 reuse_attn=False):
         super(RNNDecoderBase, self).__init__()
 
         # Basic attributes.
@@ -222,11 +223,13 @@ class RNNDecoderBase(nn.Module):
 
         # Set up a separated copy attention layer, if needed.
         self._copy = False
-        if copy_attn:
+        if copy_attn and not reuse_attn:
             self.copy_attn = onmt.modules.GlobalAttention(
                 hidden_size, attn_type=attn_type
             )
+        if copy_attn:
             self._copy = True
+        self._reuse_attn = reuse_attn
 
     def forward(self, input, context, state, context_lengths=None):
         """
@@ -480,11 +483,12 @@ class InputFeedRNNDecoder(RNNDecoderBase):
                 attns["coverage"] += [coverage]
 
             # Run the forward pass of the copy attention layer.
-            if self._copy:
+            if self._copy and not self._reuse_attn:
                 _, copy_attn = self.copy_attn(output,
                                               context.transpose(0, 1))
                 attns["copy"] += [copy_attn]
-
+            elif self._copy:
+                attns["copy"] = attns["std"]
         # Return result.
         return hidden, outputs, attns, coverage
 

--- a/onmt/io/TextDataset.py
+++ b/onmt/io/TextDataset.py
@@ -97,14 +97,21 @@ class TextDataset(ONMTDatasetBase):
         """
         offset = len(tgt_vocab)
         for b in range(batch.batch_size):
+            blank = []
+            fill = []
             index = batch.indices.data[b]
             src_vocab = src_vocabs[index]
             for i in range(1, len(src_vocab)):
                 sw = src_vocab.itos[i]
                 ti = tgt_vocab.stoi[sw]
                 if ti != 0:
-                    scores[:, b, ti] += scores[:, b, offset + i]
-                    scores[:, b, offset + i].fill_(1e-20)
+                    blank.append(offset + i)
+                    fill.append(ti)
+            blank = torch.LongTensor(blank).cuda()
+            fill = torch.LongTensor(fill).cuda()
+            scores[:, b].index_add_(1, fill,
+                                    scores[:, b].index_select(1, blank))
+            scores[:, b].index_fill_(1, blank, 1e-10)
         return scores
 
     @staticmethod

--- a/onmt/io/TextDataset.py
+++ b/onmt/io/TextDataset.py
@@ -107,8 +107,8 @@ class TextDataset(ONMTDatasetBase):
                 if ti != 0:
                     blank.append(offset + i)
                     fill.append(ti)
-            blank = torch.LongTensor(blank).cuda()
-            fill = torch.LongTensor(fill).cuda()
+            blank = torch.cuda.LongTensor(blank)
+            fill = torch.cuda.LongTensor(fill)
             scores[:, b].index_add_(1, fill,
                                     scores[:, b].index_select(1, blank))
             scores[:, b].index_fill_(1, blank, 1e-10)

--- a/opts.py
+++ b/opts.py
@@ -108,6 +108,8 @@ def model_opts(parser):
                        help='Train copy attention layer.')
     group.add_argument('-copy_attn_force', action="store_true",
                        help='When available, train to copy.')
+    group.add_argument('-reuse_attn', action="store_true",
+                       help="Reuse standard attention for copy")
     group.add_argument('-coverage_attn', action="store_true",
                        help='Train a coverage attention layer.')
     group.add_argument('-lambda_coverage', type=float, default=1,


### PR DESCRIPTION
This PR implements two different possible speedups for copy attention (thanks, @srush for the initial code). 

The first one is a replacement for `collapse_copy_scores()` in `TextDataset.py`. In my tests, it does not change performance at all while being ~20% faster. 
__Note__: As of right now, this change causes `copy_attention` to require a cuda device. Since neither the Dataset class nor the functions that call `collapse_copy_scores` know whether the code is executed on a cuda device, adding a gpu parameter would require changes to multiple classes. Another option, albeit less beautiful, would be to wrap the `index_select` call in a try-except block that converts the tensor to a normal LongTensor. 

The second change introduces the flag `-reuse_attn` which causes the standard attention to be reused for copying instead of using a separate attention object. I did not exhaustively test this option yet, but initial convergence numbers are very similar to the normal method while being more than 50%! faster. 