### PR TITLE
Adding comments to copyCriterion and introduce option for more advanced copy loss

### DIFF
--- a/onmt/Loss.py
+++ b/onmt/Loss.py
@@ -110,8 +110,6 @@ class LossComputeBase(nn.Module):
           trunc_size (int) : length of truncation window
           shard_size (int) : maximum number of examples in a shard
           normalization (int) : Loss is divided by this number
-          tgt_lens (:obj: `LongTensor`) :
-              lengths of the targets in batch [batch_size]
 
         Returns:
             :obj:`onmt.Statistics`: validation loss statistics
@@ -120,8 +118,10 @@ class LossComputeBase(nn.Module):
         batch_stats = onmt.Statistics()
         range_ = (cur_trunc, cur_trunc + trunc_size)
         shard_state = self._make_shard_state(batch, output, range_, attns)
+
         for shard in shards(shard_state, shard_size):
             loss, stats = self._compute_loss(batch, **shard)
+
             loss.div(normalization).backward()
             batch_stats.update(stats)
 

--- a/opts.py
+++ b/opts.py
@@ -110,6 +110,8 @@ def model_opts(parser):
                        help='When available, train to copy.')
     group.add_argument('-reuse_copy_attn', action="store_true",
                        help="Reuse standard attention for copy")
+    group.add_argument('-copy_loss_by_seqlength', action="store_true",
+                       help="Divide copy loss by length of sequence")
     group.add_argument('-coverage_attn', action="store_true",
                        help='Train a coverage attention layer.')
     group.add_argument('-lambda_coverage', type=float, default=1,

--- a/train.py
+++ b/train.py
@@ -185,7 +185,8 @@ def make_loss_compute(model, tgt_vocab, opt):
     """
     if opt.copy_attn:
         compute = onmt.modules.CopyGeneratorLossCompute(
-            model.generator, tgt_vocab, opt.copy_attn_force)
+            model.generator, tgt_vocab, opt.copy_attn_force,
+            opt.copy_loss_by_seqlength)
     else:
         compute = onmt.Loss.NMTLossCompute(
             model.generator, tgt_vocab,


### PR DESCRIPTION
The main part of this PR introduces an option `copy_loss_by_seqlength` which changes the behavior of the loss when using `copy_attention`.

Normally we are computing the loss per token in a batch (zeroing out padding). Then the loss was computed as the average loss per batch. So, if the `loss` is a tensor with all individual token losses, the total loss is computed as
    `loss.sum().div(batch_size)`

With `copy_loss_by_seqlength`, the loss is computed such that the loss is first divided by the length of its sequence. Let `loss` be a `batchsize x seqlength` tensor and `tgt_lengths` the actual lengths in the target without padding. Then, the loss is computed as 
`loss.div(tgt_lengths).sum().div(batch_size)`.

Example: 

Loss:

| 1  | 2 |
| ------------- | ------------- |
| 1  | 0  |

tgt_lengths:

| 2 |
| ------------- |
| 1  | 

Before:

4 / 2 = 2

After:

((3/2)+(1/1)) / 2 = 1.25

Since this method leads to a lower total loss per batch, so learning rates have to be adjusted. 

I also included some organization of the code for the copy criterion in this PR to add comments and make the code more readable. 