### PR TITLE
Fixes to the transformer model

### DIFF
--- a/onmt/Loss.py
+++ b/onmt/Loss.py
@@ -159,7 +159,6 @@ class NMTLossCompute(LossComputeBase):
                  label_smoothing=0.0):
         super(NMTLossCompute, self).__init__(generator, tgt_vocab)
         assert (label_smoothing >= 0.0 and label_smoothing <= 1.0)
-
         if label_smoothing > 0:
             # When label smoothing is turned on,
             # KL-divergence between q_{smoothed ground truth prob.}(w)
@@ -191,18 +190,17 @@ class NMTLossCompute(LossComputeBase):
         if self.confidence < 1:
             tdata = gtruth.data
             mask = torch.nonzero(tdata.eq(self.padding_idx)).squeeze()
-            likelihood = torch.gather(scores.data, 1, tdata.unsqueeze(1))
+            log_likelihood = torch.gather(scores.data, 1, tdata.unsqueeze(1))
             tmp_ = self.one_hot.repeat(gtruth.size(0), 1)
             tmp_.scatter_(1, tdata.unsqueeze(1), self.confidence)
             if mask.dim() > 0:
-                likelihood.index_fill_(0, mask, 0)
+                log_likelihood.index_fill_(0, mask, 0)
                 tmp_.index_fill_(0, mask, 0)
             gtruth = Variable(tmp_, requires_grad=False)
 
         loss = self.criterion(scores, gtruth)
         if self.confidence < 1:
             loss_data = loss.data.clone()
-            # loss_data = - likelihood.sum(0)
         else:
             loss_data = loss.data.clone()
 

--- a/onmt/Loss.py
+++ b/onmt/Loss.py
@@ -201,7 +201,8 @@ class NMTLossCompute(LossComputeBase):
 
         loss = self.criterion(scores, gtruth)
         if self.confidence < 1:
-            loss_data = - likelihood.sum(0)
+            loss_data = loss.data.clone()
+            # loss_data = - likelihood.sum(0)
         else:
             loss_data = loss.data.clone()
 

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -611,8 +611,13 @@ class DecoderState(object):
 
     def beam_update(self, idx, positions, beam_size):
         for e in self._all:
-            a, br, d = e.size()
-            sent_states = e.view(a, beam_size, br // beam_size, d)[:, :, idx]
+            sizes = e.size()
+            br = sizes[1]
+            if len(sizes) == 3:
+                sent_states = e.view(sizes[0], beam_size, br // beam_size, sizes[2])[:, :, idx]
+            else:
+                sent_states = e.view(sizes[0], beam_size, br // beam_size, sizes[2], sizes[3])[:, :, idx]
+
             sent_states.data.copy_(
                 sent_states.data.index_select(1, positions))
 

--- a/onmt/Models.py
+++ b/onmt/Models.py
@@ -614,9 +614,13 @@ class DecoderState(object):
             sizes = e.size()
             br = sizes[1]
             if len(sizes) == 3:
-                sent_states = e.view(sizes[0], beam_size, br // beam_size, sizes[2])[:, :, idx]
+                sent_states = e.view(sizes[0], beam_size, br // beam_size,
+                                     sizes[2])[:, :, idx]
             else:
-                sent_states = e.view(sizes[0], beam_size, br // beam_size, sizes[2], sizes[3])[:, :, idx]
+                sent_states = e.view(sizes[0], beam_size,
+                                     br // beam_size,
+                                     sizes[2],
+                                     sizes[3])[:, :, idx]
 
             sent_states.data.copy_(
                 sent_states.data.index_select(1, positions))

--- a/onmt/Optim.py
+++ b/onmt/Optim.py
@@ -2,6 +2,8 @@ import torch.optim as optim
 from torch.nn.utils import clip_grad_norm
 
 
+
+
 class Optim(object):
     """
     Controller class for optimization. Mostly a thin
@@ -68,6 +70,9 @@ class Optim(object):
         elif self.method == 'adam':
             self.optimizer = optim.Adam(self.params, lr=self.lr,
                                         betas=self.betas, eps=1e-9)
+            # self.optimizer = optim.SparseAdam(self.params, lr=self.lr,
+            #                                   betas=self.betas, eps=1e-9)
+
         else:
             raise RuntimeError("Invalid optim method: " + self.method)
 

--- a/onmt/Optim.py
+++ b/onmt/Optim.py
@@ -1,9 +1,6 @@
 import torch.optim as optim
 from torch.nn.utils import clip_grad_norm
-
-
-
-
+            
 class Optim(object):
     """
     Controller class for optimization. Mostly a thin
@@ -70,9 +67,6 @@ class Optim(object):
         elif self.method == 'adam':
             self.optimizer = optim.Adam(self.params, lr=self.lr,
                                         betas=self.betas, eps=1e-9)
-            # self.optimizer = optim.SparseAdam(self.params, lr=self.lr,
-            #                                   betas=self.betas, eps=1e-9)
-
         else:
             raise RuntimeError("Invalid optim method: " + self.method)
 

--- a/onmt/Optim.py
+++ b/onmt/Optim.py
@@ -1,6 +1,7 @@
 import torch.optim as optim
 from torch.nn.utils import clip_grad_norm
-            
+
+
 class Optim(object):
     """
     Controller class for optimization. Mostly a thin

--- a/onmt/Trainer.py
+++ b/onmt/Trainer.py
@@ -163,8 +163,9 @@ class Trainer(object):
             true_batchs.append(batch)
             accum += 1
             if self.norm_method == "tokens":
-                normalization += batch.tgt[1:].data.view(-1) \
+                num_tokens = batch.tgt[1:].data.view(-1) \
                     .ne(self.train_loss.padding_idx).sum()
+                normalization += num_tokens
             else:
                 normalization += batch.batch_size
 
@@ -172,7 +173,12 @@ class Trainer(object):
                 self._gradient_accumulation(
                         true_batchs, total_stats,
                         report_stats, normalization)
-
+                # if idx % 500 == 0: 
+                #     print(idx, normalization, len(true_batchs))
+                #     for b in true_batchs:
+                #         num_tokens = b.tgt[1:].data.view(-1) \
+                #                                        .ne(self.train_loss.padding_idx).sum()
+                #         print(b.src[0].size(), b.tgt.size(), num_tokens)
                 if report_func is not None:
                     report_stats = report_func(
                             epoch, idx, num_batches,

--- a/onmt/io/IO.py
+++ b/onmt/io/IO.py
@@ -328,10 +328,15 @@ def _make_examples_nfeats_tpl(data_type, src_path, src_dir,
 class OrderedIterator(torchtext.data.Iterator):
     def create_batches(self):
         if self.train:
-            self.batches = torchtext.data.pool(
-                self.data(), self.batch_size,
-                self.sort_key, self.batch_size_fn,
-                random_shuffler=self.random_shuffler)
+            def pool(data, random_shuffler):
+                if random_shuffler is None:
+                    random_shuffler = random.shuffle
+                for p in torchtext.data.batch(data, self.batch_size * 100):
+                    p_batch = torchtext.data.batch(sorted(p, key=self.sort_key),
+                                                   self.batch_size, self.batch_size_fn)
+                    for b in random_shuffler(list(p_batch)):
+                        yield b
+            self.batches = pool(self.data(), self.random_shuffler)
         else:
             self.batches = []
             for b in torchtext.data.batch(self.data(), self.batch_size,

--- a/onmt/io/TextDataset.py
+++ b/onmt/io/TextDataset.py
@@ -97,8 +97,8 @@ class TextDataset(ONMTDatasetBase):
         """ Sort using length of source sentences. """
         # Default to a balanced sort, prioritizing tgt len match.
         # TODO: make this configurable.
-        return len(ex.src)
-        # return len(ex.tgt) / 5, len(ex.src) / 5
+        # return len(ex.src)
+        return len(ex.tgt) / 5, len(ex.src) / 5
 
     @staticmethod
     def collapse_copy_scores(scores, batch, tgt_vocab, src_vocabs):

--- a/onmt/io/TextDataset.py
+++ b/onmt/io/TextDataset.py
@@ -67,24 +67,22 @@ class TextDataset(ONMTDatasetBase):
         out_fields = [(k, fields[k]) if k in fields else (k, None)
                       for k in keys]
         example_values = ([ex[k] for k in keys] for ex in examples_iter)
-        
+
         # If out_examples is a generator, we need to save the filter_pred
         # function in serialization too, which would cause a problem when
         # `torch.save()`. Thus we materialize it as a list.
         src_size = 0
-        # tgt_size = 0
-        
+
         out_examples = []
         for ex_values in example_values:
             example = self._construct_example_fromlist(
                 ex_values, out_fields)
             src_size += len(example.src)
-            # tgt_size += len(example.tgt)
             out_examples.append(example)
 
-        # print("average src", src_size / len(out_examples), len(out_examples))
-        # print("average tgt", tgt_size / len(out_examples), len(out_examples))
-        
+        print("average src size", src_size / len(out_examples),
+              len(out_examples))
+
         def filter_pred(example):
             return 0 < len(example.src) <= src_seq_length \
                and 0 < len(example.tgt) <= tgt_seq_length
@@ -99,8 +97,7 @@ class TextDataset(ONMTDatasetBase):
         """ Sort using length of source sentences. """
         # Default to a balanced sort, prioritizing tgt len match.
         # TODO: make this configurable.
-        return len(ex.src) #(int(len(ex.tgt) / 5), int(len(ex.src) / 5))
-        #return (int(len(ex.tgt) / 5), int(len(ex.src) / 5))
+        return len(ex.src)
 
     @staticmethod
     def collapse_copy_scores(scores, batch, tgt_vocab, src_vocabs):

--- a/onmt/io/TextDataset.py
+++ b/onmt/io/TextDataset.py
@@ -67,14 +67,24 @@ class TextDataset(ONMTDatasetBase):
         out_fields = [(k, fields[k]) if k in fields else (k, None)
                       for k in keys]
         example_values = ([ex[k] for k in keys] for ex in examples_iter)
-        out_examples = (self._construct_example_fromlist(
-                            ex_values, out_fields)
-                        for ex_values in example_values)
+        
         # If out_examples is a generator, we need to save the filter_pred
         # function in serialization too, which would cause a problem when
         # `torch.save()`. Thus we materialize it as a list.
-        out_examples = list(out_examples)
+        src_size = 0
+        # tgt_size = 0
+        
+        out_examples = []
+        for ex_values in example_values:
+            example = self._construct_example_fromlist(
+                ex_values, out_fields)
+            src_size += len(example.src)
+            # tgt_size += len(example.tgt)
+            out_examples.append(example)
 
+        # print("average src", src_size / len(out_examples), len(out_examples))
+        # print("average tgt", tgt_size / len(out_examples), len(out_examples))
+        
         def filter_pred(example):
             return 0 < len(example.src) <= src_seq_length \
                and 0 < len(example.tgt) <= tgt_seq_length
@@ -89,7 +99,8 @@ class TextDataset(ONMTDatasetBase):
         """ Sort using length of source sentences. """
         # Default to a balanced sort, prioritizing tgt len match.
         # TODO: make this configurable.
-        return (int(len(ex.tgt) / 5), int(len(ex.src) / 5))
+        return len(ex.src) #(int(len(ex.tgt) / 5), int(len(ex.src) / 5))
+        #return (int(len(ex.tgt) / 5), int(len(ex.src) / 5))
 
     @staticmethod
     def collapse_copy_scores(scores, batch, tgt_vocab, src_vocabs):

--- a/onmt/io/TextDataset.py
+++ b/onmt/io/TextDataset.py
@@ -98,6 +98,7 @@ class TextDataset(ONMTDatasetBase):
         # Default to a balanced sort, prioritizing tgt len match.
         # TODO: make this configurable.
         return len(ex.src)
+        # return len(ex.tgt) / 5, len(ex.src) / 5
 
     @staticmethod
     def collapse_copy_scores(scores, batch, tgt_vocab, src_vocabs):

--- a/onmt/modules/MultiHeadedAttn.py
+++ b/onmt/modules/MultiHeadedAttn.py
@@ -134,8 +134,9 @@ class MultiHeadedAttention(nn.Module):
             mask = mask.unsqueeze(1).expand_as(scaled)
             scaled = scaled.masked_fill(Variable(mask), -1e18) \
                            .view(bh, l, dim_per_head)
-        attn = self.sm(scaled)
+
         # Return one attn
+        attn = self.sm(scaled)
         top_attn = attn \
             .view(b, self.head_count, l, dim_per_head)[:, 0, :, :] \
             .contiguous()
@@ -144,9 +145,8 @@ class MultiHeadedAttention(nn.Module):
 
         # values : (batch * 8) x qlen x dim
         out = unshape_projection(torch.bmm(drop_attn, value_up), residual)
-
-        # Residual and layer norm
-        ret = self.res_dropout(out)
+        
+        ret = out #self.res_dropout(out)
 
         # CHECK
         batch_, q_len_, d_ = ret.size()

--- a/onmt/modules/Transformer.py
+++ b/onmt/modules/Transformer.py
@@ -336,6 +336,9 @@ class TransformerDecoder(nn.Module):
         attns["std"] = attn
         if self._copy:
             attns["copy"] = attn
+        print(attn[0, 0, :5])
+        if tgt.size(0) == 2:
+            exit()
 
         # Update the state.
         state.update_state(tgt, saved_inputs)

--- a/onmt/modules/Transformer.py
+++ b/onmt/modules/Transformer.py
@@ -328,16 +328,10 @@ class TransformerDecoder(nn.Module):
         # Process the result and update the attentions.
         outputs = output.transpose(0, 1).contiguous()
         attn = attn.transpose(0, 1).contiguous()
-        # if state.previous_input is not None:
-        #     attn = torch.stack([attn.squeeze()])
-        # else:
 
         attns["std"] = attn
         if self._copy:
             attns["copy"] = attn
-        # print(attn[0, 0, :5])
-        # if tgt.size(0) == 2:
-        #     exit()
 
         # Update the state.
         state.update_state(tgt, saved_inputs)

--- a/onmt/modules/Transformer.py
+++ b/onmt/modules/Transformer.py
@@ -188,7 +188,6 @@ class TransformerDecoderLayer(nn.Module):
         if previous_input is not None:
             all_input = torch.cat((previous_input, input_norm), dim=1)
             dec_mask = None
-            
         query, attn = self.self_attn(all_input, all_input, input_norm,
                                      mask=dec_mask)
         query_norm = self.layer_norm_2(query+input)
@@ -285,7 +284,7 @@ class TransformerDecoder(nn.Module):
         tgt_batch, tgt_len = tgt_words.size()
         aeq(tgt_batch, memory_batch, src_batch, tgt_batch)
         aeq(memory_len, src_len)
-        
+
         if state.previous_input is not None:
             tgt = torch.cat([state.previous_input, tgt], 0)
         # END CHECKS
@@ -324,7 +323,7 @@ class TransformerDecoder(nn.Module):
 
         saved_inputs = torch.stack(saved_inputs)
         output = self.layer_norm(output)
-        
+
         # Process the result and update the attentions.
         outputs = output.transpose(0, 1).contiguous()
         attn = attn.transpose(0, 1).contiguous()
@@ -351,7 +350,7 @@ class TransformerDecoderState(DecoderState):
         self.src = src
         self.previous_input = None
         self.previous_layer_inputs = None
-        
+
     @property
     def _all(self):
         """

--- a/onmt/modules/Transformer.py
+++ b/onmt/modules/Transformer.py
@@ -188,9 +188,8 @@ class TransformerDecoderLayer(nn.Module):
         if previous_input is not None:
             all_input = torch.cat((previous_input, input_norm), dim=1)
             dec_mask = None
-        else:
-            previous_input = input_norm
-        query, attn = self.self_attn(previous_input, previous_input, input_norm,
+            
+        query, attn = self.self_attn(all_input, all_input, input_norm,
                                      mask=dec_mask)
         query_norm = self.layer_norm_2(query+input)
         mid, attn = self.context_attn(memory_bank, memory_bank, query_norm,
@@ -336,9 +335,9 @@ class TransformerDecoder(nn.Module):
         attns["std"] = attn
         if self._copy:
             attns["copy"] = attn
-        print(attn[0, 0, :5])
-        if tgt.size(0) == 2:
-            exit()
+        # print(attn[0, 0, :5])
+        # if tgt.size(0) == 2:
+        #     exit()
 
         # Update the state.
         state.update_state(tgt, saved_inputs)

--- a/onmt/modules/Transformer.py
+++ b/onmt/modules/Transformer.py
@@ -163,16 +163,20 @@ class TransformerDecoderLayer(nn.Module):
         # it gets TransformerDecoderLayer's cuda behavior automatically.
         self.register_buffer('mask', mask)
 
-    def forward(self, input, memory_bank, src_pad_mask, tgt_pad_mask):
+    def forward(self, input, memory_bank, src_pad_mask, tgt_pad_mask,
+                previous_input=None):
         # Args Checks
         input_batch, input_len, _ = input.size()
+        if previous_input is not None:
+            pi_batch, _, _ = previous_input.size()
+            aeq(pi_batch, input_batch)
         contxt_batch, contxt_len, _ = memory_bank.size()
         aeq(input_batch, contxt_batch)
 
         src_batch, t_len, s_len = src_pad_mask.size()
         tgt_batch, t_len_, t_len__ = tgt_pad_mask.size()
         aeq(input_batch, contxt_batch, src_batch, tgt_batch)
-        aeq(t_len, t_len_, t_len__, input_len)
+        # aeq(t_len, t_len_, t_len__, input_len)
         aeq(s_len, contxt_len)
         # END Args Checks
 
@@ -180,7 +184,13 @@ class TransformerDecoderLayer(nn.Module):
                             :tgt_pad_mask.size(1)]
                             .expand_as(tgt_pad_mask), 0)
         input_norm = self.layer_norm_1(input)
-        query, attn = self.self_attn(input_norm, input_norm, input_norm,
+        all_input = input_norm
+        if previous_input is not None:
+            all_input = torch.cat((previous_input, input_norm), dim=1)
+            dec_mask = None
+        else:
+            previous_input = input_norm
+        query, attn = self.self_attn(previous_input, previous_input, input_norm,
                                      mask=dec_mask)
         query_norm = self.layer_norm_2(query+input)
         mid, attn = self.context_attn(memory_bank, memory_bank, query_norm,
@@ -198,7 +208,7 @@ class TransformerDecoderLayer(nn.Module):
         aeq(input_len, t_len_)
         # END CHECKS
 
-        return output, attn
+        return output, attn, all_input
 
     def _get_attn_subsequent_mask(self, size):
         ''' Get an attention mask to avoid using the subsequent info.'''
@@ -269,9 +279,6 @@ class TransformerDecoder(nn.Module):
         memory_len, memory_batch, _ = memory_bank.size()
         aeq(tgt_batch, memory_batch)
 
-        if state.previous_input is not None:
-            tgt = torch.cat([state.previous_input, tgt], 0)
-
         src = state.src
         src_words = src[:, :, 0].transpose(0, 1)
         tgt_words = tgt[:, :, 0].transpose(0, 1)
@@ -279,7 +286,9 @@ class TransformerDecoder(nn.Module):
         tgt_batch, tgt_len = tgt_words.size()
         aeq(tgt_batch, memory_batch, src_batch, tgt_batch)
         aeq(memory_len, src_len)
-        # aeq(tgt_len, tgt_len)
+        
+        if state.previous_input is not None:
+            tgt = torch.cat([state.previous_input, tgt], 0)
         # END CHECKS
 
         # Initialize return variables.
@@ -290,6 +299,8 @@ class TransformerDecoder(nn.Module):
 
         # Run the forward pass of the TransformerDecoder.
         emb = self.embeddings(tgt)
+        if state.previous_input is not None:
+            emb = emb[state.previous_input.size(0):, ]
         assert emb.dim() == 3  # len x batch x embedding_dim
 
         output = emb.transpose(0, 1).contiguous()
@@ -301,25 +312,33 @@ class TransformerDecoder(nn.Module):
         tgt_pad_mask = tgt_words.data.eq(padding_idx).unsqueeze(1) \
             .expand(tgt_batch, tgt_len, tgt_len)
 
+        saved_inputs = []
         for i in range(self.num_layers):
-            output, attn \
+            prev_layer_input = None
+            if state.previous_input is not None:
+                prev_layer_input = state.previous_layer_inputs[i]
+            output, attn, all_input \
                 = self.transformer_layers[i](output, src_memory_bank,
-                                             src_pad_mask, tgt_pad_mask)
+                                             src_pad_mask, tgt_pad_mask,
+                                             previous_input=prev_layer_input)
+            saved_inputs.append(all_input)
 
+        saved_inputs = torch.stack(saved_inputs)
         output = self.layer_norm(output)
+        
         # Process the result and update the attentions.
         outputs = output.transpose(0, 1).contiguous()
-        if state.previous_input is not None:
-            outputs = outputs[state.previous_input.size(0):]
-            attn = attn[:, state.previous_input.size(0):].squeeze()
-            attn = torch.stack([attn])
+        attn = attn.transpose(0, 1).contiguous()
+        # if state.previous_input is not None:
+        #     attn = torch.stack([attn.squeeze()])
+        # else:
+
         attns["std"] = attn
         if self._copy:
             attns["copy"] = attn
 
         # Update the state.
-        state.update_state(tgt)
-
+        state.update_state(tgt, saved_inputs)
         return outputs, state, attns
 
     def init_decoder_state(self, src, memory_bank, enc_hidden):
@@ -335,17 +354,19 @@ class TransformerDecoderState(DecoderState):
         """
         self.src = src
         self.previous_input = None
-
+        self.previous_layer_inputs = None
+        
     @property
     def _all(self):
         """
         Contains attributes that need to be updated in self.beam_update().
         """
-        return (self.previous_input, self.src)
+        return (self.previous_input, self.previous_layer_inputs, self.src)
 
-    def update_state(self, input):
+    def update_state(self, input, previous_layer_inputs):
         """ Called for every decoder forward pass. """
         self.previous_input = input
+        self.previous_layer_inputs = previous_layer_inputs
 
     def repeat_beam_size_times(self, beam_size):
         """ Repeat beam_size times along batch dimension. """

--- a/onmt/translate/Translator.py
+++ b/onmt/translate/Translator.py
@@ -28,6 +28,7 @@ class Translator(object):
                  max_length=100,
                  global_scorer=None, copy_attn=False, cuda=False,
                  beam_trace=False, min_length=0):
+        print(copy_attn)
         self.model = model
         self.fields = fields
         self.n_best = n_best

--- a/onmt/translate/Translator.py
+++ b/onmt/translate/Translator.py
@@ -28,7 +28,6 @@ class Translator(object):
                  max_length=100,
                  global_scorer=None, copy_attn=False, cuda=False,
                  beam_trace=False, min_length=0):
-        print(copy_attn)
         self.model = model
         self.fields = fields
         self.n_best = n_best

--- a/opts.py
+++ b/opts.py
@@ -280,7 +280,7 @@ def train_opts(parser):
     group.add_argument('-epochs', type=int, default=13,
                        help='Number of training epochs')
     group.add_argument('-optim', default='sgd',
-                       choices=['sgd', 'adagrad', 'adadelta', 'adam'],
+                       choices=['sgd', 'adagrad', 'adadelta', 'adam', 'sparseadam'],
                        help="""Optimization method.""")
     group.add_argument('-adagrad_accumulator_init', type=float, default=0,
                        help="""Initializes the accumulator values in adagrad.

--- a/train.py
+++ b/train.py
@@ -20,6 +20,8 @@ import onmt.modules
 from onmt.Utils import use_gpu
 import opts
 
+
+
 parser = argparse.ArgumentParser(
     description='train.py',
     formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -93,6 +95,7 @@ def report_func(epoch, batch, num_batches,
     """
     if batch % opt.report_every == -1 % opt.report_every:
         report_stats.output(epoch, batch + 1, num_batches, start_time)
+        print(lr)
         if opt.exp_host:
             report_stats.log("progress", experiment, lr)
         if opt.tensorboard:
@@ -378,7 +381,7 @@ def build_optim(model, checkpoint):
             warmup_steps=opt.warmup_steps,
             model_size=opt.rnn_size)
 
-    optim.set_parameters(model.parameters())
+    optim.set_parameters(model.named_parameters())
 
     return optim
 

--- a/train.py
+++ b/train.py
@@ -188,6 +188,8 @@ def make_dataset_iter(datasets, fields, opt, is_train=True):
             max_tgt_in_batch = max(max_tgt_in_batch,  len(new.tgt) + 1)
             src_elements = count * max_src_in_batch
             tgt_elements = count * max_tgt_in_batch
+            # print(count, src_elements, tgt_elements, max_tgt_in_batch, max_src_in_bat
+                  # ch)
             return max(src_elements, tgt_elements)
 
     device = opt.gpuid[0] if opt.gpuid else -1


### PR DESCRIPTION
These are some fixes the should square transformer performance and output with the opennmt-tf model. 

These include changes to:

- Hack around torchtext to balance the batches for speed. 
- Fix dropout order in the internal aspect of the model.
- Save some memory to allow for larger batches. 

Next up is a major cleanup of this code. First though, want to confirm that we can replicate WMT results.  