### PR TITLE
Gideon fix optimizer loading erases parameters

### DIFF
--- a/train.py
+++ b/train.py
@@ -72,7 +72,6 @@ if opt.exp_host != "":
 
 if opt.tensorboard:
     from tensorboardX import SummaryWriter
-
     writer = SummaryWriter(opt.tensorboard_log_dir, comment="Onmt")
 
 


### PR DESCRIPTION
Dear Sasha and others, I found a bug in the loading of the optimizers from a checkpoint. What happens is that the current code, in the train.py script, completely overwrites the optimizer state even when an existing optimizer is loaded. This happens because the method 
"optim.set_parameters(model.named_parameters())" which calls the optimizer constructor, is always called, even when loading from a checkpoint. This constructor in turn completely resets the state, that is, it completely undoes whatever had been loaded by 
" optim.optimizer.load_state_dict(
            checkpoint['optim'].optimizer.state_dict())" earlier in the 
build_optim(model, checkpoint) method.

I fixed this, by executing the method optim.set_parameters(model.named_parameters())
only when a new optimizer is needed since it is not loaded from a checkpoint. I also added a test to check the state is not empty if an existing optimizer was loaded, which at least for Adam always needs to be true. You can check for yourself, that in the current version of the code this check will not succeed: the state becomes empty when (always) creating a new optimizer in the current version of the code. Note that this bug may have had serious repercussions when running Adam in particular and (often) restarting it from earlier checkpoints.

