### PR TITLE
Load models to CPU when releasing.

### DIFF
--- a/tools/release_model.py
+++ b/tools/release_model.py
@@ -11,6 +11,6 @@ if __name__ == "__main__":
                         help="The output filename (*.pt)", required=True)
     opt = parser.parse_args()
 
-    model = torch.load(opt.model)
+    model = torch.load(opt.model, map_location=lambda storage, loc: storage)
     model['optim'] = None
     torch.save(model, opt.output)


### PR DESCRIPTION
This makes the release script itself not require GPU. 

https://github.com/OpenNMT/OpenNMT-py/blob/fa0acc9413a547931ed047926f15254ac5804518/onmt/ModelConstructor.py#L119 seems to be loading the results this way, so I don't think this change would be keeping models off the GPU during testing. But I'm not sure how models end up back on the GPU at test time, though; the only model.cuda() call I see is in https://github.com/OpenNMT/OpenNMT-py/blob/master/onmt/ModelConstructor.py#L233 which is only called at training time.
