### PR TITLE
Fixed NoneType error in ./tools/embeddings_to_torch.py get_vocabs

### DIFF
--- a/tools/embeddings_to_torch.py
+++ b/tools/embeddings_to_torch.py
@@ -21,7 +21,7 @@ def get_vocabs(dict_file):
             enc_vocab = vocab[1]
         if vocab[0] == 'tgt':
             dec_vocab = vocab[1]
-    assert None not in [enc_vocab, dec_vocab]
+    assert type(None) not in [type(enc_vocab), type(dec_vocab)]
 
     print("From: %s" % dict_file)
     print("\t* source vocab: %d words" % len(enc_vocab))


### PR DESCRIPTION
Fixed the following error when executing the script ./tools/embeddings_to_torch.py

```
Traceback (most recent call last):
  File "./tools/embeddings_to_torch.py", line 124, in <module>
    main()
  File "./tools/embeddings_to_torch.py", line 87, in main
    enc_vocab, dec_vocab = get_vocabs(opt.dict_file)
  File "./tools/embeddings_to_torch.py", line 24, in get_vocabs
    assert None not in [enc_vocab, dec_vocab]
  File "/home/xing/anaconda3/envs/pytorch-new/lib/python3.6/site-packages/torchtext/vocab.py", line 75, in __eq__
    if self.freqs != other.freqs:
AttributeError: 'NoneType' object has no attribute 'freqs'
```
