### PR TITLE
Earlystopping

### DIFF
--- a/onmt/Loss.py
+++ b/onmt/Loss.py
@@ -189,20 +189,23 @@ class NMTLossCompute(LossComputeBase):
         if self.confidence < 1:
             tdata = gtruth.data
             mask = torch.nonzero(tdata.eq(self.padding_idx)).squeeze()
-            log_likelihood = torch.gather(scores.data, 1, tdata.unsqueeze(1))
+            #log_likelihood = torch.gather(scores.data, 1, tdata.unsqueeze(1))
             tmp_ = self.one_hot.repeat(gtruth.size(0), 1)
             tmp_.scatter_(1, tdata.unsqueeze(1), self.confidence)
             if mask.dim() > 0:
-                log_likelihood.index_fill_(0, mask, 0)
+                #log_likelihood.index_fill_(0, mask, 0)
                 tmp_.index_fill_(0, mask, 0)
             gtruth = Variable(tmp_, requires_grad=False)
+
         loss = self.criterion(scores, gtruth)
-        if self.confidence < 1:
-            # Default: report smoothed ppl.
-            # loss_data = -log_likelihood.sum(0)
-            loss_data = loss.data.clone()
-        else:
-            loss_data = loss.data.clone()
+        # if self.confidence < 1:
+        #     # Default: report smoothed ppl.
+        #     # loss_data = -log_likelihood.sum(0)
+        #     loss_data = loss.data.clone()
+        # else:
+        #     loss_data = loss.data.clone()
+
+        loss_data = loss.data.clone()
 
         stats = self._stats(loss_data, scores.data, target.view(-1).data)
 

--- a/onmt/Loss.py
+++ b/onmt/Loss.py
@@ -189,11 +189,11 @@ class NMTLossCompute(LossComputeBase):
         if self.confidence < 1:
             tdata = gtruth.data
             mask = torch.nonzero(tdata.eq(self.padding_idx)).squeeze()
-            #log_likelihood = torch.gather(scores.data, 1, tdata.unsqueeze(1))
+            # log_likelihood = torch.gather(scores.data, 1, tdata.unsqueeze(1))
             tmp_ = self.one_hot.repeat(gtruth.size(0), 1)
             tmp_.scatter_(1, tdata.unsqueeze(1), self.confidence)
             if mask.dim() > 0:
-                #log_likelihood.index_fill_(0, mask, 0)
+                # log_likelihood.index_fill_(0, mask, 0)
                 tmp_.index_fill_(0, mask, 0)
             gtruth = Variable(tmp_, requires_grad=False)
 

--- a/onmt/ModelConstructor.py
+++ b/onmt/ModelConstructor.py
@@ -175,7 +175,7 @@ def make_base_model(model_opt, fields, gpu, checkpoint=None):
     # Share the embedding matrix - preprocess with share_vocab required.
     if model_opt.share_embeddings:
         # src/tgt vocab should be the same if `-share_vocab` is specified.
-        if src_dict != tgt_dict:
+        if not (src_dict == tgt_dict):
             raise AssertionError('The `-share_vocab` should be set during '
                                  'preprocess if you use share_embeddings!')
 

--- a/onmt/Trainer.py
+++ b/onmt/Trainer.py
@@ -13,9 +13,6 @@ import time
 import sys
 import math
 
-#FIXME enum import
-from enum import Enum
-
 import torch
 import torch.nn as nn
 
@@ -394,7 +391,7 @@ class EarlyStoppingTrainer(Trainer):
         Args:
             train_iter: training data iterator
             epoch(int): the epoch number
-            valid_iter(funfnction): validation data builder, needs to be callable
+            valid_iter(fn): validation data builder, needs to be callable
             report_func(fn): function for logging
 
         Returns:
@@ -485,6 +482,7 @@ class EarlyStopping(object):
                 trainer(:py:class:`onmt.Trainer`): trainer
                 scorer(fn): score of the stats to compare with previous best model
         """
+    from enum import Enum
 
     class PatienceEnum(Enum):
         IMPROVING = 0

--- a/onmt/__init__.py
+++ b/onmt/__init__.py
@@ -2,9 +2,11 @@ import onmt.io
 import onmt.translate
 import onmt.Models
 import onmt.Loss
-from onmt.Trainer import Trainer, Statistics, EarlyStoppingTrainer, EarlyStopping
+from onmt.Trainer import Trainer, Statistics, \
+    EarlyStoppingTrainer, EarlyStopping
 from onmt.Optim import Optim
 
 # For flake8 compatibility
 __all__ = [onmt.Loss, onmt.Models,
-           Trainer, Optim, Statistics, onmt.io, onmt.translate, EarlyStoppingTrainer, EarlyStopping]
+           Trainer, Optim, Statistics, onmt.io, onmt.translate,
+           EarlyStoppingTrainer, EarlyStopping]

--- a/onmt/__init__.py
+++ b/onmt/__init__.py
@@ -2,9 +2,9 @@ import onmt.io
 import onmt.translate
 import onmt.Models
 import onmt.Loss
-from onmt.Trainer import Trainer, Statistics
+from onmt.Trainer import Trainer, Statistics, EarlyStoppingTrainer, EarlyStopping
 from onmt.Optim import Optim
 
 # For flake8 compatibility
 __all__ = [onmt.Loss, onmt.Models,
-           Trainer, Optim, Statistics, onmt.io, onmt.translate]
+           Trainer, Optim, Statistics, onmt.io, onmt.translate, EarlyStoppingTrainer, EarlyStopping]

--- a/onmt/io/IO.py
+++ b/onmt/io/IO.py
@@ -2,6 +2,7 @@
 
 from collections import Counter, defaultdict, OrderedDict
 from itertools import count
+import copy
 
 import torch
 import torchtext.data
@@ -69,8 +70,9 @@ def save_fields_to_vocab(fields):
     vocab = []
     for k, f in fields.items():
         if f is not None and 'vocab' in f.__dict__:
-            f.vocab.stoi = dict(f.vocab.stoi)
-            vocab.append((k, f.vocab))
+            new_vocab = copy.copy(f.vocab)
+            new_vocab.stoi = dict(new_vocab.stoi)
+            vocab.append((k, new_vocab))
     return vocab
 
 

--- a/opts.py
+++ b/opts.py
@@ -311,7 +311,7 @@ def train_opts(parser):
                        Typically a value of 0.999 is recommended, as this is
                        the value suggested by the original paper describing
                        Adam, and is also the value adopted in other frameworks
-                       such as Tensorflow and Kerras, i.e. see:
+                       such as Tensorflow and Keras, i.e. see:
                        https://www.tensorflow.org/api_docs/python/tf/train/AdamOptimizer
                        https://keras.io/optimizers/ .
                        Whereas recently the paper "Attention is All You Need"
@@ -325,6 +325,16 @@ def train_opts(parser):
                        Set to zero to turn off label smoothing.
                        For more detailed information, see:
                        https://arxiv.org/abs/1512.00567""")
+    # Early stopping
+    group = parser.add_argument_group('Early Stopping (es)')
+    group.add_argument('-es_patience', type=int, default=None,
+                       help="""Early stopping patience. Max number of consecutive checkpoints without improvement.""")
+    group.add_argument('-es_type', default="epoch", choices=["epoch", "batch"],
+                       help="""Early stopping type. End of epoch validation (epoch);
+                            validation after batches (batch, see -es_after_batches).""")
+    group.add_argument('-es_after_batches', type=int,
+                       help="""Early stopping after batches. Perform validation after N batches processed.""")
+
     # learning rate
     group = parser.add_argument_group('Optimization- Rate')
     group.add_argument('-learning_rate', type=float, default=1.0,

--- a/opts.py
+++ b/opts.py
@@ -326,13 +326,13 @@ def train_opts(parser):
                        For more detailed information, see:
                        https://arxiv.org/abs/1512.00567""")
     # Early stopping
-    group = parser.add_argument_group('Early Stopping (es)')
-    group.add_argument('-es_patience', type=int, default=None,
-                       help="""Early stopping patience. Max number of consecutive checkpoints without improvement.""")
-    group.add_argument('-es_type', default="epoch", choices=["epoch", "batch"],
+    group = parser.add_argument_group('Early Stopping')
+    group.add_argument('-earlystop_tolerance', type=int, default=None,
+                       help="""Early stopping tolerance. Max number of consecutive checkpoints without improvement.""")
+    group.add_argument('-earlystop_type', default="epoch", choices=["epoch", "batch"],
                        help="""Early stopping type. End of epoch validation (epoch);
-                            validation after batches (batch, see -es_after_batches).""")
-    group.add_argument('-es_after_batches', type=int,
+                            validation after batches (batch, see -earlystop_after_batches).""")
+    group.add_argument('-earlystop_after_batches', type=int,
                        help="""Early stopping after batches. Perform validation after N batches processed.""")
 
     # learning rate

--- a/opts.py
+++ b/opts.py
@@ -328,12 +328,18 @@ def train_opts(parser):
     # Early stopping
     group = parser.add_argument_group('Early Stopping')
     group.add_argument('-earlystop_tolerance', type=int, default=None,
-                       help="""Early stopping tolerance. Max number of consecutive checkpoints without improvement.""")
-    group.add_argument('-earlystop_type', default="epoch", choices=["epoch", "batch"],
-                       help="""Early stopping type. End of epoch validation (epoch);
-                            validation after batches (batch, see -earlystop_after_batches).""")
+                       help="""Early stopping tolerance.
+                       Max number of consecutive checkpoints without
+                       improving.""")
+    group.add_argument('-earlystop_type', default="epoch",
+                       choices=["epoch", "batch"],
+                       help="""Early stopping type.
+                       End of epoch validation (epoch);
+                       validation after batches (batch,
+                        see -earlystop_after_batches).""")
     group.add_argument('-earlystop_after_batches', type=int,
-                       help="""Early stopping after batches. Perform validation after N batches processed.""")
+                       help="""Early stopping after batches.
+                       Perform validation after N batches processed.""")
 
     # learning rate
     group = parser.add_argument_group('Optimization- Rate')

--- a/train.py
+++ b/train.py
@@ -160,7 +160,6 @@ class DatasetLazyIter(object):
             self.cur_dataset = next(dataset_iter)
         except StopIteration:
             return None
-
         # We clear `fields` when saving, restore when loading.
         self.cur_dataset.fields = self.fields
 


### PR DESCRIPTION
# Early Stopping

This pull request address one of the most common feature in all NMT frameworks: Early Stopping. In addition, Loss.py had two operations over a variable never used (log_likelihood variable); it also had a non-necessary if/else statement.

Two types of early stopping were added: after each epoch; after N batches (user-defined) are processed.

## Changes

- Trainer.py
- opt.py
- train.py
- Loss.py

### Detailed changes
#### Trainer.py

The Trainer class was updated: the train method is now designed for extension with an additional argument `**kwargs`; two additional methods were added, generate_checkpoint and drop_best_checkpoin -- the first is to avoid repeating code, while the second is to save the best model only.

Two additional classes are added to this module: EarlyStoppingTrainer and EarlyStopping. The first is just a subclass of the Trainer class, while the second is the concrete implementation of EarlyStopping as a callable class. Moreover, the EarlyStoppingTrainer is similar to the regular Trainer, but after accumulating the gradients it performs validation if the number of batches to perform validation was reached. 

Important note: as the number of validation points can be significantly high and the model can be quite big, a checkpoint is only saved if the model is improving. The last commit addresses this.

Finally, the new trainer only requires a callable function to refresh the validation iterator, making it compatible with the current train.py module.

#### opts.py

Three flags added: 

- earlystop_tolerance, the number of consecutive validation points without improvement
- earlystop_type, either "epoch" or "batch"
- earlystop_after_batches, only required for "batch" type, specifies the number of batches to perform validation
 
#### train.py

This module was updated accordingly with the additional features. Note there is full compatibility with the Trainer class and a typo was fixed in the tensor board logging ("valid" instead of "train").




 
