### PR TITLE
fix bugs when using label smoothing.

### DIFF
--- a/onmt/Loss.py
+++ b/onmt/Loss.py
@@ -192,7 +192,7 @@ class NMTLossCompute(LossComputeBase):
             log_likelihood = torch.gather(scores.data, 1, tdata.unsqueeze(1))
             tmp_ = self.one_hot.repeat(gtruth.size(0), 1)
             tmp_.scatter_(1, tdata.unsqueeze(1), self.confidence)
-            if mask.dim() > 0:
+            if mask.numel() > 0:
                 log_likelihood.index_fill_(0, mask, 0)
                 tmp_.index_fill_(0, mask, 0)
             gtruth = Variable(tmp_, requires_grad=False)


### PR DESCRIPTION
in pytorch 0.4 version. Call .dim() on a null tensor will also
 return 1, which will trigger bugs when unsing index_fill_
 afterwards.