### PR TITLE
fix ModuleNotFoundError: No module named 'onmt.Utils', in tools/embed…

### DIFF
--- a/tools/embeddings_to_torch.py
+++ b/tools/embeddings_to_torch.py
@@ -7,7 +7,7 @@ import sys
 import numpy as np
 import argparse
 import torch
-from onmt.Utils import get_logger
+from onmt.utils.misc import get_logger
 
 
 def get_vocabs(dict_file):


### PR DESCRIPTION
According to: https://github.com/OpenNMT/OpenNMT-py/issues/788

