### PR TITLE
Faster batched beam search

### DIFF
--- a/onmt/decoders/decoder.py
+++ b/onmt/decoders/decoder.py
@@ -406,6 +406,9 @@ class DecoderState(object):
             sent_states.data.copy_(
                 sent_states.data.index_select(1, positions))
 
+    def map_batch_fn(self, fn):
+        raise NotImplementedError()
+
 
 class RNNDecoderState(DecoderState):
     """ Base class for RNN decoder state """
@@ -448,3 +451,7 @@ class RNNDecoderState(DecoderState):
                 for e in self._all]
         self.hidden = tuple(vars[:-1])
         self.input_feed = vars[-1]
+
+    def map_batch_fn(self, fn):
+        self.hidden = tuple(map(lambda x: fn(x, 1), self.hidden))
+        self.input_feed = fn(self.input_feed, 1)

--- a/onmt/modules/global_attention.py
+++ b/onmt/modules/global_attention.py
@@ -175,9 +175,9 @@ class GlobalAttention(nn.Module):
         align = self.score(source, memory_bank)
 
         if memory_lengths is not None:
-            mask = sequence_mask(memory_lengths)
+            mask = sequence_mask(memory_lengths, max_len=align.size(-1))
             mask = mask.unsqueeze(1)  # Make it broadcastable.
-            align.data.masked_fill_(1 - mask, -float('inf'))
+            align.masked_fill_(1 - mask, -float('inf'))
 
         # Softmax to normalize attention weights
         align_vectors = self.softmax(align.view(batch*target_l, source_l))

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -417,6 +417,9 @@ def translate_opts(parser):
                        help="Share source and target vocabulary")
 
     group = parser.add_argument_group('Beam')
+    group.add_argument('-fast', action="store_true",
+                       help="""Use fast beam search (some features may not be
+                       supported!)""")
     group.add_argument('-beam_size', type=int, default=5,
                        help='Beam size')
     group.add_argument('-min_length', type=int, default=0,

--- a/onmt/utils/misc.py
+++ b/onmt/utils/misc.py
@@ -26,6 +26,28 @@ def sequence_mask(lengths, max_len=None):
             .lt(lengths.unsqueeze(1)))
 
 
+def tile(x, count, dim=0):
+    """
+    Tiles x on dimension dim count times.
+    """
+    perm = list(range(len(x.size())))
+    if dim != 0:
+        perm[0], perm[dim] = perm[dim], perm[0]
+        x = x.permute(perm).contiguous()
+    out_size = list(x.size())
+    out_size[0] *= count
+    batch = x.size(0)
+    x = x.view(batch, -1) \
+         .transpose(0, 1) \
+         .repeat(count, 1) \
+         .transpose(0, 1) \
+         .contiguous() \
+         .view(*out_size)
+    if dim != 0:
+        x = x.permute(perm).contiguous()
+    return x
+
+
 def use_gpu(opt):
     """
     Creates a boolean if gpu used


### PR DESCRIPTION
This PR adds a new batched beam search implementation that is up to 7x faster than the current implementation. This is made possible by batching all operations, in particular the batch reordering and TopK, which results in an overall better GPU usage.

However, this new code path does not support all decoding features. Here, I'm suggesting to add a `-fast` translation flag and raise an `AssertionError` on incompatible options. A typical goal would be to migrate all existing features to this new implementation (without impacting the speed if they are not enabled).

Here are some numbers from the pretrained models available on the website. The translation was executed on a GTX 1060 with the following options:

```text
-batch_size 32 -beam_size 4 -gpu 0
```

## [English-German](https://s3.amazonaws.com/opennmt-models/transformer-ende-wmt-pyOnmt.tar.gz) on newstest2014 (Transformer)

|  | Time to translate (s) | BLEU (tokenized output) |
| --- | --- | --- |
| baseline | 444 | 32.93 |
| `-fast` | 139 | 33.02 |

## [German-English](https://s3.amazonaws.com/opennmt-models/iwslt-brnn2.s131_acc_62.71_ppl_7.74_e20.pt) on iwslt14/test.de (RNN)

|  | Time to translate (s) | BLEU (tokenized output) |
| --- | --- | --- |
| baseline | 314 | 30.25 |
| `-fast` | 43 | 30.27 |

Based on these results, I think it is worth merging this to move forward on speed optimization.