### PR TITLE
Add decoder cache on top of fast beam search for transformer

### DIFF
--- a/onmt/decoders/cnn_decoder.py
+++ b/onmt/decoders/cnn_decoder.py
@@ -55,7 +55,7 @@ class CNNDecoder(nn.Module):
                 hidden_size, attn_type=attn_type)
             self._copy = True
 
-    def forward(self, tgt, memory_bank, state, memory_lengths=None):
+    def forward(self, tgt, memory_bank, state, memory_lengths=None, step=None):
         """ See :obj:`onmt.modules.RNNDecoderBase.forward()`"""
         # NOTE: memory_lengths is only here for compatibility reasons
         #       with onmt.modules.RNNDecoderBase.forward()
@@ -121,7 +121,7 @@ class CNNDecoder(nn.Module):
 
         return outputs, state, attns
 
-    def init_decoder_state(self, _, memory_bank, enc_hidden):
+    def init_decoder_state(self, _, memory_bank, enc_hidden, with_cache=False):
         """
         Init decoder state.
         """

--- a/onmt/decoders/decoder.py
+++ b/onmt/decoders/decoder.py
@@ -104,7 +104,7 @@ class RNNDecoderBase(nn.Module):
         self._reuse_copy_attn = reuse_copy_attn
 
     def forward(self, tgt, memory_bank, state, memory_lengths=None,
-                step=None):
+                step=None, fast=None):
         """
         Args:
             tgt (`LongTensor`): sequences of padded tokens

--- a/onmt/decoders/decoder.py
+++ b/onmt/decoders/decoder.py
@@ -156,7 +156,8 @@ class RNNDecoderBase(nn.Module):
 
         return decoder_outputs, state, attns
 
-    def init_decoder_state(self, src, memory_bank, encoder_final, with_cache=False):
+    def init_decoder_state(self, src, memory_bank, encoder_final,
+                           with_cache=False):
         """ Init decoder state with last state of the encoder """
         def _fix_enc_hidden(hidden):
             # The encoder hidden is  (layers*directions) x batch x dim.

--- a/onmt/decoders/decoder.py
+++ b/onmt/decoders/decoder.py
@@ -104,7 +104,7 @@ class RNNDecoderBase(nn.Module):
         self._reuse_copy_attn = reuse_copy_attn
 
     def forward(self, tgt, memory_bank, state, memory_lengths=None,
-                step=None, fast=None):
+                step=None):
         """
         Args:
             tgt (`LongTensor`): sequences of padded tokens
@@ -156,7 +156,7 @@ class RNNDecoderBase(nn.Module):
 
         return decoder_outputs, state, attns
 
-    def init_decoder_state(self, src, memory_bank, encoder_final):
+    def init_decoder_state(self, src, memory_bank, encoder_final, with_cache=False):
         """ Init decoder state with last state of the encoder """
         def _fix_enc_hidden(hidden):
             # The encoder hidden is  (layers*directions) x batch x dim.

--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -79,7 +79,9 @@ class TransformerDecoderLayer(nn.Module):
 
         if self.self_attn_type == "scaled-dot":
             query, attn = self.self_attn(all_input, all_input, input_norm,
-                                         mask=dec_mask)
+                                         mask=dec_mask,
+                                         layer_cache=layer_cache,
+                                         type="self")
         elif self.self_attn_type == "average":
             query, attn = self.self_attn(input_norm, mask=dec_mask,
                                          layer_cache=layer_cache, step=step)
@@ -88,7 +90,9 @@ class TransformerDecoderLayer(nn.Module):
 
         query_norm = self.layer_norm_2(query)
         mid, attn = self.context_attn(memory_bank, memory_bank, query_norm,
-                                      mask=src_pad_mask)
+                                      mask=src_pad_mask,
+                                      layer_cache=None,
+                                      type="context")
         output = self.feed_forward(self.drop(mid) + query)
 
         return output, attn, all_input
@@ -147,11 +151,12 @@ class TransformerDecoder(nn.Module):
         self.decoder_type = 'transformer'
         self.num_layers = num_layers
         self.embeddings = embeddings
+        self.self_attn_type = self_attn_type
 
         # Build TransformerDecoder.
         self.transformer_layers = nn.ModuleList(
             [TransformerDecoderLayer(hidden_size, dropout,
-             self_attn_type=self_attn_type)
+             self_attn_type=self.self_attn_type)
              for _ in range(num_layers)])
 
         # TransformerDecoder has its own attention mechanism.
@@ -174,9 +179,6 @@ class TransformerDecoder(nn.Module):
         src_batch, src_len = src_words.size()
         tgt_batch, tgt_len = tgt_words.size()
 
-        if state.previous_input is not None:
-            tgt = torch.cat([state.previous_input, tgt], 0)
-
         # Initialize return variables.
         outputs = []
         attns = {"std": []}
@@ -184,9 +186,7 @@ class TransformerDecoder(nn.Module):
             attns["copy"] = []
 
         # Run the forward pass of the TransformerDecoder.
-        emb = self.embeddings(tgt)
-        if state.previous_input is not None:
-            emb = emb[state.previous_input.size(0):, ]
+        emb = self.embeddings(tgt, step=step)
         assert emb.dim() == 3  # len x batch x embedding_dim
 
         output = emb.transpose(0, 1).contiguous()
@@ -201,16 +201,12 @@ class TransformerDecoder(nn.Module):
         saved_inputs = []
 
         for i in range(self.num_layers):
-            prev_layer_input = None
-            if state.previous_input is not None:
-                prev_layer_input = state.previous_layer_inputs[i]
             output, attn, all_input \
                 = self.transformer_layers[i](output, src_memory_bank,
                                              src_pad_mask, tgt_pad_mask,
-                                             previous_input=prev_layer_input,
-                                             layer_cache=cache["layer_{}".
+                                             layer_cache=state.cache["layer_{}".
                                                                format(i)]
-                                             if cache is not None else None,
+                                             if state.cache is not None else None,
                                              step=step)
             saved_inputs.append(all_input)
 
@@ -226,14 +222,14 @@ class TransformerDecoder(nn.Module):
             attns["copy"] = attn
 
         # Update the state.
-        state = state.update_state(tgt, saved_inputs)
+        # state = state.update_state(tgt, saved_inputs)
         return outputs, state, attns
 
     def init_decoder_state(self, src, memory_bank, enc_hidden):
         """ Init decoder state """
         state = TransformerDecoderState(src)
-        state._init_cache(memory_bank, self.num_layers)
-        return TransformerDecoderState(src)
+        state._init_cache(memory_bank, self.num_layers, self.self_attn_type)
+        return state
 
 
 class TransformerDecoderState(DecoderState):
@@ -246,8 +242,6 @@ class TransformerDecoderState(DecoderState):
                     with optional feature tensors, of size (len x batch).
         """
         self.src = src
-        self.previous_input = None
-        self.previous_layer_inputs = None
         self.cache = None
 
     @property
@@ -255,11 +249,9 @@ class TransformerDecoderState(DecoderState):
         """
         Contains attributes that need to be updated in self.beam_update().
         """
-        return (self.previous_input, self.previous_layer_inputs, self.src)
+        return (self.src)
 
     def detach(self):
-        self.previous_input = self.previous_input.detach()
-        self.previous_layer_inputs = self.previous_layer_inputs.detach()
         self.src = self.src.detach()
 
     def update_state(self, new_input, previous_layer_inputs):
@@ -269,14 +261,25 @@ class TransformerDecoderState(DecoderState):
         state.previous_layer_inputs = previous_layer_inputs
         return state
 
-    def _init_cache(self, memory_bank, num_layers):
-        cache = {}
+    def _init_cache(self, memory_bank, num_layers, self_attn_type):
+        self.cache = {}
         batch_size = memory_bank.size(1)
         depth = memory_bank.size(-1)
+
         for l in range(num_layers):
-            layer_cache = {"prev_g": torch.zeros((batch_size, 1, depth))}
-            cache["layer_{}".format(l)] = layer_cache
-        return cache
+            layer_cache = {
+                "memory_keys": None,
+                "memory_values": None
+            }
+            if self_attn_type == "scaled-dot":
+                layer_cache["self_keys"] = None
+                layer_cache["self_values"] = None
+            elif self_attn_type == "average":
+                layer_cache["prev_g"] = torch.zeros((batch_size, 1, depth))
+            else:
+                layer_cache["self_keys"] = None
+                layer_cache["self_values"] = None
+            self.cache["layer_{}".format(l)] = layer_cache
 
     def repeat_beam_size_times(self, beam_size):
         """ Repeat beam_size times along batch dimension. """
@@ -285,15 +288,16 @@ class TransformerDecoderState(DecoderState):
     def map_batch_fn(self, fn):
         def _recursive_map(struct, batch_dim=0):
             for k, v in struct.items():
-                if isinstance(v, dict):
-                    _recursive_map(v)
-                else:
-                    struct[k] = fn(v, batch_dim)
+                if v is not None:
+                    if isinstance(v, dict):
+                        _recursive_map(v)
+                    else:
+                        struct[k] = fn(v, batch_dim)
 
         self.src = fn(self.src, 1)
-        if self.previous_input is not None:
-            self.previous_input = fn(self.previous_input, 1)
-        if self.previous_layer_inputs is not None:
-            self.previous_layer_inputs = fn(self.previous_layer_inputs, 1)
+        # if self.previous_input is not None:
+        #     self.previous_input = fn(self.previous_input, 1)
+        # if self.previous_layer_inputs is not None:
+        #     self.previous_layer_inputs = fn(self.previous_layer_inputs, 1)
         if self.cache is not None:
             _recursive_map(self.cache)

--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -318,16 +318,3 @@ class TransformerDecoderState(DecoderState):
         self.src = fn(self.src, 1)
         if self.cache is not None:
             _recursive_map(self.cache)
-
-    # def beam_update(self, idx, positions, beam_size):
-    #     """ Need to document this """
-    #     if self.cache is not None:
-    #         for k_layer, layer in self.cache.items():
-    #             if k_layer not in ["memory", "memory_mask"]:
-    #                 for layer_cache in [layer["self_keys"], layer["self_values"]]:
-    #                     if layer_cache is not None:
-    #                         n, n_step, dim = layer_cache.size()
-    #                         batch_size = n // beam_size
-    #                         sent_states = layer_cache.view(beam_size, batch_size, -1)[:, idx, :]
-    #                         sent_states.data.copy_(
-    #                             sent_states.data.index_select(0, positions))

--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -270,7 +270,7 @@ class TransformerDecoderState(DecoderState):
                     self.previous_layer_inputs,
                     self.src)
         else:
-            return (self.src)
+            return (self.src,)
 
     def detach(self):
         if self.previous_input is not None:

--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -210,13 +210,13 @@ class TransformerDecoder(nn.Module):
                 if state.previous_input is not None:
                     prev_layer_input = state.previous_layer_inputs[i]
             output, attn, all_input \
-                = self.transformer_layers[i](output, src_memory_bank,
-                                             src_pad_mask, tgt_pad_mask,
-                                             previous_input=prev_layer_input,
-                                             layer_cache=state.cache["layer_{}".
-                                                               format(i)]
-                                             if state.cache is not None else None,
-                                             step=step, fast=fast)
+                = self.transformer_layers[i](
+                    output, src_memory_bank,
+                    src_pad_mask, tgt_pad_mask,
+                    previous_input=prev_layer_input,
+                    layer_cache=state.cache["layer_{}".format(i)]
+                    if state.cache is not None else None,
+                    step=step, fast=fast)
             if not(fast):
                 saved_inputs.append(all_input)
 
@@ -264,8 +264,11 @@ class TransformerDecoderState(DecoderState):
         """
         Contains attributes that need to be updated in self.beam_update().
         """
-        if self.previous_input is not None and self.previous_layer_inputs is not None:
-            return (self.previous_input, self.previous_layer_inputs, self.src)
+        if (self.previous_input is not None
+                and self.previous_layer_inputs is not None):
+            return (self.previous_input,
+                    self.previous_layer_inputs,
+                    self.src)
         else:
             return (self.src)
 

--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -235,11 +235,13 @@ class TransformerDecoder(nn.Module):
 
         return outputs, state, attns
 
-    def init_decoder_state(self, src, memory_bank, enc_hidden, with_cache=False):
+    def init_decoder_state(self, src, memory_bank, enc_hidden,
+                           with_cache=False):
         """ Init decoder state """
         state = TransformerDecoderState(src)
         if with_cache:
-            state._init_cache(memory_bank, self.num_layers, self.self_attn_type)
+            state._init_cache(memory_bank, self.num_layers,
+                              self.self_attn_type)
         return state
 
 

--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -92,7 +92,7 @@ class TransformerDecoderLayer(nn.Module):
         query_norm = self.layer_norm_2(query)
         mid, attn = self.context_attn(memory_bank, memory_bank, query_norm,
                                       mask=src_pad_mask,
-                                      layer_cache=None,
+                                      layer_cache=layer_cache,
                                       type="context",
                                       fast=fast)
         output = self.feed_forward(self.drop(mid) + query)

--- a/onmt/modules/embeddings.py
+++ b/onmt/modules/embeddings.py
@@ -33,9 +33,12 @@ class PositionalEncoding(nn.Module):
         self.dropout = nn.Dropout(p=dropout)
         self.dim = dim
 
-    def forward(self, emb):
+    def forward(self, emb, step=None):
         emb = emb * math.sqrt(self.dim)
-        emb = emb + self.pe[:emb.size(0)]
+        if step is None:
+            emb = emb + self.pe[:emb.size(0)]
+        else:
+            emb = emb + self.pe[step]
         emb = self.dropout(emb)
         return emb
 
@@ -145,7 +148,9 @@ class Embeddings(nn.Module):
             mlp = nn.Sequential(nn.Linear(in_dim, out_dim), nn.ReLU())
             self.make_embedding.add_module('mlp', mlp)
 
-        if position_encoding:
+        self.position_encoding = position_encoding
+
+        if self.position_encoding:
             pe = PositionalEncoding(dropout, self.embedding_size)
             self.make_embedding.add_module('pe', pe)
 
@@ -172,7 +177,7 @@ class Embeddings(nn.Module):
             if fixed:
                 self.word_lut.weight.requires_grad = False
 
-    def forward(self, source):
+    def forward(self, source, step=None):
         """
         Computes the embeddings for words and features.
 
@@ -181,6 +186,15 @@ class Embeddings(nn.Module):
         Return:
             `FloatTensor`: word embeddings `[len x batch x embedding_size]`
         """
-        emb = self.make_embedding(source)
+        # emb = self.make_embedding(source)
+        if self.position_encoding:
+            for i, module in enumerate(self.make_embedding._modules.values()):
+                if i == len(self.make_embedding._modules.values()) - 1:
+                    # print("STEP : ", step)
+                    source = module(source, step=step)
+                else:
+                    source = module(source)
+        else:
+            source = self.make_embedding(source)
 
-        return emb
+        return source

--- a/onmt/modules/embeddings.py
+++ b/onmt/modules/embeddings.py
@@ -186,11 +186,9 @@ class Embeddings(nn.Module):
         Return:
             `FloatTensor`: word embeddings `[len x batch x embedding_size]`
         """
-        # emb = self.make_embedding(source)
         if self.position_encoding:
             for i, module in enumerate(self.make_embedding._modules.values()):
                 if i == len(self.make_embedding._modules.values()) - 1:
-                    # print("STEP : ", step)
                     source = module(source, step=step)
                 else:
                     source = module(source)

--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -167,17 +167,14 @@ class MultiHeadedAttention(nn.Module):
             key = shape(key)
             value = shape(value)
 
+        query = shape(query)
 
-        key_up = key
-        value_up = value
-        query_up = shape(query)
-
-        key_len = key_up.size(2)
-        query_len = query_up.size(2)
+        key_len = key.size(2)
+        query_len = query.size(2)
 
         # 2) Calculate and scale scores.
-        query_up = query_up / math.sqrt(dim_per_head)
-        scores = torch.matmul(query_up, key_up.transpose(2, 3))
+        query = query / math.sqrt(dim_per_head)
+        scores = torch.matmul(query, key.transpose(2, 3))
 
         if mask is not None:
             mask = mask.unsqueeze(1).expand_as(scores)
@@ -186,7 +183,7 @@ class MultiHeadedAttention(nn.Module):
         # 3) Apply attention dropout and compute context vectors.
         attn = self.softmax(scores)
         drop_attn = self.dropout(attn)
-        context = unshape(torch.matmul(drop_attn, value_up))
+        context = unshape(torch.matmul(drop_attn, value))
 
         output = self.final_linear(context)
         # CHECK

--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -120,13 +120,10 @@ class MultiHeadedAttention(nn.Module):
                     .view(batch_size, -1, head_count * dim_per_head)
 
         # 1) Project key, value, and query.
-
         if type == "self":
-
           query, key, value = self.linear_query(query),\
                               self.linear_keys(query),\
                               self.linear_values(query)
-
           if layer_cache is not None:
             device = key.device
             if layer_cache["self_keys"] is not None:
@@ -135,58 +132,18 @@ class MultiHeadedAttention(nn.Module):
               value = torch.cat((layer_cache["self_values"].to(device), value), dim=1)
             layer_cache["self_keys"] = key
             layer_cache["self_values"] = value
-
-          # print("############")
-          # print("SELF")
-          # print("############")
-          # print("############")
-          # print("QUERY")
-          # print(query)
-          # print("############")
-          # print("############")
-          # print("KEY")
-          # print(key)
-          # print("############")
-          # print("############")
-          # print("VALUE")
-          # print(value)
-          # print("############")
-
-
         elif type == "context":
-
           query = self.linear_query(query)
-
           if layer_cache is not None:
-
             if layer_cache["memory_keys"] is None:
               key, value = self.linear_keys(key), self.linear_values(value)
             else:
               key, value = layer_cache["memory_keys"], layer_cache["memory_values"]
-
             layer_cache["memory_keys"] = key
             layer_cache["memory_values"] = value
           else:
             key, value = self.linear_keys(key), self.linear_values(value)
-
-          # print("############")
-          # print("CONTEXT")
-          # print("############")
-          # print("############")
-          # print("QUERY")
-          # print(query)
-          # print("############")
-          # print("############")
-          # print("KEY")
-          # print(key)
-          # print("############")
-          # print("############")
-          # print("VALUE")
-          # print(value)
-          # print("############")
-
         else:
-
           key = self.linear_keys(key)
           value = self.linear_values(value)
           query = self.linear_query(query)

--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -126,16 +126,20 @@ class MultiHeadedAttention(nn.Module):
                 query, key, value = self.linear_query(query),\
                                     self.linear_keys(query),\
                                     self.linear_values(query)
+
+                key = shape(key)
+                value = shape(value)
+
                 if layer_cache is not None:
                     device = key.device
                     if layer_cache["self_keys"] is not None:
                         key = torch.cat(
                             (layer_cache["self_keys"].to(device), key),
-                            dim=1)
+                            dim=2)
                     if layer_cache["self_values"] is not None:
                         value = torch.cat(
                             (layer_cache["self_values"].to(device), value),
-                            dim=1)
+                            dim=2)
                     layer_cache["self_keys"] = key
                     layer_cache["self_values"] = value
             elif type == "context":
@@ -144,6 +148,8 @@ class MultiHeadedAttention(nn.Module):
                     if layer_cache["memory_keys"] is None:
                         key, value = self.linear_keys(key),\
                                      self.linear_values(value)
+                        key = shape(key)
+                        value = shape(value)
                     else:
                         key, value = layer_cache["memory_keys"],\
                                    layer_cache["memory_values"]
@@ -152,17 +158,22 @@ class MultiHeadedAttention(nn.Module):
                 else:
                     key, value = self.linear_keys(key),\
                                  self.linear_values(value)
+                    key = shape(key)
+                    value = shape(value)
         else:
             key = self.linear_keys(key)
             value = self.linear_values(value)
             query = self.linear_query(query)
+            key = shape(key)
+            value = shape(value)
 
-        key_len = key.size(1)
-        query_len = query.size(1)
 
-        key_up = shape(key)
-        value_up = shape(value)
+        key_up = key
+        value_up = value
         query_up = shape(query)
+
+        key_len = key_up.size(2)
+        query_len = query_up.size(2)
 
         # 2) Calculate and scale scores.
         query_up = query_up / math.sqrt(dim_per_head)

--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -67,7 +67,7 @@ class MultiHeadedAttention(nn.Module):
         self.final_linear = nn.Linear(model_dim, model_dim)
 
     def forward(self, key, value, query, mask=None,
-                layer_cache=None, type=None, fast=False):
+                layer_cache=None, type=None):
         """
         Compute the context vector and the attention vectors.
 
@@ -121,7 +121,7 @@ class MultiHeadedAttention(nn.Module):
                     .view(batch_size, -1, head_count * dim_per_head)
 
         # 1) Project key, value, and query.
-        if fast:
+        if layer_cache is not None:
             if type == "self":
                 query, key, value = self.linear_query(query),\
                                     self.linear_keys(query),\

--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -66,7 +66,7 @@ class MultiHeadedAttention(nn.Module):
         self.dropout = nn.Dropout(dropout)
         self.final_linear = nn.Linear(model_dim, model_dim)
 
-    def forward(self, key, value, query, mask=None):
+    def forward(self, key, value, query, mask=None, layer_cache=None, type=None):
         """
         Compute the context vector and the attention vectors.
 
@@ -120,9 +120,83 @@ class MultiHeadedAttention(nn.Module):
                     .view(batch_size, -1, head_count * dim_per_head)
 
         # 1) Project key, value, and query.
-        key_up = shape(self.linear_keys(key))
-        value_up = shape(self.linear_values(value))
-        query_up = shape(self.linear_query(query))
+
+        if type == "self":
+
+          query, key, value = self.linear_query(query),\
+                              self.linear_keys(query),\
+                              self.linear_values(query)
+
+          if layer_cache is not None:
+            device = key.device
+            if layer_cache["self_keys"] is not None:
+              key = torch.cat((layer_cache["self_keys"].to(device), key), dim=1)
+            if layer_cache["self_values"] is not None:
+              value = torch.cat((layer_cache["self_values"].to(device), value), dim=1)
+            layer_cache["self_keys"] = key
+            layer_cache["self_values"] = value
+
+          # print("############")
+          # print("SELF")
+          # print("############")
+          # print("############")
+          # print("QUERY")
+          # print(query)
+          # print("############")
+          # print("############")
+          # print("KEY")
+          # print(key)
+          # print("############")
+          # print("############")
+          # print("VALUE")
+          # print(value)
+          # print("############")
+
+
+        elif type == "context":
+
+          query = self.linear_query(query)
+
+          if layer_cache is not None:
+
+            if layer_cache["memory_keys"] is None:
+              key, value = self.linear_keys(key), self.linear_values(value)
+            else:
+              key, value = layer_cache["memory_keys"], layer_cache["memory_values"]
+
+            layer_cache["memory_keys"] = key
+            layer_cache["memory_values"] = value
+          else:
+            key, value = self.linear_keys(key), self.linear_values(value)
+
+          # print("############")
+          # print("CONTEXT")
+          # print("############")
+          # print("############")
+          # print("QUERY")
+          # print(query)
+          # print("############")
+          # print("############")
+          # print("KEY")
+          # print(key)
+          # print("############")
+          # print("############")
+          # print("VALUE")
+          # print(value)
+          # print("############")
+
+        else:
+
+          key = self.linear_keys(key)
+          value = self.linear_values(value)
+          query = self.linear_query(query)
+
+        key_len = key.size(1)
+        query_len = query.size(1)
+
+        key_up = shape(key)
+        value_up = shape(value)
+        query_up = shape(query)
 
         # 2) Calculate and scale scores.
         query_up = query_up / math.sqrt(dim_per_head)

--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -66,7 +66,7 @@ class MultiHeadedAttention(nn.Module):
         self.dropout = nn.Dropout(dropout)
         self.final_linear = nn.Linear(model_dim, model_dim)
 
-    def forward(self, key, value, query, mask=None, layer_cache=None, type=None):
+    def forward(self, key, value, query, mask=None, layer_cache=None, type=None, fast=False):
         """
         Compute the context vector and the attention vectors.
 
@@ -120,29 +120,30 @@ class MultiHeadedAttention(nn.Module):
                     .view(batch_size, -1, head_count * dim_per_head)
 
         # 1) Project key, value, and query.
-        if type == "self":
-          query, key, value = self.linear_query(query),\
-                              self.linear_keys(query),\
-                              self.linear_values(query)
-          if layer_cache is not None:
-            device = key.device
-            if layer_cache["self_keys"] is not None:
-              key = torch.cat((layer_cache["self_keys"].to(device), key), dim=1)
-            if layer_cache["self_values"] is not None:
-              value = torch.cat((layer_cache["self_values"].to(device), value), dim=1)
-            layer_cache["self_keys"] = key
-            layer_cache["self_values"] = value
-        elif type == "context":
-          query = self.linear_query(query)
-          if layer_cache is not None:
-            if layer_cache["memory_keys"] is None:
-              key, value = self.linear_keys(key), self.linear_values(value)
+        if fast:
+          if type == "self":
+            query, key, value = self.linear_query(query),\
+                                self.linear_keys(query),\
+                                self.linear_values(query)
+            if layer_cache is not None:
+              device = key.device
+              if layer_cache["self_keys"] is not None:
+                key = torch.cat((layer_cache["self_keys"].to(device), key), dim=1)
+              if layer_cache["self_values"] is not None:
+                value = torch.cat((layer_cache["self_values"].to(device), value), dim=1)
+              layer_cache["self_keys"] = key
+              layer_cache["self_values"] = value
+          elif type == "context":
+            query = self.linear_query(query)
+            if layer_cache is not None:
+              if layer_cache["memory_keys"] is None:
+                key, value = self.linear_keys(key), self.linear_values(value)
+              else:
+                key, value = layer_cache["memory_keys"], layer_cache["memory_values"]
+              layer_cache["memory_keys"] = key
+              layer_cache["memory_values"] = value
             else:
-              key, value = layer_cache["memory_keys"], layer_cache["memory_values"]
-            layer_cache["memory_keys"] = key
-            layer_cache["memory_values"] = value
-          else:
-            key, value = self.linear_keys(key), self.linear_values(value)
+              key, value = self.linear_keys(key), self.linear_values(value)
         else:
           key = self.linear_keys(key)
           value = self.linear_values(value)

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -367,6 +367,8 @@ class Translator(object):
         results["batch"] = batch
 
         for step in range(self.max_length):
+            # print("STEP: ", step)
+
             decoder_input = alive_seq[:, -1].view(1, -1, 1)
 
             # Decoder forward.

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -367,8 +367,6 @@ class Translator(object):
         results["batch"] = batch
 
         for step in range(self.max_length):
-            # print("STEP: ", step)
-
             decoder_input = alive_seq[:, -1].view(1, -1, 1)
 
             # Decoder forward.

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -377,7 +377,8 @@ class Translator(object):
                 memory_bank,
                 dec_states,
                 memory_lengths=memory_lengths,
-                step=step)
+                step=step,
+                fast=True)
 
             # Generator forward.
             log_probs = self.model.generator.forward(dec_out.squeeze(0))
@@ -530,8 +531,9 @@ class Translator(object):
 
             # Run one step.
             dec_out, dec_states, attn = self.model.decoder(
-                inp, memory_bank, dec_states, memory_lengths=memory_lengths,
-                step=i)
+                inp, memory_bank, dec_states,
+                memory_lengths=memory_lengths,
+                step=i, fast=False)
 
             dec_out = dec_out.squeeze(0)
 

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -332,7 +332,7 @@ class Translator(object):
         _, src_lengths = batch.src
         enc_states, memory_bank = self.model.encoder(src, src_lengths)
         dec_states = self.model.decoder.init_decoder_state(
-            src, memory_bank, enc_states)
+            src, memory_bank, enc_states, with_cache=True)
 
         # Tile states and memory beam_size times.
         dec_states.map_batch_fn(
@@ -375,8 +375,7 @@ class Translator(object):
                 memory_bank,
                 dec_states,
                 memory_lengths=memory_lengths,
-                step=step,
-                fast=True)
+                step=step)
 
             # Generator forward.
             log_probs = self.model.generator.forward(dec_out.squeeze(0))
@@ -531,7 +530,7 @@ class Translator(object):
             dec_out, dec_states, attn = self.model.decoder(
                 inp, memory_bank, dec_states,
                 memory_lengths=memory_lengths,
-                step=i, fast=False)
+                step=i)
 
             dec_out = dec_out.squeeze(0)
 


### PR DESCRIPTION
This is an implementation of the transformer decoder cache.
As it is only beneficial for the fast beam search (thanks @guillaumekln!), its use is conditioned to the `-fast` option.

For 3k segments (WMT EN-DE 2014, sorted) on a GTX 1080:
BATCH 32 - BEAM 5
- fast beam: 77 seconds (peak VRAM usage 7.9G)
- fast beam + cache: 65 seconds (peak VRAM usage 2.4G)

BATCH 32 - BEAM 10
- fast beam: 137 seconds (peak VRAM usage 7.9G)
- fast beam + cache: 114 seconds (peak VRAM usage 3.7G)

