### PR TITLE
add options to transformer (heads, transformer_ff) + fix typo trainer.py

### DIFF
--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -16,34 +16,33 @@ MAX_SIZE = 5000
 class TransformerDecoderLayer(nn.Module):
     """
     Args:
-      size(int): the dimension of keys/values/queries in
+      d_model (int): the dimension of keys/values/queries in
                        MultiHeadedAttention, also the input size of
                        the first-layer of the PositionwiseFeedForward.
-      droput(float): dropout probability(0-1.0).
-      head_count(int): the number of heads for MultiHeadedAttention.
-      hidden_size(int): the second-layer of the PositionwiseFeedForward.
+      heads (int): the number of heads for MultiHeadedAttention.
+      d_ff (int): the second-layer of the PositionwiseFeedForward.
+      droput (float): dropout probability(0-1.0).
+      self_attn_type (string): type of self-attention scaled-dot, average
     """
 
-    def __init__(self, size, dropout,
-                 head_count=8, hidden_size=2048, self_attn_type="scaled-dot"):
+    def __init__(self, d_model, heads, d_ff, dropout,
+                 self_attn_type="scaled-dot"):
         super(TransformerDecoderLayer, self).__init__()
 
         self.self_attn_type = self_attn_type
 
         if self_attn_type == "scaled-dot":
             self.self_attn = onmt.modules.MultiHeadedAttention(
-                head_count, size, dropout=dropout)
+                heads, d_model, dropout=dropout)
         elif self_attn_type == "average":
             self.self_attn = onmt.modules.AverageAttention(
-                size, dropout=dropout)
+                d_model, dropout=dropout)
 
         self.context_attn = onmt.modules.MultiHeadedAttention(
-            head_count, size, dropout=dropout)
-        self.feed_forward = PositionwiseFeedForward(size,
-                                                    hidden_size,
-                                                    dropout)
-        self.layer_norm_1 = onmt.modules.LayerNorm(size)
-        self.layer_norm_2 = onmt.modules.LayerNorm(size)
+            heads, d_model, dropout=dropout)
+        self.feed_forward = PositionwiseFeedForward(d_model, d_ff, dropout)
+        self.layer_norm_1 = onmt.modules.LayerNorm(d_model)
+        self.layer_norm_2 = onmt.modules.LayerNorm(d_model)
         self.dropout = dropout
         self.drop = nn.Dropout(dropout)
         mask = self._get_attn_subsequent_mask(MAX_SIZE)
@@ -132,14 +131,16 @@ class TransformerDecoder(nn.Module):
 
     Args:
        num_layers (int): number of encoder layers.
-       hidden_size (int): number of hidden units
+       d_model (int): size of the model
+       heads (int): number of heads
+       d_ff (int): size of the inner FF layer
        dropout (float): dropout parameters
        embeddings (:obj:`onmt.modules.Embeddings`):
           embeddings to use, should have positional encodings
        attn_type (str): if using a seperate copy attention
     """
 
-    def __init__(self, num_layers, hidden_size, attn_type,
+    def __init__(self, num_layers, d_model, heads, d_ff, attn_type,
                  copy_attn, self_attn_type, dropout, embeddings):
         super(TransformerDecoder, self).__init__()
 
@@ -150,7 +151,7 @@ class TransformerDecoder(nn.Module):
 
         # Build TransformerDecoder.
         self.transformer_layers = nn.ModuleList(
-            [TransformerDecoderLayer(hidden_size, dropout,
+            [TransformerDecoderLayer(d_model, heads, d_ff, dropout,
              self_attn_type=self_attn_type)
              for _ in range(num_layers)])
 
@@ -159,9 +160,9 @@ class TransformerDecoder(nn.Module):
         self._copy = False
         if copy_attn:
             self.copy_attn = onmt.modules.GlobalAttention(
-                hidden_size, attn_type=attn_type)
+                d_model, attn_type=attn_type)
             self._copy = True
-        self.layer_norm = onmt.modules.LayerNorm(hidden_size)
+        self.layer_norm = onmt.modules.LayerNorm(d_model)
 
     def forward(self, tgt, memory_bank, state, memory_lengths=None,
                 step=None, cache=None):

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -68,6 +68,7 @@ def build_encoder(opt, embeddings):
     """
     if opt.encoder_type == "transformer":
         return TransformerEncoder(opt.enc_layers, opt.rnn_size,
+                                  opt.heads, opt.transformer_ff,
                                   opt.dropout, embeddings)
     elif opt.encoder_type == "cnn":
         return CNNEncoder(opt.enc_layers, opt.rnn_size,
@@ -91,6 +92,7 @@ def build_decoder(opt, embeddings):
     """
     if opt.decoder_type == "transformer":
         return TransformerDecoder(opt.dec_layers, opt.rnn_size,
+                                  opt.heads, opt.transformer_ff,
                                   opt.global_attention, opt.copy_attn,
                                   opt.self_attn_type,
                                   opt.dropout, embeddings)

--- a/onmt/modules/position_ffn.py
+++ b/onmt/modules/position_ffn.py
@@ -11,21 +11,19 @@ class PositionwiseFeedForward(nn.Module):
     """ A two-layer Feed-Forward-Network with residual layer norm.
 
         Args:
-            size (int): the size of input for the first-layer of the FFN.
-            hidden_size (int): the hidden layer size of the second-layer
+            d_model (int): the size of input for the first-layer of the FFN.
+            d_ff (int): the hidden layer size of the second-layer
                               of the FNN.
             dropout (float): dropout probability(0-1.0).
     """
 
-    def __init__(self, size, hidden_size, dropout=0.1):
+    def __init__(self, d_model, d_ff, dropout=0.1):
         super(PositionwiseFeedForward, self).__init__()
-        self.w_1 = nn.Linear(size, hidden_size)
-        self.w_2 = nn.Linear(hidden_size, size)
-        self.layer_norm = onmt.modules.LayerNorm(size)
+        self.w_1 = nn.Linear(d_model, d_ff)
+        self.w_2 = nn.Linear(d_ff, d_model)
+        self.layer_norm = onmt.modules.LayerNorm(d_model)
         self.dropout_1 = nn.Dropout(dropout)
         self.relu = nn.ReLU()
-        # Save a little memory, by doing inplace.
-        # self.relu = nn.ReLU(inplace=True)
         self.dropout_2 = nn.Dropout(dropout)
 
     def forward(self, x):

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -107,6 +107,10 @@ def model_opts(parser):
     group.add_argument('-self_attn_type', type=str, default="scaled-dot",
                        help="""Self attention type in Transformer decoder
                        layer -- currently "scaled-dot" or "average" """)
+    group.add_argument('-heads', type=int, default=8,
+                       help='Number of heads for transformer self-attention')
+    group.add_argument('-transformer_ff', type=int, default=2048,
+                       help='Size of hidden transformer feed-forward')
 
     # Genenerator and loss options.
     group.add_argument('-copy_attn', action="store_true",

--- a/onmt/tests/output_hyp.txt
+++ b/onmt/tests/output_hyp.txt
@@ -1,3000 +1,3000 @@
-<unk> Parlament <unk> <unk> <unk>
-Die <unk> <unk> , der <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> , die die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> wurde , <unk> während der <unk> des <unk> für <unk> <unk> .
-In <unk> <unk> wurde <unk> Jahre <unk> für <unk> in <unk> <unk> , was <unk> <unk> <unk> , um <unk> <unk> mit Russland <unk> .
-Die <unk> ist nicht <unk> der <unk> der <unk> in <unk> .
-<unk> der <unk> ist ein politische <unk> der <unk> in der <unk> , der <unk> <unk> hat .
-Die Vorschlag der <unk> <unk> von der <unk> <unk> <unk> <unk> wurde von der <unk> <unk> <unk> , die <unk> <unk> <unk> wurde .
+<unk> Parlament <unk> <unk> <unk> <unk>
+Die <unk> <unk> <unk> , in der <unk> <unk> , in der <unk> <unk> , in der <unk> der <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> .
+Die <unk> , die die <unk> <unk> <unk> <unk> hat , war es in <unk> <unk> <unk> der <unk> für <unk> <unk> .
+In <unk> wurde <unk> <unk> in <unk> <unk> in <unk> <unk> <unk> <unk> .
+Die <unk> ist nicht <unk> die <unk> <unk> der <unk> in <unk> .
+<unk> <unk> die <unk> ist eine politische <unk> der <unk> in der <unk> , die <unk> <unk> <unk> <unk> .
+Die Vorschlag der <unk> <unk> von der <unk> von <unk> <unk> <unk> , <unk> die <unk> <unk> <unk> wurde , war er <unk> <unk> <unk> <unk> .
 <unk> wäre <unk> <unk> <unk> .
 <unk>
-Die <unk> von <unk> oder <unk> hat bereits <unk> .
-<unk> <unk> ist <unk> im <unk> .
-Es ist <unk> , die <unk> zu <unk> .
-Als eine <unk> , <unk> <unk> in der <unk> der Frage ist , ob sie die <unk> oder die <unk> <unk> .
-Die <unk> <unk> <unk> sich eine <unk> der <unk> , der wir bereits <unk> haben .
-<unk> wird ein <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> kann man über <unk> <unk> <unk> <unk> werden .
-<unk> eines <unk> , ein <unk> <unk> der <unk> <unk> werden durch <unk> <unk> .
-<unk> werden wir nicht <unk> , und <unk> nicht für <unk> .
-unser <unk> ist jedoch <unk> <unk> <unk> der besten einen <unk> , <unk> , <unk> , <unk> , <unk> der Menschen .
-<unk> ist es ein <unk> , dass die <unk> <unk> von der <unk> <unk> .
-<unk> nur in <unk> <unk> wurden nur <unk> <unk> durch eine <unk> <unk> <unk> , aber <unk> , die <unk> <unk> sie mit <unk> <unk> .
-<unk> sind für <unk> in <unk> , die <unk> ist nicht auf der Liste .
-Wir <unk> in einer <unk> , <unk> und unsere <unk> <unk> einer <unk> , <unk> <unk> <unk> <unk> <unk> .
-<unk> die <unk> <unk> Erfahrung in <unk> <unk> , <unk> wir gegen <unk> <unk> <unk> .
-Die <unk> <unk> sich nicht <unk> über die &quot; <unk> &quot; .
-<unk> die <unk> Unternehmen der <unk> <unk> <unk> für <unk> <unk> .
-Es ist <unk> <unk> , dass sie <unk> werden soll , um die <unk> <unk> der Menschenrechte <unk> zu <unk> .
-<unk> die <unk> der <unk> <unk> <unk> eine <unk> <unk> .
+Die <unk> von <unk> , <unk> oder <unk> , ist bereits <unk> .
+<unk> <unk> ist ein <unk> <unk> in der <unk> .
+<unk> ist die <unk> .
+Wie eine <unk> , <unk> <unk> in der <unk> ist , ob sie die <unk> oder die <unk> <unk> .
+Die <unk> <unk> <unk> <unk> sich eine <unk> der <unk> <unk> , die wir bereits bereits <unk> haben .
+<unk> wird ein <unk> <unk> Land , als die <unk> für <unk> ist .
+<unk> können <unk> <unk> <unk> <unk> <unk> <unk> werden .
+<unk> eines <unk> , ein <unk> <unk> von <unk> <unk> werden .
+<unk> wird ein <unk> <unk> , <unk> , <unk> , <unk> nicht für <unk> .
+<unk> ist unser <unk> <unk> , die <unk> <unk> der <unk> <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> ist es ein <unk> , dass die <unk> <unk> von der <unk> <unk> <unk> <unk> .
+<unk> nur nur <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Unsere <unk> sind <unk> für <unk> , die <unk> ist nicht <unk> .
+Wir <unk> in einer <unk> , <unk> , <unk> und unsere <unk> <unk> <unk> von einer <unk> , die politische <unk> , ohne die politische <unk> zu <unk> .
+<unk> die <unk> <unk> mit <unk> <unk> , <unk> wir gegen <unk> <unk> <unk> .
+Die <unk> sind nicht über die <unk> der &quot; <unk> &quot; .
+<unk> die <unk> <unk> , wird die <unk> der <unk> <unk> <unk> für <unk> <unk> <unk> .
+Es ist <unk> , dass sie <unk> nicht <unk> wird .
+<unk> die <unk> der <unk> <unk> eine <unk> <unk> .
+<unk> <unk>
+Frankreich und die <unk> Europas Europas <unk> <unk> .
+Ein <unk> <unk> <unk> über Europa auf <unk> .
+<unk> Länder <unk> ihre <unk> <unk> <unk> .
+<unk> <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> .
+<unk> der <unk> ist <unk> <unk> .
+<unk> sind kein <unk> <unk> <unk> , <unk> sie <unk> , <unk> , <unk> und anderen .
+<unk> <unk> <unk> in Deutschland , <unk> , <unk> , <unk> , <unk> und <unk> Länder .
+Die <unk> hat durch die <unk> <unk> und <unk> <unk> .
+<unk> <unk> auch <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+In diesem Jahr <unk> <unk> die <unk> <unk> eine <unk> <unk> .
+<unk> die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> der <unk> <unk> <unk> .
+Die Ergebnisse sind <unk> als <unk> <unk> .
 <unk>
-Frankreich und die <unk> Europas sind nun in der <unk> " <unk> .
-<unk> <unk> über Europa über <unk> <unk> .
-<unk> Länder sind ihre <unk> <unk> <unk> .
-Die <unk> <unk> <unk> der <unk> <unk> und Frankreich sind <unk> .
-<unk> Sie die <unk> <unk> <unk> .
-<unk> sind nicht mehr an nur <unk> , sondern jetzt auf <unk> , Frankreich , <unk> , <unk> und andere .
-<unk> <unk> <unk> in Deutschland , <unk> <unk> und einige Länder sind <unk> ihre <unk> <unk> in der <unk> .
-<unk> ist <unk> von der <unk> <unk> und Frankreich des <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-In diesem Jahr <unk> die <unk> eine <unk> <unk> der <unk> .
-<unk> <unk> die <unk> <unk> .
-Die Ergebnisse sind <unk> als <unk> .
-<unk>
-In diesem Jahr <unk> die Wirtschaft <unk> eine <unk> <unk> der <unk> .
-<unk> auf <unk> und <unk> Daten , in der <unk> der <unk> <unk> .
-<unk> <unk> und <unk> , die Wirtschaft und die <unk> der Europäischen Union , die <unk> und die <unk> der Europäischen Union , die von <unk> <unk> , <unk> , <unk> mit <unk> <unk> .
-Die <unk> <unk> eine <unk> <unk> der <unk> .
-Die <unk> zur <unk> sind <unk> .
-<unk> von beiden <unk> sind <unk> <unk> .
-<unk> <unk> , Frankreich , Frankreich , <unk> , Frankreich und <unk> sind für <unk> Probleme .
-<unk> die Tatsache , dass die Lage in der Region <unk> , <unk> <unk> 1 - <unk> <unk> <unk> .
-<unk> sind <unk> aus Deutschland , <unk> , dass <unk> die <unk> <unk> .
-<unk> <unk> für <unk> .
-<unk> <unk> sie <unk> und <unk> ein <unk> <unk> .
-<unk>
-<unk> <unk> und <unk> <unk> <unk> <unk> <unk> sie <unk> <unk> .
-In den zweiten <unk> wurde <unk> seine <unk> <unk> <unk> , um seine <unk> von <unk> zu <unk> .
+In diesem Jahr <unk> <unk> die <unk> <unk> eine <unk> <unk> der <unk> <unk> .
+Die <unk> und <unk> Daten , in <unk> <unk> , die <unk> und <unk> <unk> .
+<unk> <unk> und <unk> , die Wirtschaft der <unk> und der Europäischen Union <unk> , um die <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> mit <unk> .
+Der <unk> ist eine <unk> <unk> von <unk> .
+Die <unk> der <unk> sind <unk> <unk> .
+<unk> <unk> und <unk> sind in <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> , Frankreich , Frankreich , <unk> sind <unk> <unk> .
+<unk> der Tatsache , dass die Situation in der Region <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> sind die <unk> <unk> , die <unk> <unk> <unk> <unk> .
+<unk> für <unk> .
+<unk> <unk> sie <unk> <unk> und <unk> ein <unk> <unk> <unk> .
+<unk> <unk> <unk> die <unk> <unk> der <unk> !
+<unk> <unk> und <unk> <unk> <unk> , <unk> sie <unk> <unk> .
+Im zweiten <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> aus dem <unk> <unk> <unk> <unk> <unk> .
 <unk> <unk> die <unk> in einer <unk> Bericht .
-<unk> <unk> im ersten <unk> , und ein <unk> <unk> von <unk> in der anderen .
-<unk> <unk> , die von der <unk> <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> , <unk> und <unk> <unk> auf die europäischen <unk> .
-<unk> <unk> <unk> <unk> nur <unk> die <unk> <unk> an .
-<unk> <unk> wurde <unk> <unk> , zwei <unk> <unk> zu <unk> .
-Die <unk> <unk> <unk> ist eines der <unk> <unk> des <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> <unk> , die <unk> war sehr <unk> .
-<unk> Sie <unk> , dass <unk> in der <unk> der <unk> <unk> <unk> <unk> .
-Das war auch kein <unk> Druck des <unk> in den ersten <unk> <unk> .
-<unk>
-Sie <unk> eine <unk> .
-<unk> <unk> <unk> <unk> eine <unk> <unk> in <unk> .
-Die <unk> ist darin , ihre Unterstützung des Landes <unk> <unk> zu unterstützen .
-<unk> <unk> , <unk> &quot; <unk> in <unk> des <unk> waren durch die <unk> und <unk> <unk> .
-<unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Diese <unk> , <unk> sie ihre <unk> zu <unk> , ihre <unk> zu <unk> , ihre eigenen <unk> zu <unk> .
-In den letzten Bericht <unk> die internationale <unk> <unk> <unk> <unk> <unk> , die <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> auf <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> ihre <unk> und <unk> .
-Bei einer <unk> <unk> <unk> die <unk> <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> <unk> <unk> <unk> und <unk> für <unk> <unk> .
-Die <unk> <unk> zwischen Kinder zwischen <unk> und <unk> , während die <unk> <unk> sind .
-Wie eine <unk> <unk> <unk> , <unk> Kinder <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> können wir die Bedeutung der <unk> und <unk> <unk> einen <unk> <unk> .
-Für <unk> <unk> <unk> sich <unk> auf der <unk> von <unk> Kinder , um die <unk> Kinder mit <unk> zu <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> Kinder <unk> die <unk> Kinder <unk> .
-Die <unk> <unk> <unk> die <unk> <unk> .
-Die <unk> <unk> am <unk> des <unk> des <unk> <unk> <unk> <unk> <unk> <unk> mit <unk> <unk> <unk> <unk> <unk> .
-Es war die zweite Jahr von <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> von <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Für das <unk> <unk> sich nur <unk> , sagte sie ein <unk> , in der <unk> <unk> , einer der <unk> <unk> der <unk> <unk> , &quot; <unk> <unk> <unk> <unk> , &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk>
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-In der <unk> <unk> nur <unk> von <unk> <unk> .
-In einer <unk> Mehrheit der <unk> .
-Die <unk> <unk> wurde <unk> , dass ein <unk> <unk> nicht <unk> haben .
-<unk> ist das <unk> von <unk> <unk> <unk> .
-<unk> hat die <unk> <unk> , die mehr <unk> <unk> sind .
-<unk> alle - <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> über <unk> <unk> <unk> , <unk> die Zahl der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , wenn es sich um <unk> <unk> .
-<unk> Ihre eigenen <unk> <unk>
-<unk> Teil der <unk> <unk> Kinder <unk> und <unk> <unk> von <unk> bis <unk> ihre eigenen <unk> auf <unk> <unk> und <unk> .
-&quot; <unk> <unk> <unk> zwischen 12 und 15 <unk> pro <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> und <unk> <unk> .
-&quot; <unk> <unk> ist der <unk> der <unk> <unk> .
-Wie die <unk> für <unk> , <unk> <unk> sehr <unk> <unk> .
-Es <unk> jedoch <unk> <unk> , <unk> , <unk> und <unk> <unk> .
-<unk> im Bereich der Gesundheit und der <unk> in der <unk>
-Die <unk> <unk> <unk> , dass Kinder ihre <unk> <unk> , <unk> sie <unk> Informationen zu <unk> .
-&quot; <unk> <unk> von der <unk> <unk> <unk> eine <unk> von <unk> in <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Diese <unk> ist sehr <unk> , denn <unk> im Falle der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Darüber hinaus sind die <unk> Kinder <unk> und <unk> mehr <unk> , <unk> <unk> und <unk> <unk> .
-Ein <unk> <unk> <unk> ein <unk> <unk> , <unk> <unk>
-Im <unk> <unk> <unk> ich ein <unk> <unk> über die <unk> <unk> <unk> .
-Ich habe <unk> , was ich <unk> .
-<unk> von drei <unk> von drei <unk> <unk> <unk> <unk> für <unk> und <unk> .
-Und mehr ist noch noch zu <unk> .
-<unk> Sie den <unk> <unk> , die <unk> und <unk> <unk> <unk> .
-<unk> <unk> Sie alle <unk> und <unk> , aber es ist wirklich <unk> mit Informationen .
-Diese <unk> , zusammen mit <unk> , die <unk> , die <unk> ist nicht eine <unk> <unk> in der <unk> <unk> , wie die <unk> <unk> ist .
-Ein <unk> im <unk> <unk> nicht <unk> .
-<unk> hat ein <unk> <unk> ohne <unk> <unk> ohne <unk> <unk> <unk> .
-Ein <unk> muss wissen , wie <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> <unk> .
-Wir waren <unk> auf , wie die <unk> der <unk> <unk> <unk> wie <unk> <unk> , <unk> mit <unk> <unk> und <unk> und <unk> <unk> , nicht <unk> .
-<unk> der <unk> zwischen den <unk> und <unk> <unk> , dass die <unk> oder <unk> <unk> werden , ist es <unk> , in einem <unk> <unk> zu <unk> .
-Sie werden nicht die <unk> <unk> , da <unk> <unk> <unk> werden .
-In einem <unk> <unk> werden Sie viel <unk> als in einer <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
-<unk> <unk> <unk> mit <unk> , <unk> , <unk> , <unk> oder <unk> .
-<unk> der <unk> <unk> Informationen , <unk> ich mich <unk> , eine ganze Woche zu <unk> .
-<unk> , ich habe es viel viel <unk> , um die <unk> , die wir <unk> wurden .
-Die <unk> des <unk> wurde mit <unk> <unk> <unk> und <unk> .
-Wir müssen ihre <unk> <unk> <unk> und ihre <unk> <unk> .
-Ich <unk> mich zu <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Ich habe <unk> , wie sie <unk> ist , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-Wir müssen die <unk> <unk> von <unk> oder <unk> werden , wie sie <unk> und <unk> <unk> werden .
-<unk> , wie die <unk> unserer persönlichen <unk> und <unk> <unk> werden .
-Es ist wichtig , dass der <unk> Teil der <unk> <unk> .
-Ein <unk> <unk> nicht nur <unk> <unk> , sondern <unk> , Seiten in <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
-Dies ist was ein <unk> und <unk> , <unk> <unk> , die uns <unk> <unk> .
-Aber das war nicht <unk> .
-<unk> <unk> <unk> <unk>
-Die <unk> der <unk> , <unk> mit Informationen über <unk> <unk> wurde von drei <unk> <unk> .
-Ein <unk> , <unk> <unk> eine <unk> <unk> , <unk> <unk> und eine <unk> <unk> , <unk> <unk> .
-<unk> <unk> uns , dass die <unk> eines <unk> <unk> und eine <unk> sollte <unk> werden .
-Ein <unk> kann mit einem <unk> <unk> <unk> .
-In diesem Fall ist <unk> .
-Zum Beispiel kann ein <unk> <unk> <unk> <unk> <unk> in der <unk> Weise <unk> , <unk> und <unk> , als <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , als <unk> <unk> .
-<unk> ist <unk> der <unk> oder <unk> , und die gesamte <unk> <unk> <unk> .
-&quot; <unk> mit <unk> , &quot; er <unk> .
-Ich <unk> die <unk> <unk> der <unk> &quot; <unk> <unk> &quot; <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> können Sie <unk> <unk> , &quot; <unk> <unk> .
-<unk> ich <unk> , dass wir alle <unk> und die <unk> der <unk> mit <unk> <unk> , was wir in <unk> <unk> <unk> , was wir oft <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> .
-<unk> <unk> , <unk> ich , dass ein <unk> <unk> <unk> , muss mehr <unk> <unk> als die Zahl der <unk> ist .
-Es ist für eine <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> ich , dass in der <unk> ein <unk> der <unk> <unk> und in <unk> mit anderen <unk> noch nicht <unk> .
-Deshalb müssen wir in <unk> <unk> eine <unk> <unk> .
-<unk> <unk> <unk> , dass <unk> und <unk> <unk> werden .
-<unk> <unk> , die keine <unk> <unk> ist , ist es keine <unk> und <unk> <unk> <unk> .
-Das <unk> in <unk> noch immer <unk> <unk> .
-<unk>
-Und wenn man uns <unk> , sollten wir <unk> <unk> , dann sollten wir <unk> <unk> als <unk> <unk> <unk> als <unk> .
-<unk> <unk> wir uns auf die <unk> <unk> , wenn die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> .
-<unk> <unk> und <unk> wurden die Tatsache , dass für eine <unk> es nicht <unk> ist , um <unk> und <unk> zu <unk> .
-Unsere <unk> <unk> von Menschen , <unk> wir <unk> , dass es ein <unk> <unk> ist .
-Um die <unk> zu <unk> , nicht zu <unk> , nicht zu <unk> .
-Wenn ein <unk> <unk> und einige <unk> <unk> <unk> <unk> , können Sie sich nicht <unk> , dass die <unk> <unk> sind .
-&quot; <unk> <unk> in <unk> <unk> können Sie mit &quot; <unk> <unk> und <unk> <unk> .
-Er <unk> auch <unk> , was ein <unk> <unk> <unk> müssen .
-Das ist das <unk> <unk> Ihre <unk> für alle <unk> <unk> .
-<unk> , wie die <unk> <unk> , <unk> <unk> <unk> , sollte es eine <unk> <unk> <unk> , die die <unk> von <unk> wie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Um die <unk> von <unk> und einige <unk> Erfahrung zu <unk> und einige <unk> Erfahrung zu <unk> .
-<unk> , wenn die <unk> in einem <unk> <unk> , wo die <unk> noch <unk> <unk> haben , nicht <unk> <unk> <unk> .
-Und so waren wir doch <unk> .
-Sie müssen nicht die <unk> mit den <unk> <unk> , <unk> <unk> .
-Das <unk> <unk> <unk> .
-<unk> <unk> mir .
-Die <unk> <unk> sind nicht <unk> .
-Dies ist nur ein <unk> , was wir in der <unk> <unk> haben .
-Ich habe mich vor , dass es ein <unk> <unk> ist , keine <unk> <unk> zu können .
-<unk> <unk> für die <unk> des <unk> <unk> <unk> .
-<unk>
-Ein <unk> <unk> <unk> <unk> in einer <unk> <unk> <unk> <unk> , weil der <unk> <unk> <unk> und <unk> <unk> <unk> .
-<unk> wurden die <unk> ein <unk> <unk> , aber es ist keine Angelegenheit .
-<unk> war es <unk> , dass neue Version <unk> <unk> <unk> <unk> <unk> .
-Es <unk> sich auf die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Wir haben uns <unk> , dass die <unk> <unk> <unk> und <unk> <unk> .
-In der <unk> <unk> <unk> die <unk> <unk> , was wir <unk> .
-Das <unk> <unk> ein <unk> <unk> , aber die gesamte <unk> ist <unk> von <unk> <unk> in der <unk> für Jahre <unk> .
-Das bedeutet , dass <unk> nicht wirklich <unk> , sondern das <unk> einer <unk> <unk> der <unk> .
-Die <unk> <unk> sehr gut gut .
-Sie <unk> in einer <unk> , wo die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
-Sie haben im <unk> über die <unk> <unk> , in <unk> <unk> , und Ihre <unk> ist für die erste <unk> <unk> .
-<unk> <unk> mehrere <unk> .
-Die <unk> ist <unk> in <unk> <unk> .
-Das bedeutet <unk> <unk> am <unk> <unk> , und <unk> <unk> sind in <unk> und <unk> <unk> .
-<unk> ist es nicht der richtigen <unk> .
-<unk> die <unk> <unk> auf der gleichen <unk> , einige der <unk> <unk> zu <unk> , sind es sehr <unk> .
-<unk> ist nichts <unk> .
-<unk> Sie durch die <unk> , <unk> , <unk> oder <unk> in <unk> <unk> .
-<unk> sind die <unk> , die von <unk> <unk> <unk> .
-Für den <unk> in <unk> haben Sie die <unk> .
-Auf dem anderen Seite haben Sie die <unk> nicht unter einem <unk> <unk> .
-<unk> <unk> sind <unk> <unk> .
-Es gibt nur ein <unk> , aber es ist <unk> .
-Für ein <unk> <unk> <unk> Sie eine Reihe von <unk> <unk> , <unk> Sie die <unk> <unk> oder Sie in einer <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> der <unk> sind <unk> .
-Sie werden nur <unk> <unk> , wo die <unk> der <unk> <unk> ist , und Sie müssen ihm <unk> , daß die <unk> der <unk> auf das Recht <unk> .
-<unk> <unk> <unk> .
-Es ist ein <unk> , dass diese <unk> viel viel <unk> ist , als sie <unk> <unk> <unk> werden .
-Es ist <unk> , gut zu sein , weil dieses <unk> nicht innerhalb der <unk> <unk> , was er bereits gesagt ist , es ist , dass die <unk> <unk> .
-Die <unk> <unk> die <unk> <unk> .
-<unk> bedeutet , dass <unk> <unk> ist , aber es kann nicht <unk> werden .
-Wenn Sie eine <unk> <unk> , haben Sie <unk> .
-Das <unk> <unk> ist <unk> für die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Das ist alles sehr <unk> .
-Aber nach <unk> <unk> <unk> <unk> .
-In <unk> mit der <unk> wird die <unk> <unk> nicht gut .
-<unk> ein <unk> <unk> , ein <unk> nicht <unk> und <unk> , aber wenn Sie keine <unk> <unk> haben , da Sie keine <unk> <unk> , da Sie keine <unk> <unk> .
-<unk> , wenn <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> , <unk> <unk> <unk> .
-Dies ist nicht <unk> , dass diese <unk> nicht die <unk> <unk> , aber <unk> ist , die <unk> zu <unk> .
-Die <unk> sind so <unk> , wenn man <unk> oder <unk> die <unk> , <unk> <unk> <unk> .
-<unk> gibt es nur fünf <unk> pro <unk> .
-Wenn Sie ihnen , haben Sie die <unk> von den <unk> <unk> .
-Diese <unk> <unk> in <unk> <unk> nicht <unk> , aber Sie können keine <unk> <unk> .
-<unk> <unk> sind nicht <unk> und Sie brauchen eine <unk> <unk> des <unk> von <unk> .
-<unk> <unk> der <unk> ist der Tatsache , dass die <unk> oft in der <unk> <unk> <unk> <unk> .
-Für <unk> gibt es durch eine <unk> <unk> <unk> , <unk> Sie einfach einfach .
-Bei anderen <unk> im <unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf <unk> , fünf
-Dies ist besonders <unk> in <unk> , wo Sie Ihre <unk> in den <unk> zwei <unk> <unk> , während Sie sich <unk> <unk> <unk> oder <unk> <unk> <unk> .
-Es <unk> nicht , wenn Sie alles <unk> haben , alles zu <unk> ist , dass die Lage immer in <unk> Ihres <unk> <unk> .
-Die <unk> haben auch <unk> <unk> .
-<unk> Sie die <unk> <unk> , wo Sie mehrere <unk> , wo <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Das ist <unk> am Ende des <unk> , in <unk> <unk> <unk> <unk> , wo Sie im <unk> <unk> <unk> .
-<unk> hat Ihre <unk> nicht <unk> .
-Die <unk> ist , dass er <unk> in <unk> von Ihnen <unk> , er hat <unk> <unk> , die Sie die <unk> eines <unk> <unk> .
-<unk> kann man die <unk> im <unk> <unk> <unk> und <unk> , aber es ist so <unk> <unk> .
-Es ist ein <unk> , weil sie die <unk> <unk> <unk> , <unk> die <unk> <unk> <unk> und <unk> <unk> <unk> .
-Das ist nicht wichtig , ob die <unk> <unk> nicht <unk> ist , <unk> oder <unk> <unk> .
-Die <unk> der <unk> <unk> während der <unk> ist <unk> .
-Sie haben <unk> für die <unk> des <unk> <unk> <unk> , die <unk> ist , wo Sie die Tatsache <unk> , dass man die Tatsache <unk> , dass man die Tatsache <unk> , dass Sie <unk> <unk> haben .
-<unk> sind in drei <unk> .
-<unk> <unk> sind <unk> für <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Der <unk> <unk> ist <unk> <unk> mit der <unk> <unk> <unk> <unk> .
-<unk> , Sie <unk> auch <unk> und Erfahrung , die <unk> und <unk> <unk> .
-<unk> <unk> <unk> <unk> ein <unk> <unk> mit <unk> und <unk> mit <unk> <unk> .
-<unk> ist die <unk> mit einem <unk> <unk> <unk> , die sich mit <unk> von anderen <unk> , und <unk> <unk> .
-<unk> eine andere <unk> <unk> , ist der Situation von der <unk> in der <unk> .
-Sie haben Ihre <unk> in einem <unk> <unk> <unk> , <unk> Sie <unk> die <unk> in den <unk> <unk> .
-<unk> <unk> <unk> von <unk> bis <unk> <unk> / <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Für <unk> Tage <unk> sich unser <unk> <unk> <unk> <unk> , ob wenn die <unk> keine <unk> <unk> , oder ob die <unk> wirklich <unk> ist .
-Das <unk> <unk> der <unk> , ist nichts <unk> , aber die <unk> <unk> <unk> ist <unk> <unk> <unk> .
-Es ist ein <unk> , das sich in einigen Fällen <unk> , die <unk> , in einigen Fällen <unk> , <unk> .
-Dieses <unk> betrifft <unk> mit großen Zahl , wo <unk> <unk> <unk> würde .
-Die <unk> ist alle <unk> der <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> von <unk> für <unk> ist <unk> .
-Wenn die <unk> <unk> , dass wir sagen , könnten wir sagen , dass die <unk> der <unk> für die <unk> in <unk> Jahren <unk> .
-Die <unk> <unk> <unk> .
-Es ist ein <unk> <unk> , aber <unk> <unk> sich durch die <unk> mit dem <unk> der <unk> <unk> .
-<unk> <unk>
-Das <unk> <unk> <unk> bietet <unk> die internationale <unk> &quot; <unk> und <unk> <unk> mit einer <unk> <unk> .
-Es wird über <unk> hohen <unk> und <unk> <unk> <unk> .
-Die <unk> der <unk> ist auf <unk> <unk> , die die <unk> <unk> <unk> .
-&quot; <unk> <unk> <unk> ist <unk> <unk> , <unk> &quot; <unk> .
-&quot; <unk> <unk> <unk> <unk> die <unk> der <unk> <unk> und <unk> <unk> <unk> , wird der <unk> , <unk> der <unk> <unk> <unk> <unk> .
-Die <unk> wird ein <unk> <unk> <unk> durch eine <unk> <unk> <unk> , der das Ziel des <unk> <unk> im <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> , ein <unk> von einem <unk> <unk> <unk> , <unk> <unk> auf der Programm .
-In der <unk> <unk> <unk> <unk> wird in <unk> eine &quot; <unk> für <unk> &quot; <unk> , <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , die aus der <unk> <unk> .
-Die <unk> ist darin , die internationale <unk> &quot; <unk> und die <unk> der <unk> mit <unk> als auch für die <unk> <unk> der <unk> mit <unk> <unk> <unk> .
-Die <unk> <unk> ist <unk> <unk> <unk> in Zusammenarbeit mit <unk> und <unk> <unk> .
-Die gesamte <unk> ist unter der <unk> der <unk> <unk> <unk> , <unk> <unk> und <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> und <unk> .
-Das Programm bietet <unk> <unk> und einen <unk> <unk> , <unk> &quot; <unk> , <unk> &quot; und <unk> .
-<unk> Informationen finden Sie bitte bitte <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk>
-<unk> haben die <unk> <unk> und <unk> <unk> .
-&quot; <unk> <unk> der <unk> <unk> zwischen <unk> .
-&quot; Ich habe nicht <unk> sein .
-&quot; Es wird fünf fünf fünf <unk> <unk> , <unk> , <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> , wie sie <unk> ist , ist <unk> , dass sie <unk> <unk> und die <unk> zwischen ihnen <unk> <unk> , wo sie <unk> <unk> und die <unk> zwischen ihnen <unk> <unk> , <unk> , <unk> , <unk> , <unk> und <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> , <unk> , <unk> , <unk> ,
-<unk> , <unk> <unk> der <unk> der <unk> .
-&quot; <unk> er war <unk> , sagte er <unk> <unk> , ein <unk> <unk> <unk> , die nicht mehr <unk> <unk> habe , dass er seine Rolle <unk> <unk> &quot; habe .
-<unk> &quot; <unk> ist eine Person , die kann alle <unk> <unk> <unk> , <unk> mit ihnen <unk> <unk> , und die <unk> ist ein <unk> <unk> , wo der EU <unk> &quot; <unk> werden sollten .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk>
-Die <unk> <unk> auf der Tagesordnung der EU für die EU in der <unk> , <unk> und <unk> .
-Die <unk> <unk> <unk> von der <unk> vor dem Jahr <unk> .
-<unk> waren mit den <unk> <unk> <unk> , <unk> sie die <unk> und <unk> der Osten <unk> .
-<unk> sagte , <unk> der Regierung bei der Zeit des <unk> <unk> war , die <unk> <unk> <unk> zu <unk> .
-<unk> , <unk> <unk> in der EU war sehr <unk> .
-Als <unk> sagte , wie die <unk> <unk> und die <unk> <unk> <unk> eine <unk> <unk> .
-Darüber hinaus ist eine neue <unk> für eine <unk> <unk> <unk> , die sehr <unk> werden soll .
-<unk> die <unk> <unk> <unk> und <unk> , die <unk> werden , die <unk> <unk> werden , und die <unk> alle <unk> sind , die <unk> <unk> .
-Das <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Ich bin wirklich nicht <unk> .
-Wie sind die Bürger , die in <unk> nicht <unk> oder <unk> <unk> , <unk> , <unk> , <unk> oder <unk> , <unk> , <unk> oder <unk> .
-<unk> auch die <unk> der EU <unk> <unk> , <unk> mehr in europäischen Institutionen .
-<unk>
-Die <unk> <unk> sind <unk> , wie <unk> die <unk> <unk> als die <unk> <unk> <unk> .
-<unk> mehr sind <unk> <unk> , die in europäischen Institutionen <unk> .
-<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> mit dem Erfolg von <unk> <unk> , <unk> <unk> die <unk> und die Zusammenarbeit der <unk> .
-<unk> , wenn ich von der <unk> und <unk> <unk> und <unk> <unk> ist , uns <unk> , dass die <unk> <unk> wieder <unk> ist ?
-In der Zukunft ist der <unk> <unk> <unk> der <unk> der <unk> .
-<unk> als eine neue europäischen <unk> , sie <unk> die <unk> der <unk> , <unk> nicht <unk> .
-&quot; Wir Länder sowohl als Länder <unk> .
-&quot; Wir haben <unk> <unk> , und wir haben schon eine <unk> Zusammenarbeit haben .
-&quot; Für die erste Zeit war es gesagt , dass die Länder , die nicht <unk> sind , <unk> , die nicht <unk> sind .
-&quot; Der <unk> von <unk> <unk> wird es ein sehr <unk> <unk> <unk> , wird &quot; <unk> &quot; <unk> &quot; .
-In diesem Zusammenhang hat sie die <unk> sowohl die <unk> <unk> und <unk> <unk> <unk> <unk> <unk> , die die gesamte <unk> <unk> <unk> , die gesamte <unk> <unk> , <unk> und nicht nur nicht <unk> werden .
-<unk>
-Die <unk> <unk> der <unk> <unk>
-<unk> <unk> <unk> für die <unk> , die die <unk> <unk> , <unk> eine <unk> <unk> .
-<unk> <unk> ist ein <unk> <unk> der <unk> <unk> <unk> .
-Die <unk> <unk> sich auf seine ersten <unk> , ein <unk> , <unk> <unk> <unk> <unk> .
-Er <unk> in seiner <unk> <unk> , die zahlreichen <unk> <unk> können , wenn die Menschen <unk> können .
-<unk> <unk> <unk> <unk> &apos; <unk> &apos; <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> war es der <unk> <unk> Kultur <unk> <unk> .
-Die <unk> <unk> <unk> sich in <unk> <unk> <unk> <unk> .
-Eine <unk> Jahre <unk> und <unk> für eine <unk> Jahre , weil es <unk> , dass sie sich nicht <unk> ist , alles zu <unk> .
-Während unserer ersten <unk> und der Unternehmen .
-Im <unk> Jahrhundert <unk> wir <unk> , dass <unk> <unk> <unk> <unk> <unk> werden können .
-<unk>
-Im <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> ist der <unk> <unk> mit <unk> .
-<unk> wurde der <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> mit dem <unk> ist der <unk> <unk> ein <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> .
-<unk> wurde <unk> für <unk> <unk> <unk> , <unk> , <unk> und <unk> .
-In den letzten Jahren wurde <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-Es ist keine <unk> , dass der <unk> <unk> - die Unternehmen <unk> eine <unk> <unk> <unk> .
-<unk> mit einem <unk> <unk> <unk>
-<unk> <unk> <unk> ist <unk> durch seine <unk> <unk> und <unk> <unk> .
-&quot; <unk> <unk> ist der <unk> der <unk> <unk> , dass der <unk> eines <unk> <unk> als eine <unk> Unternehmen <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; <unk> ist nicht ein <unk> <unk> , dass die <unk> <unk> <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Als <unk> hat sich <unk> zwischen <unk> und <unk> <unk> .
-Während der <unk> Jahre <unk> , <unk> , <unk> oder <unk> in den USA als <unk> in den USA .
-Es scheint , dass die <unk> Technologie - <unk> und <unk> <unk> und <unk> <unk> <unk> und <unk> <unk> <unk> <unk> .
-Es <unk> die meisten <unk> aller Technologie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk>
-<unk> aller Produkten <unk> die <unk> sowohl die <unk> und <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Deshalb <unk> <unk> die <unk> ihrer <unk> <unk> - wenn sie <unk> nicht <unk> .
-Dies ist , wie es von der <unk> <unk> , für die <unk> , <unk> , <unk> , <unk> und <unk> auf <unk> , <unk> <unk> .
-<unk>
-Die <unk> <unk> <unk> von <unk> , über eine <unk> von <unk> und <unk> .
-<unk> in <unk> mit über einer <unk> <unk> , war es das <unk> <unk> .
-Seit 2000 <unk> hat <unk> <unk> <unk> 15 <unk> <unk> .
-Es hat <unk> die <unk> noch nach 2008 , wenn der <unk> <unk> <unk> <unk> .
-<unk> die <unk> ihrer ersten <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Darüber hinaus ist <unk> <unk> <unk> durch die <unk> <unk> ohne <unk> <unk> .
-Seit Anfang 2008 wurde die Preis von <unk> <unk> <unk> <unk> <unk> pro <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> ist <unk> , alles zu <unk> .
-Deshalb kann ich <unk> , dass <unk> eine solche Krise in diesem <unk> <unk> , wird diese <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Es <unk> die <unk> <unk> in <unk> <unk> .
-Die <unk> <unk> wurden von einer <unk> <unk> <unk> <unk> , die <unk> auf den <unk> <unk> .
-Sie <unk> <unk> wie die Zeit &quot; <unk> , &quot; <unk> eine <unk> <unk> und <unk> <unk> .
-Die <unk> des neuen Unternehmen wurde <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> ein <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> <unk> zu helfen .
-Die <unk> <unk> die <unk> der <unk> in der <unk> - <unk> der <unk> für <unk> <unk> und <unk> .
-<unk> <unk> bis <unk> <unk> .
-<unk> , wie Namen <unk> , <unk> von <unk> und <unk> <unk> <unk> - aus <unk> und <unk> <unk> .
-Während des ersten <unk> von <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> so <unk> für Unternehmen , dass nach <unk> <unk> <unk> <unk> <unk> <unk> wurde .
-<unk> seiner <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> und <unk> die ersten <unk> .
-Im <unk> , sowohl der <unk> und <unk> von <unk> <unk> <unk> <unk> <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
-<unk> , in <unk> <unk> die ersten <unk> - die <unk> <unk> / <unk> .
-Die <unk> <unk> , die die <unk> <unk> der <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
-<unk> Jahre <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-In der drei Jahren ist mit <unk> mit <unk> <unk> <unk> <unk> .
-<unk> <unk> ist <unk> von <unk> in <unk> , die keine <unk> <unk> und <unk> <unk> .
-Für <unk> hat die <unk> <unk> eine <unk> <unk> , das die <unk> <unk> <unk> <unk> .
-Die Geschichte <unk> ist <unk> auch in unserem Land .
-In <unk> <unk> <unk> die ersten Land in anderen <unk> und <unk> Europa , <unk> die <unk> ihrer <unk> in <unk> .
-<unk> <unk> <unk> <unk> <unk> in <unk> .
-Die <unk> für die <unk> und <unk> Europa in <unk> , wo es auch eine <unk> <unk> auf <unk> <unk> <unk> .
-<unk>
-<unk> , <unk> <unk> ich mir <unk> !
-<unk>
-Nach dem <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> die <unk> und <unk> <unk> <unk> <unk> <unk> <unk> .
-Allerdings muss sie jedoch nicht <unk> , nicht mehr zu <unk> und <unk> <unk> zu <unk> .
-&quot; <unk> <unk> <unk> , aber nicht mehr als mein <unk> , &quot; <unk> <unk> <unk> .
-Wenn der <unk> <unk> <unk> <unk> für <unk> in <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-<unk> wäre es <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> , er <unk> <unk> <unk> <unk> .
-Nach einigen <unk> , <unk> , <unk> , <unk> , <unk> <unk> , ihre <unk> und <unk> zu <unk> .
-<unk> <unk> nicht , die <unk> <unk> mit <unk> <unk> .
-<unk> wenn einer Tag <unk> und <unk> wäre , würde seine <unk> nicht <unk> , seine <unk> wird er <unk> <unk> .
-&quot; Er ist der <unk> <unk> , wenn er seine Tagen in unseren <unk> <unk> , nicht <unk> .
-&quot; <unk> wird er seine Tage als <unk> , <unk> und <unk> <unk> <unk> , aber auch <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> und <unk> <unk> .
-<unk> , <unk> <unk> , dass seine <unk> die <unk> <unk> <unk> .
-&quot; Ich <unk> meine <unk> des <unk> .
-&quot; Ich werde mit <unk> , und ich <unk> dies nicht <unk> .
-&quot; <unk> <unk>
-<unk> &quot; <unk> <unk> <unk> ich <unk> in <unk> , <unk> , <unk> und <unk> .
-&quot; <unk> und ich <unk> in einem <unk> <unk> <unk> <unk> , &quot; <unk> sagte für <unk> , &quot; sagte für <unk> <unk> .
-Er <unk> <unk> , wenn <unk> ein <unk> <unk> , <unk> er nicht in ihren <unk> .
-&quot; Wir <unk> nicht , und ich <unk> nicht , dass sie mit <unk> <unk> , und wenn sie ein <unk> <unk> hat .
-Ich weiß es , dass meine <unk> nicht <unk> bin , und ich <unk> <unk> <unk> .
-<unk> Sie den <unk> <unk> <unk> und <unk> Sie <unk> ?
-Wenn man den Namen <unk> <unk> <unk> <unk> <unk> <unk> <unk> haben , <unk> sie mit allen <unk> in einer <unk> .
-<unk> meine <unk> <unk> in der <unk> , <unk> <unk> <unk> <unk> <unk> , die <unk> <unk> <unk> ?
-<unk>
-<unk> Ihre <unk> <unk> Sie <unk> ?
-Wer muss zu einem <unk> von <unk> <unk> ?
-<unk> Sie <unk> , in <unk> <unk> <unk> ?
-Wenn dies Ihre <unk> <unk> , kann das <unk> nicht <unk> .
-<unk> Frauen <unk> sich <unk> , wie sie ihre <unk> für <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> kann eine <unk> für Frauen , <unk> <unk> <unk> werden .
-<unk> <unk> <unk> , wie viele <unk> <unk> haben , für Sie <unk> ...
-<unk>
-&quot; <unk> <unk> ich <unk> ?
-&quot; Ich muss noch einige <unk> <unk> - sollte einige <unk> <unk> ?
-&quot;
-<unk> Sie diese <unk> <unk> ?
-Sie haben ?
-<unk> , Sie haben die Gruppe der <unk> <unk> durch Frauen <unk> .
-<unk> , Sie sollten nach <unk> <unk> , aber viele <unk> sind <unk> <unk> , um <unk> <unk> <unk> zu <unk> .
-Die <unk> <unk> auch <unk> , dass die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> und <unk> <unk> <unk>
-Es ist ein <unk> <unk> .
-<unk> die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> ein <unk> Woche .
-<unk> Sie Ihre <unk> für die <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Bei diesem <unk> &quot; <unk> <unk> &quot; <unk> <unk> , dass keine <unk> und <unk> <unk> <unk> , <unk> und <unk> <unk> sollten .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk>
-&quot; <unk> Sie den <unk> in den <unk> .
-&quot;
-&quot; <unk>
-Wenn Sie Ihre <unk> <unk> <unk> , kann er sehr <unk> <unk> .
-Wenn Sie gut gut <unk> , haben Sie alles <unk> .
-<unk> , wenn <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , sie <unk> ...
-<unk>
-<unk> Frauen <unk> Frauen <unk> <unk> , <unk> , und <unk> <unk> .
-<unk> sind <unk> auf <unk> , die <unk> , die <unk> , <unk> und <unk> .
-<unk> Sie nun <unk> und dann <unk> jeder <unk> ein <unk> oder <unk> .
-Das ist <unk> das <unk> <unk> Frauen .
-Es gibt <unk> <unk> , Frauen , die die <unk> <unk> und <unk> alle <unk> <unk> .
-<unk> und <unk> <unk>
-Während der <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> in der <unk> auch der <unk> <unk> , <unk> <unk> .
-Nach der <unk> <unk> <unk> <unk> er eine <unk> <unk> für <unk> .
-&quot; Ich <unk> ihm vor dem <unk> <unk> <unk> <unk> .
-&quot; Ich <unk> es &quot; .
-&quot; Sie haben <unk> <unk> , <unk> &quot; <unk> , &quot; <unk> , nach dem <unk> <unk> <unk> eine <unk> auf dem ersten <unk> &quot; .
-<unk> Sie das <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> <unk> die <unk> und <unk> sie zu <unk> , die zwischen den <unk> <unk> .
-<unk> <unk> die ersten <unk> , ein <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> .
-Nach <unk> mit <unk> , er <unk> die <unk> <unk> <unk> <unk> , <unk> er <unk> in einem <unk> <unk> .
-&quot; Ich <unk> <unk> <unk> .
-&quot; Ich <unk> meine <unk> <unk> , <unk> er <unk> <unk> , aber er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Ich bin überzeugt , dass bei der <unk> meine <unk> <unk> habe .
-&quot; Es ist mir <unk> .
-&quot; Ich möchte ihn &quot; <unk> .
-&quot; Alle Jahre <unk> in <unk> , meine <unk> , meine <unk> , und ich <unk> &quot; <unk> <unk> <unk> .
-<unk> <unk> die <unk> <unk> mit <unk> <unk> und <unk> von einem <unk> <unk> , <unk> sie eine <unk> <unk> .
-<unk> wurden <unk> von <unk> <unk> <unk> , die die <unk> <unk> <unk> .
-&quot; <unk> <unk> <unk> in unserem <unk> .
-&quot; Er <unk> die <unk> , <unk> ich <unk> , und <unk> <unk> auf die <unk> <unk> .
-&quot; Ich <unk> mich auf , und ich <unk> mich <unk> , dass die letzten <unk> der letzten <unk> des <unk> <unk> .
-<unk> <unk> <unk> <unk> die <unk> <unk> .
-<unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> auf einer der <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-&quot; Die Situation ist <unk> .
-&quot; Wir <unk> die <unk> mit einer <unk> <unk> , die <unk> <unk> <unk> .
-&quot; Wir können jedoch nichts <unk> , dass wir über &quot; <unk> , &quot; <unk> <unk> <unk> .
-&quot; <unk> <unk> ist es <unk> und <unk> <unk> .
-&quot; Wir sollten die <unk> <unk> <unk> , <unk> die <unk> unserer <unk> <unk> .
-&quot; Das war unser <unk> , &quot; <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> &quot; <unk> , die eine <unk> <unk> von fünf verschiedene <unk> <unk> wurden .
-<unk>
-<unk> <unk> , <unk> <unk> <unk> <unk> <unk> in <unk> <unk> , <unk> , <unk> und <unk> .
-Als <unk> <unk> war <unk> <unk> <unk> , <unk> <unk> der <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die einzige <unk> war das <unk> von <unk> , in dem wir die Gelegenheit <unk> , um <unk> <unk> zu <unk> , die <unk> <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> .
-Eine sehr <unk> <unk> war , dass die Bürger der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Wenn ein <unk> <unk> <unk> , als <unk> , <unk> , für <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-Bei der Zeit <unk> sich <unk> <unk> , aber ein <unk> <unk> <unk> <unk> <unk> in der <unk> <unk> mit einem <unk> oder einige <unk> <unk> .
-<unk> , dass nicht alle <unk> .
-Ein <unk> <unk> <unk> <unk> <unk> <unk> für die <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> , <unk> <unk> , <unk> eine <unk> <unk> .
-<unk> bis <unk> im <unk> oder <unk> war der <unk> unseres <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> wir nicht <unk> , dass <unk> <unk> die <unk> <unk> <unk> nicht <unk> können .
-<unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> .
-<unk> könnte nicht <unk> <unk> , dass die <unk> <unk> <unk> <unk> , um einen <unk> <unk> .
-Zum Beispiel in <unk> , <unk> <unk> <unk> in <unk> in <unk> , weil ihre <unk> in <unk> <unk> <unk> <unk> <unk> , ein <unk> oder ein <unk> <unk> .
-Ein <unk> <unk> von <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> zu <unk> .
-<unk> <unk> ist der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Unsere <unk> <unk> und <unk> wurden <unk> <unk> , die <unk> in einem anderen wichtigen <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Ende des <unk> ist <unk> nicht <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Als <unk> <unk> in 2000 <unk> <unk> <unk> <unk> <unk> <unk> in 2000 .
-Da dann <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> ein <unk> wichtige <unk> dieser <unk> , <unk> in 2008 .
-Auf den <unk> <unk> 2008 hat die <unk> <unk> <unk> für <unk> <unk> .
-Für die erste Zeit in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk>
-<unk> fünf Monate , <unk> <unk> hat keine Gelegenheit .
-Es gibt noch nicht <unk> , dass <unk> <unk> .
-<unk> , die für drei <unk> wird nicht <unk> .
-<unk> <unk> , <unk> , <unk> und <unk> sind <unk> <unk> .
-Die <unk> <unk> aus seinem <unk> im Juni <unk> , <unk> er in <unk> und <unk> eine <unk> <unk> , die im <unk> <unk> würde .
-<unk> der <unk> <unk> <unk> in <unk> zwischen <unk> als auch <unk> <unk> <unk> , um <unk> zu <unk> .
-Das war <unk> <unk> auf <unk> <unk> , wenn ein neue <unk> <unk> wurde .
-<unk> <unk> <unk> ihre <unk> <unk> in <unk> <unk> , <unk> , wie die Verhandlungen <unk> <unk> , nicht nur in der <unk> <unk> .
-<unk> <unk> <unk> als <unk> <unk> , ob die <unk> <unk> nur <unk> oder auch <unk> <unk> <unk> <unk> .
-Diese <unk> ist <unk> seit <unk> der <unk> und <unk> , die <unk> auf <unk> <unk> ist .
-Die <unk> des <unk> werden allerdings <unk> .
-Die <unk> <unk> ist <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> hat mehrere <unk> <unk> , aber die <unk> ist <unk> .
-Die Frage , die sich in den <unk> <unk> , um <unk> ?
-&quot; Das <unk> ist <unk> auf , ob die <unk> oder die <unk> eines anderen <unk> <unk> , &quot; <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> des <unk> <unk> der <unk> ist die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> ist <unk> , dass ein <unk> mit dem <unk> der <unk> <unk> von <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> eine <unk> , die in der <unk> <unk> , muss <unk> <unk> <unk> <unk> .
-&quot; <unk> wäre es zwei <unk> <unk> , die <unk> <unk> <unk> , die <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> des <unk> .
-<unk> Sie den <unk> <unk> .
-&quot; Ich möchte alle <unk> von <unk> <unk> , wie bei der <unk> <unk> <unk> , der <unk> <unk> , der <unk> <unk> , der für die erste <unk> und in seiner <unk> <unk> <unk> .
-<unk> ist ein <unk> .
-Er <unk> die neue Präsidentin , die in <unk> <unk> , <unk> er auch <unk> , dass in der Zukunft die <unk> <unk> <unk> .
-&quot; <unk> <unk> wird mit heute <unk> <unk> der <unk> in den europäischen <unk> " <unk> <unk> in den europäischen <unk> .
-&quot; <unk> <unk> wird auf der <unk> <unk> , <unk> , <unk> , &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> ist <unk> .
-<unk> &quot; Ich hoffe , dass ein Abkommen <unk> ist , aber die Lage ist &quot; <unk> &quot; .
-&quot; Es ist zwischen <unk> von <unk> und <unk> , aber es gibt <unk> auf <unk> <unk> .
-&quot; Das kann das <unk> <unk> <unk> .
-&quot; Ich hoffe , dass die <unk> <unk> <unk> &quot; <unk> .
-<unk> gibt es nicht um ein <unk> zwischen der <unk> .
-<unk> Verhandlungen haben bereits <unk> Verhandlungen <unk> haben , um die <unk> <unk> , aber die <unk> ist der <unk> <unk> <unk> <unk> .
-Die <unk> <unk> , die <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> von <unk> , <unk> , <unk> und <unk> möchte die <unk> <unk> <unk> <unk> <unk> <unk> die <unk> <unk> des <unk> <unk> <unk> <unk> .
-<unk> ist im <unk> Regierung <unk> <unk> <unk> und die <unk> <unk> <unk> <unk> <unk> .
-<unk>
-Wenn der <unk> <unk> , die <unk> <unk> , die <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> ich eine gute <unk> <unk> , <unk> ich mich <unk> , und nicht <unk> in der <unk> .
-&quot; Aber kein <unk> hat sich nicht <unk> , &quot; <unk> , <unk> <unk> , <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> , <unk> <unk> , <unk> <unk> <unk> würde er nur <unk> , wenn ein <unk> <unk> <unk> wird , wenn ein <unk> <unk> <unk> wird .
-In Zukunft möchte er den <unk> <unk> zu einem <unk> <unk> <unk> , nicht <unk> <unk> zu <unk> .
-&quot; Ich <unk> mich auf einige <unk> , die <unk> &quot; <unk> werden kann .
-&quot; Ich war mich <unk> , einige von ihnen sagen , daß sie <unk> <unk> , nicht zu <unk> .
-&quot; Ich <unk> mich zu <unk> .
-<unk> der <unk> <unk> mit <unk> ist <unk> auf der <unk> des <unk> <unk> , <unk> von <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> der <unk> <unk> <unk> .
-Deshalb <unk> ich <unk> , dass es <unk> ist .
-<unk> er <unk> , <unk> Situation <unk> und nichts in <unk> wäre <unk> .
-&quot; <unk> mit Unterstützung von <unk> , einer <unk> <unk> , würde der <unk> , <unk> &quot; <unk> <unk> .
-Er ist <unk> am <unk> , dass einige Jahre <unk> <unk> <unk> wurde , ohne einen <unk> <unk> zu <unk> .
-&quot; Ich weiß nicht , was <unk> der <unk> <unk> würde .
-&quot; Und wie wäre der <unk> <unk> und <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Im Falle <unk> <unk> auf <unk> <unk> , könnte er die Zusammenarbeit mit <unk> im <unk> <unk> .
-Dies ist <unk> durch eine andere <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
-&quot; &quot; <unk> <unk> wäre der ersten <unk> ich <unk> .
-<unk> ist sehr <unk> <unk> .
-&quot; Ich kann ihm als <unk> der <unk> <unk> .
-<unk> <unk> kann er nicht <unk> .
-&quot; Ich <unk> nicht <unk> , dass ich nicht <unk> habe , nicht <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> von <unk> , <unk> von <unk> , <unk> von <unk> , <unk> , <unk> von <unk> , <unk> von <unk> , <unk> , <unk> von <unk> , <unk> von <unk> , <unk> , <unk> von <unk> , <unk> von <unk> , <unk> , <unk> von <unk> , <unk> , <unk> von <unk> , <unk> , <unk> von <unk> , <unk> von <unk> , <unk> , <unk> von <unk>
-<unk> wäre er <unk> , die <unk> zu <unk> .
-Er war <unk> , seine <unk> <unk> von <unk> <unk> seit dem letzten <unk> <unk> <unk> , das erste <unk> in Mai <unk> .
-&quot; Ich habe die <unk> , die <unk> <unk> <unk> zu unterstützen , die <unk> <unk> zu unterstützen .
-&quot; <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> seiner <unk> wäre die <unk> zwischen <unk> und dem <unk> <unk> <unk> , die er bei den <unk> der <unk> <unk> <unk> <unk> , <unk> <unk> .
-&quot; Das <unk> eines der <unk> , sollte die neuen Präsident <unk> &quot; .
-<unk> <unk> <unk> auf <unk> , wie die politische <unk> <unk> , <unk> ich <unk> , aber sie muss aber <unk> , wo der <unk> &quot; , &quot; <unk> &quot; <unk> &quot; <unk> <unk> .
-<unk> <unk> <unk> seine <unk> mit dem <unk> eines <unk> , <unk> er <unk> , dass ein <unk> <unk> sollte .
-<unk> ist <unk> , und <unk> <unk> <unk> .
-&quot; Es ist nicht <unk> .
-&quot; <unk> , ich bin nicht ein Problem in den <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> Tage vor der <unk> in der <unk> der <unk> <unk> , einer der <unk> <unk> , <unk> , <unk> , <unk> , <unk> er <unk> , würde er <unk> <unk> , <unk> er <unk> <unk> , <unk> er <unk> <unk> .
-<unk> Sie die <unk> Verhandlungen in <unk> , eine <unk> <unk> zu <unk> und <unk> , dass die <unk> <unk> <unk> durch die <unk> <unk> <unk> .
-Die <unk> <unk> in <unk> <unk> , <unk> <unk> <unk> , <unk> er auf die <unk> und <unk> der <unk> <unk> .
-Er <unk> auf den letzten <unk> in den letzten <unk> <unk> .
-&quot; <unk> &quot; in <unk> haben <unk> für <unk> in <unk> <unk> , und sie haben <unk> <unk> .
-&quot; Sie <unk> es als <unk> Zeit der <unk> , &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> und <unk> .
-Dies ist ihm die <unk> , die er <unk> hat , <unk> <unk> zu <unk> .
-Er <unk> <unk> Probleme mit <unk> von den <unk> <unk> worden .
-&quot; <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> in <unk> <unk> .
-<unk> <unk> , <unk> wir nicht <unk> <unk> , würde &quot; <unk> <unk> <unk> <unk> .
-Er <unk> die <unk> der <unk> <unk> als <unk> für die <unk> .
-<unk> ich Frau <unk> , dass ich <unk> , und ich <unk> <unk> <unk> , um die <unk> <unk> zu <unk> .
-&quot; Es ist ein <unk> , wir nicht ohne &quot; <unk> <unk> .
-<unk> als , dass er er <unk> <unk> , <unk> er <unk> , gegen den <unk> zu <unk> .
-In der <unk> hat er seine Zusammenarbeit mit <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Für eine lange Zeit <unk> er nicht <unk> , <unk> er nicht <unk> , die <unk> <unk> ist .
-&quot; Er <unk> im Jahr <unk> und einige Erfolg .
-&quot; <unk> <unk> jedoch jedoch nicht <unk> , und viele Menschen waren von der <unk> des <unk> <unk> &quot; .
-<unk> ist es , dass einige <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Er <unk> seine <unk> <unk> in <unk> , von der <unk> <unk> <unk> .
-Die <unk> sollte der <unk> <unk> .
-&quot; <unk> <unk> wäre auch auf die <unk> oder die <unk> des <unk> oder der <unk> von <unk> <unk> .
-&quot; <unk> nach der <unk> möchte ich mich auf die <unk> mit dem <unk> <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> .
-Er <unk> <unk> , dass seine <unk> die <unk> der <unk> nicht <unk> <unk> .
-&quot; Ich bin für die Arbeit der <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> die <unk> <unk> <unk> , <unk> er <unk> , dass auf der <unk> nicht <unk> <unk> , <unk> <unk> .
-<unk> &quot; <unk> <unk> ist <unk> , wie <unk> die <unk> <unk> können .
-&quot; <unk> <unk> ist es nur durch <unk> <unk> , die ihre <unk> <unk> , <unk> &quot; , <unk> , <unk> , <unk> , <unk> , <unk> .
-<unk> <unk> <unk> <unk>
-Wenn <unk> der <unk> <unk> , <unk> <unk> , ist der <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> , wenn er <unk> , <unk> <unk> <unk> wird .
-Er <unk> auf <unk> <unk> und <unk> <unk> des <unk> <unk> für den <unk> <unk> .
-Er <unk> auch <unk> , die <unk> <unk> zu <unk> , um die <unk> zu <unk> und <unk> <unk> zu <unk> und <unk> <unk> zu <unk> .
-&quot; <unk> Herr Präsident ! Ich möchte mich auf <unk> <unk> <unk> .
-&quot; <unk> <unk> mit <unk> und <unk> , <unk> , <unk> und <unk> für die <unk> .
-&quot; <unk> , ich bin <unk> , dass ich alles wirklich <unk> habe , <unk> &quot; <unk> in seiner <unk> <unk> .
-&quot; Ich <unk> eine <unk> <unk> , und ich möchte die <unk> in den <unk> <unk> , so möchte ich die <unk> im <unk> <unk> .
-<unk>
-&quot; Das wäre nicht <unk> <unk> , wie sie <unk> wäre , nicht nur <unk> des <unk> <unk> , nicht nur <unk> des <unk> .
-<unk> Atmosphäre in <unk> <unk> , die er <unk> <unk> .
-&quot; Ich <unk> <unk> <unk> , 20 Stunden zu <unk> <unk> .
-&quot; Aber ich muss wissen , wenn es <unk> ist und dass es nicht von Menschen <unk> werden , <unk> &quot; <unk> &quot; <unk> &quot; , er <unk> er <unk> .
-&quot; <unk> &quot; <unk> ich mir <unk> , nicht <unk> ich <unk> , wie <unk> <unk> <unk> .
-&quot; Das <unk> ich nicht nur in &quot; <unk> , &quot; er sagte .
-<unk> <unk> er seine <unk> <unk> , ist er <unk> , wie er mit <unk> <unk> wird .
-&quot; Eine große <unk> für den <unk> in <unk> <unk> <unk> ich zwei Jahre <unk> , und ich <unk> dies nicht .
-&quot; <unk> haben sich <unk> , dass <unk> in einigen Jahren <unk> , und ich möchte nicht <unk> , dass die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-&quot; Ich glaube in der <unk> , die ich <unk> ist , nicht <unk> .
-&quot; &quot; <unk> &quot; ist <unk> von Menschen , die <unk> <unk> würde , so dass es nur für die <unk> <unk> .
-&quot; Ich kann für viele Dinge <unk> , aber die <unk> nicht <unk> .
-&quot; Ich <unk> mich zu sein .
-&quot; Ich möchte mich auf jeden Fall , weil dann alle alle guten Mal <unk> , &quot; sagte .
-<unk> , er würde der <unk> <unk> nur eine <unk> <unk> .
-<unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Beispiel ist es <unk> , die zweite <unk> in <unk> und <unk> <unk> , die in den ersten <unk> <unk> würde .
-&quot; <unk> wäre das <unk> <unk> , wo es sich drei <unk> <unk> in <unk> <unk> , <unk> &quot; <unk> <unk> .
-<unk> <unk> ist <unk> von <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
-&quot; <unk> , ich kann noch noch ein <unk> Unterstützung in den <unk> <unk> , die mir seine <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Auf der anderen Seite <unk> er die Tatsache , dass die <unk> <unk> nicht <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> , dass er eine große Arbeit <unk> hat .
-<unk> er ist <unk> , ich hoffe , er würde er in der <unk> <unk> <unk> , ohne <unk> <unk> zu <unk> .
-<unk> <unk> sich nicht zu <unk> , <unk> &quot; <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk>
-<unk>
-<unk> <unk>
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> ist ein <unk> <unk> .
-Es war ein <unk> <unk> <unk> , <unk> nicht auf die <unk> einer <unk> <unk> .
-<unk> Sie auf das Wasser <unk> , hat sie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> <unk> sie zu <unk> , sie zu ihrem <unk> - mit <unk> <unk> zu <unk> - <unk> zu <unk> .
-Das <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> in <unk> , <unk> , <unk> , <unk> , <unk> und <unk> für <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> für <unk> , <unk> , <unk> , <unk> , <unk> und <unk> für <unk> , <unk> , <unk> , <unk> , <unk> und <unk> für <unk> , <unk> , <unk> , <unk> , <unk> und <unk> für <unk> , <unk> , <unk> , <unk> , <unk> und <unk> für <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und
-Die <unk> ist ein <unk> <unk> Kultur .
-<unk> hat sehr <unk> für <unk> , <unk> , <unk> , aber in der <unk> <unk> .
-Das <unk> ist <unk> , dass <unk> mit <unk> <unk> <unk> und die <unk> <unk> können , die in der <unk> <unk> der <unk> <unk> <unk> oder <unk> <unk> können .
-&quot; <unk> Tag , ich habe <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; <unk> <unk> ich <unk> <unk> .
-<unk> <unk> <unk>
-<unk> im <unk> <unk> und <unk> <unk> - die <unk> <unk> in <unk> ist so wichtig , weil alle <unk> <unk> sind .
-Und <unk> <unk> kann eine <unk> <unk> für die <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> ist sehr <unk> , aber auch <unk> die <unk> der gesamten <unk> .
-<unk> ist <unk> <unk> <unk> <unk> , <unk> <unk> und <unk> <unk> .
-Die <unk> <unk> die <unk> der <unk> und <unk> <unk> <unk> über <unk> <unk> und <unk> über <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> während in <unk> .
-<unk> <unk> <unk> <unk> in einer <unk> <unk> <unk> in <unk> und ein <unk> <unk> mit <unk> in <unk> <unk> in <unk> <unk> .
-<unk> der <unk> <unk> in <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Sie <unk> während der <unk> drei <unk> <unk> <unk> .
-<unk> in der <unk>
-<unk> <unk> <unk> wurde nicht <unk> von den <unk> <unk> in jedem <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> ist von der <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> mit <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> war jedoch im <unk> in ihren <unk> <unk> in ihren <unk> <unk> <unk> , <unk> sie die <unk> <unk> .
-Die <unk> , die von der <unk> <unk> in <unk> <unk> wurden <unk> .
-Wenn der <unk> durch die <unk> <unk> , <unk> und <unk> <unk> <unk> , könnte sie <unk> <unk> <unk> .
-<unk> ist der <unk> <unk> in der <unk> <unk> - die <unk> <unk> in <unk> <unk> .
-Die <unk> haben bereits durch drei <unk> <unk> <unk> <unk> <unk> von der <unk> von <unk> <unk> , war es <unk> in <unk> , aber auch eine <unk> <unk> in <unk> <unk> .
-Die <unk> <unk> in <unk> , die <unk> <unk> ist der <unk> <unk> der <unk> <unk> <unk> <unk> <unk> und nicht nur <unk> , weil sie <unk> vom <unk> <unk> .
-&quot; Es ist ein <unk> <unk> , um solche <unk> <unk> zu <unk> , <unk> &quot; <unk> <unk> .
-Ein <unk> in der <unk> in der <unk> <unk> eine <unk> Bedeutung .
-<unk> <unk>
-<unk> <unk> hat <unk> <unk> <unk>
-<unk> <unk>
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> ?
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> sich auf <unk> <unk> .
-<unk> - <unk> - <unk>
-Für die Lage ist klar <unk> .
-<unk> <unk> dieser <unk> <unk> , dass <unk> <unk> und andere <unk> <unk> in <unk> <unk> , wie <unk> die <unk> <unk> <unk> <unk> .
-Die <unk> waren im Namen der <unk> für <unk> und <unk> <unk> auf im Namen der <unk> <unk> .
-<unk> ist <unk> auf <unk> <unk> .
-Die <unk> der Berichts , <unk> , <unk> , <unk> , <unk> auf <unk> <unk> <unk> <unk> <unk> - und die <unk> sind daher in <unk> <unk> <unk> .
-Die von <unk> <unk> ist <unk> auf der <unk> von <unk> <unk> <unk> , <unk> <unk> große <unk> <unk> wie <unk> und <unk> <unk> .
-<unk> war <unk> als <unk> <unk> gegen <unk> <unk> .
-<unk> sind die <unk> <unk> <unk> , dass die <unk> auf die Regeln und die <unk> - <unk> - <unk> <unk> des <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> auf <unk> <unk> , ein internationale <unk> <unk> <unk> in der <unk> <unk> .
-<unk> sollte die <unk> des Jahres <unk> , wenn die <unk> der <unk> <unk> <unk> <unk> - mit <unk> für <unk> <unk> .
-Die <unk> des <unk> <unk> sich auf die <unk> des <unk> <unk> <unk> .
-<unk> <unk> <unk> oder <unk> <unk> .
-<unk>
-Die <unk> von <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> ist <unk> <unk> , <unk> <unk> zu <unk> .
-&quot; <unk> <unk> muss alle <unk> von seinen <unk> <unk> , <unk> , <unk> <unk> <unk> .
-&quot; Es ist nicht , ob dieses ist nicht <unk> oder die <unk> von <unk> <unk> .
-<unk> möchte ich <unk> <unk> <unk> , aber dann würde der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> <unk> auf <unk> , die die <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> könnte seine <unk> <unk> .
-Er <unk> auch für die Kosten - wenn die Kosten des <unk> <unk> werden .
-<unk> in zwei <unk> würde <unk> <unk> <unk>
-<unk> ist <unk> , die <unk> auf die <unk> <unk> .
-Um <unk> zu <unk> haben die <unk> der <unk> <unk> .
-<unk> <unk> die <unk> auf <unk> .
-<unk> mehr als <unk> <unk> , es ist <unk> für <unk> <unk> , die auf der <unk> der <unk> <unk> .
-<unk> <unk> <unk> sich auch eine <unk> <unk> , wenn sie ihre <unk> <unk> ist , die in zwei zwei <unk> <unk> <unk> ist , die in zwei <unk> <unk> <unk> .
-<unk> wäre <unk> die <unk> , <unk> <unk> , <unk> sie <unk> , dass die <unk> ihre <unk> und <unk> <unk> .
-<unk>
-Das <unk>
-<unk> <unk>
-Ein <unk> <unk> <unk> in <unk> , <unk> und eine <unk> .
-<unk> ist es , wie ein <unk> <unk> .
-<unk> <unk> , <unk> von <unk> <unk> für die <unk> <unk> <unk> <unk> , ist <unk> ein <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-<unk> <unk> der <unk> <unk> <unk> in <unk> für seine <unk> <unk> .
-Die <unk> ist <unk> ein <unk> im <unk> .
-Sie <unk> die <unk> <unk> , dass er auch <unk> <unk> <unk> .
-Er <unk> <unk> , <unk> mit seiner <unk> <unk> <unk> und seine <unk> <unk> .
-Die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-Die <unk> wurde jedoch nicht als <unk> für <unk> und <unk> <unk> - <unk> es keine <unk> und <unk> <unk> .
-Es ist <unk> , bis zu <unk> <unk> zu <unk> .
-Die <unk> <unk> von <unk> und <unk> in eine <unk> und <unk> <unk> .
-Die <unk> <unk> <unk> hat nun die <unk> <unk> , die die &quot; <unk> &quot; <unk> &quot; und wird als <unk> <unk> <unk> werden .
-Die <unk> ist ein <unk> der <unk> <unk> , die <unk> <unk> wird - einen <unk> in <unk> <unk> .
-<unk> <unk> der neuen <unk> der neuen <unk> in Deutschland wurde <unk> in den neuen <unk> <unk> .
-<unk> , ein <unk> <unk> <unk> mit einem <unk> <unk> in ihren <unk> als <unk> <unk> , <unk> <unk> und <unk> <unk> <unk> , <unk> <unk> <unk> und <unk> <unk> .
-Die neue <unk> wurde <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> &amp; <unk> <unk>
-<unk> wurde <unk> die <unk> <unk> , die <unk> <unk> .
-Er war <unk> , <unk> und <unk> <unk> der <unk> , aber auch <unk> die <unk> , aber er <unk> auch unter <unk> auf dem <unk> <unk> <unk> und der <unk> <unk> .
-Er <unk> die <unk> <unk> und <unk> die Probleme der <unk> , ein <unk> , der bereits <unk> <unk> , <unk> und <unk> <unk> .
-Die Probleme <unk> die <unk> <unk> viel <unk> .
-Die <unk> <unk> der <unk> waren <unk> , <unk> <unk> <unk> <unk> wurde <unk> und <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> haben <unk> und die <unk> <unk> <unk> worden .
-Und die <unk> <unk> ist es , wie es <unk> wird .
-Das <unk> unter den <unk> <unk> und mit einem <unk> <unk> .
-&quot; Wir <unk> , dass wir ein <unk> <unk> , <unk> , <unk> und <unk> mit dem <unk> der <unk> <unk> , &quot; <unk> <unk> , <unk> &quot; <unk> <unk> <unk>
-Die <unk> hat <unk> und <unk> die <unk> , Probleme und <unk> <unk> .
-<unk> <unk> <unk> <unk> , dass die <unk> &quot; <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> wie dieses <unk> ist ein <unk> <unk> &quot; und <unk> <unk> für &quot; <unk> .
-Die <unk> <unk> ist sehr <unk> , als es war der <unk> in <unk> <unk> .
-<unk> auch eine <unk> <unk> der <unk> <unk> <unk> <unk> werden .
-<unk>
-<unk> <unk> hat sich mit einem <unk> <unk> , um <unk> in den <unk> zu <unk> .
-Die Zahl der <unk> ist <unk> .
-Die Kosten <unk> die <unk> .
-In einer <unk> Bericht <unk> , wird <unk> <unk> mehr als <unk> Millionen Euro <unk> .
-<unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> ist <unk> , die <unk> von <unk> und die <unk> zu verbessern , aber auch in der <unk> von <unk> <unk> <unk> .
-Die Zahl der <unk> und <unk> <unk> , die von <unk> <unk> <unk> und <unk> ist , zu <unk> .
-Die <unk> ist sehr <unk> und <unk> von <unk> und <unk> von <unk> und <unk> .
-<unk> <unk> , <unk> der <unk> <unk> , <unk> von <unk> und <unk> dieses <unk> <unk> <unk> <unk> .
-<unk> <unk> , <unk> <unk> <unk> <unk> in seiner <unk> <unk> , als sie <unk> in der <unk> <unk> <unk> <unk> .
-<unk> neue <unk> sind für <unk> von der <unk> <unk> <unk> .
-In der <unk> gibt es auch einige <unk> <unk> .
-<unk> <unk> hat auch die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk>
-<unk> <unk> ist <unk> am <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Wie wenn die Probleme bei <unk> nicht <unk> wurden , <unk> die <unk> der <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die Frage der <unk> <unk> <unk> .
-Die <unk> der Union <unk> eine <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Der Wert der <unk> <unk> während des <unk> und <unk> die <unk> .
-Die <unk> zu haben <unk> die Frage , die <unk> <unk> , <unk> &quot; <unk> <unk> in neuen <unk> <unk> .
-Der <unk> hat nicht <unk> <unk> .
-<unk> ist der <unk> , die <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> der <unk> .
-Die <unk> <unk> <unk> ist für die <unk> <unk> <unk> und <unk> in <unk> auf <unk> .
-Die <unk> ist <unk> für <unk> , dass <unk> in der <unk> <unk> .
-Die <unk> <unk> die ersten von <unk> .
-Der <unk> hat auch andere <unk> <unk> und <unk> <unk> <unk> , die <unk> der <unk> und <unk> <unk> in der <unk> <unk> .
-Die <unk> <unk> sind <unk> <unk> .
-Sie <unk> die <unk> <unk> .
-Diese <unk> ist die <unk> eines Reihe von <unk> <unk> .
-Die USA <unk> , <unk> , <unk> , <unk> , <unk> , <unk> in <unk> 2008 im <unk> des <unk> <unk> .
-Die <unk> <unk> in der <unk> Jahren <unk> <unk> .
-<unk> und <unk> haben <unk> für <unk> oder <unk> <unk> .
-Das <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> ist <unk> , dass die <unk> Verantwortung für <unk> &quot; <unk> &quot; , aber das ist nicht der <unk> <unk> .
-<unk> <unk> hat die <unk> als <unk> und <unk> seine <unk> <unk> .
-<unk>
-<unk> <unk> <unk> <unk> <unk> in der <unk> und <unk> .
-Seit <unk> ist er <unk> <unk> <unk> mehr als <unk> <unk> .
-<unk> jetzt <unk> die <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> die <unk> <unk> seine <unk> in der <unk> .
-<unk> möchte er viel <unk> <unk> , dass die <unk> <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> ist <unk> ein <unk> in der <unk> Welt .
-Die <unk> <unk> <unk> hat nun die <unk> der <unk> <unk> <unk> <unk> .
-<unk> <unk> hatte er <unk> <unk> <unk> <unk> <unk> seit <unk> auf den USA <unk> .
-<unk> <unk> <unk> <unk> , <unk> <unk> hat eine der größten <unk> in <unk> mit einem <unk> <unk> .
-<unk> sagte , dass <unk> <unk> nicht <unk> <unk> .
-Er <unk> die <unk> , die in <unk> <unk> <unk> <unk> .
-&quot; Sie haben eine sehr <unk> Arbeit <unk> , sagte <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
-Für die <unk> lange Zeit ist <unk> auf <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> - <unk> mehr als <unk> Jahre <unk> - auch die <unk> für <unk> und <unk> <unk> .
-<unk> hatte <unk> <unk> <unk> , die <unk> <unk> <unk> .
-Er <unk> nur zu <unk> .
-<unk> in einer <unk> <unk> , für eine <unk> <unk> und eine <unk> <unk> .
-<unk> <unk> <unk> , <unk> <unk> , <unk> <unk> in einer <unk> Liste der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> über den kleinen <unk> <unk> <unk> in der <unk> und <unk> , mit <unk> <unk> , in einer der <unk> <unk> und <unk> .
-<unk> <unk> , <unk> <unk> <unk> <unk> , <unk>
-Ich bin ihm eine <unk> <unk> für <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> für <unk> <unk> , <unk> &quot; <unk> von <unk> .
-Die <unk> <unk> ist durch eine <unk> <unk> der <unk> der <unk> .
-&quot; <unk> <unk> , &quot; <unk> ist auch auch <unk> , als <unk> <unk> auf der <unk> <unk> und <unk> .
-<unk> hat jedoch gesagt , dass er nicht <unk> ist , in <unk> zu <unk> .
-<unk> ist ein <unk> <unk> .
-<unk>
-Die <unk> der &quot; <unk> <unk> , <unk> <unk> <unk> über die <unk> der <unk> in Deutschland .
-<unk> <unk> einer &quot; <unk> &quot; , das jetzt <unk> ist .
-Die <unk> von <unk> und 2006 wurde <unk> <unk> zwischen 2000 und 2006 Jahren .
-<unk> und <unk> ist in Deutschland und <unk> des Berichts in Deutschland .
-Für <unk> <unk> <unk> die <unk> <unk> ein <unk> <unk> .
-Es gab noch nicht <unk> , dass die <unk> in Deutschland <unk> .
-Die <unk> <unk> <unk> , dass nun jetzt <unk> ist , ist jedoch <unk> <unk> .
-&quot; <unk> dies ein <unk> der <unk> <unk> ?
-Die <unk> <unk> , auf der anderen Seite , möchte ich <unk> <unk> , dass die <unk> die <unk> <unk> <unk> <unk> <unk> werden .
-Die <unk> der <unk> <unk> , <unk> der <unk> <unk> <unk> <unk> in <unk> der <unk> <unk> im <unk> .
-<unk> zwei <unk> <unk> , die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> mit <unk> und <unk> <unk> .
-<unk> zwischen zwei Ländern wurde <unk> in einem <unk> <unk> <unk> .
-Die von einigen <unk> <unk> wurde <unk> <unk> worden .
-Die <unk> <unk> <unk> auch nicht die <unk> , dieses <unk> zu <unk> .
-&quot; <unk> ist der <unk> des <unk> von <unk> <unk> .
-Er <unk> <unk> , dass die <unk> <unk> , die <unk> <unk> und eine wichtige Beitrag zur <unk> des <unk> mit ihrem <unk> <unk> haben .
-Die <unk> der <unk> und der <unk> <unk> <unk> ist <unk> auf <unk> <unk> .
-Die <unk> sind <unk> , die <unk> Behörden sind , dass die <unk> Behörden nicht <unk> , <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> &quot; <unk> .
-&quot; <unk> in Deutschland <unk> sehr <unk> auf , wie die gesamte <unk> ist und auf der <unk> <unk> , &quot; <unk> &quot; .
-Die <unk> auf <unk> und <unk> im <unk> sind für <unk> <unk> .
-Die <unk> des <unk> <unk> <unk> <unk> in <unk> und <unk> <unk> .
-<unk> anderer <unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> die <unk> der <unk> <unk> .
-<unk>
-Die <unk> im <unk> <unk> <unk> der <unk> <unk> <unk> die <unk> <unk> .
-Er <unk> eine <unk> von <unk> für die <unk> <unk> in Deutschland , aber es war <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> in Deutschland <unk> .
-<unk> , wenn er den Wert eines Person <unk> , <unk> er <unk> die <unk> eines Person .
-Die von der <unk> <unk> in der <unk> <unk> , wie die <unk> der <unk> <unk> in der aktuellen <unk> <unk> ist .
-<unk> <unk> , was jetzt <unk> ist , <unk> <unk> zu <unk> und <unk> <unk> zu <unk> .
-Das <unk> <unk>
-Die <unk> <unk> in Europa nicht in <unk> oder Frankreich , aber in <unk> .
-Die <unk> <unk> sich <unk> während der <unk> <unk> und ist von einem Krise , die den <unk> <unk> .
-<unk> ist nun <unk> .
-<unk> hat die <unk> nicht <unk> , dass er seine Rolle <unk> werden .
-Nach seiner <unk> <unk> war es <unk> <unk> , dass er ein <unk> <unk> <unk> <unk> würde , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> war sehr <unk> , <unk> <unk> für seine <unk> und <unk> für seine <unk> <unk> und <unk> <unk> .
-&quot; <unk> <unk> ist <unk> zu <unk> &quot; .
-&quot; Ich bin auf <unk> und <unk> <unk> <unk> .
-Es war schon klar gemacht , dass alles <unk> , daß alles sehr <unk> <unk> .
-Ein <unk> im <unk> <unk> <unk> alle <unk> der <unk> der <unk> und der <unk> von <unk> <unk> .
-<unk> <unk> , <unk> <unk> - ein <unk> nicht nur <unk> in <unk> - <unk> <unk> .
-Die <unk> <unk> <unk> seit seit Jahren <unk> <unk> <unk> <unk> <unk> ?
-<unk> ist es , die <unk> von <unk> <unk> <unk> .
-Und er wird auf der Rolle der <unk> in Mai und nicht in <unk> , die <unk> auf <unk> <unk> .
-Das <unk> <unk> <unk> .
-Er ist ein <unk> <unk> und <unk> <unk> , die eine <unk> <unk> , und eine <unk> wäre es zu <unk> .
-<unk> <unk> er sich auf die Strategie der Strategie der <unk> <unk> , die wieder <unk> hat , dass es die <unk> <unk> der &quot; <unk> <unk> ist .
-<unk> sowohl in der <unk> - er wurde von einem <unk> <unk> in der Welt <unk> - und hat von einem <unk> <unk> <unk> .
-Die <unk> <unk> , <unk> <unk> ist es <unk> .
-Das <unk> im <unk> .
-<unk> hat <unk> <unk> <unk> 2007 <unk> .
-Die <unk> <unk> die <unk> der <unk> und <unk> , aber <unk> <unk> <unk> <unk> mit <unk> <unk> , ein <unk> <unk> in <unk> <unk> .
-<unk> <unk> wurde im Bereich 2007 <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> des <unk> <unk> <unk> <unk> als <unk> <unk> .
-Das <unk> eine <unk> .
-Die <unk> <unk> <unk> und <unk> <unk> auf den <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> eines guten <unk> .
-&quot; <unk> , was wir heute wissen , wie ich <unk> kann , wie ich <unk> <unk> &quot; .
-Er war sehr <unk> .
-In <unk> ist klar <unk> , dass ein wirklich <unk> <unk> <unk> .
-Im <unk> der <unk> des Jahres <unk> <unk> eine große <unk> und <unk> <unk> <unk> <unk> .
-<unk> Monate die <unk> Monate <unk> wir auf <unk> <unk> , <unk> er <unk> <unk> .
-Die <unk> <unk> der <unk> <unk> auf <unk> <unk> und <unk> <unk> .
-<unk> <unk> eine <unk> <unk> , die <unk> <unk> oder nicht , <unk> <unk> <unk> zu <unk> .
-Die <unk> ist <unk> , aber <unk> viele <unk> wäre ein <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Das war nur die erste <unk> .
-Es <unk> eine <unk> <unk> in <unk> .
-Die <unk> wurde <unk> neue <unk> in den <unk> und <unk> der <unk> der <unk> , <unk> <unk> - die zweite <unk> <unk> in <unk> - <unk> .
-<unk> in <unk> 2008 .
-Die <unk> <unk> <unk> <unk> von <unk> für <unk> <unk> und <unk> <unk> <unk> <unk> für <unk> <unk> der <unk> .
-Die gesamte <unk> wurde <unk> - die <unk> des <unk> <unk> für einen Land von <unk> .
-<unk> <unk> <unk> <unk> <unk> in <unk> war <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-&quot; Wir würden nicht <unk> , dass die <unk> für eine <unk> Zeit &quot; <unk> <unk> <unk> <unk> .
-Die zweite <unk> <unk> <unk> am <unk> des <unk> .
-Ein <unk> <unk> später , <unk> <unk> in der <unk> <unk> mit dem <unk> und <unk> , die <unk> <unk> wurde , die <unk> mit den <unk> der <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> von <unk> <unk> von <unk> <unk> <unk> von <unk> und <unk> .
-<unk> gibt es mehr oder weniger <unk> , um <unk> zu <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> , dass immer seine <unk> <unk> <unk> , die <unk> der <unk> .
-<unk> <unk> <unk> <unk> wurde nicht der gleichen <unk> .
-Die <unk> und der <unk> sind <unk> und <unk> <unk> .
-die <unk> von <unk> Geld <unk> .
-Die <unk> <unk> <unk> ihre <unk> <unk> in beiden Monate - in <unk> <unk> <unk> <unk> und in <unk> <unk> <unk> <unk> .
-Aber <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> ist klar - <unk> - <unk> in der <unk> <unk> <unk> noch nicht <unk> .
-&quot; Die <unk> <unk> hat deutlich <unk> , dass <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> und <unk> <unk> .
-Die <unk> eines großer <unk> <unk> <unk> hat auch keine <unk> <unk> .
-Es war <unk> der <unk> , dass die <unk> der <unk> <unk> <unk> <unk> <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , aber die <unk> , ob die <unk> <unk> oder nicht <unk> .
-Die <unk> von <unk> <unk> <unk> <unk> eine <unk> von <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> in <unk> noch immer den <unk> der <unk> <unk> <unk> <unk> - nur eine <unk> <unk> .
-Die <unk> Lage ist <unk> .
-Die <unk> hat auf der <unk> der <unk> <unk> , die von der <unk> <unk> <unk> <unk> , die von der <unk> <unk> <unk> <unk> .
-Das <unk> sind <unk> und die <unk> <unk> <unk> .
-<unk> <unk> wie <unk> , die <unk> zu <unk> , die <unk> zu <unk> , die <unk> zu <unk> .
-Die <unk> haben hier für die <unk> von <unk> - von der <unk> <unk> <unk> und <unk> <unk> <unk> .
-Ein <unk> <unk> <unk> <unk> die <unk> <unk> .
-Die <unk> sind in <unk> im <unk> <unk> <unk> . Es gibt <unk> eine große <unk> an den <unk> .
-<unk> <unk> die <unk> <unk> für die <unk> .
-Aber die <unk> <unk> <unk> , <unk> und <unk> <unk> <unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Er wäre nicht <unk> , seine Namen zu <unk> - er möchte ich <unk> <unk> <unk> , <unk> <unk> mit dem zwei <unk> <unk> .
-Er <unk> <unk> <unk> <unk> - <unk> <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk>
-In seiner <unk> <unk> die <unk> nichts <unk> .
-&quot; Und wenn sie <unk> , haben sie <unk> , um die <unk> des <unk> <unk> <unk> <unk> .
-Es war <unk> <unk> <unk> , dass <unk> <unk> in seiner ersten <unk> <unk> <unk> und dann die <unk> anderen <unk> <unk> hat .
-Die <unk> wurde über 15 <unk> 2008 .
-&quot; Das <unk> , die Regierung <unk> von kleinen Landes mit einer Bevölkerung von <unk> Millionen <unk> <unk> , &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> von <unk> bis <unk> <unk> <unk> <unk> <unk> <unk> die <unk> von <unk> .
-Wie muss sie zu ergreifen ?
-<unk> Sie die Frage , die in der <unk> der <unk> <unk> wird .
-Der <unk> der drei <unk> <unk> <unk> <unk> <unk> in <unk> , <unk> <unk> in Juni <unk> .
-Ein <unk> war <unk> , dass es bereits <unk> <unk> , <unk> , wenn die <unk> - und eine <unk> <unk> , die <unk> <unk> .
-Die Tatsache , dass die beiden <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> <unk> <unk> <unk> Zugang zu <unk> , dass sie ein <unk> <unk> <unk> können .
-<unk> <unk> sind mit der <unk> von <unk> <unk> <unk> , <unk> <unk> von <unk> , <unk> und <unk> <unk> .
-&quot; Ich bin <unk> , dass <unk> und <unk> ein <unk> <unk> , &quot; <unk> <unk> <unk> <unk> .
-&quot; <unk> , <unk> , <unk> , <unk> mit einem <unk> <unk> und <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-Doch in dem <unk> <unk> auf <unk> .
-Und <unk> <unk> kann eine <unk> <unk> <unk> .
-Das ist <unk> .
-<unk> ist es .
-<unk> ist ein <unk> .
-<unk> von <unk> <unk> die <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> wurde der <unk> <unk> <unk> .
-Sie <unk> das &quot; <unk> &quot; , das die Erfolg von <unk> <unk> .
-<unk> <unk> sich auf die sehr <unk> <unk> .
-Es <unk> einige des <unk> .
-<unk> war ein <unk> <unk> in <unk> und <unk> .
-<unk> <unk> , <unk> <unk> <unk> eine <unk> .
-<unk> hatte in ihrer USA <unk> <unk> <unk> .
-Um die <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> für Wachstum , die <unk> selbst und eine <unk> <unk> der <unk> in den USA <unk> .
-Es <unk> in einer <unk> <unk> , die auf <unk> <unk> <unk> <unk> <unk> und sie <unk> auf <unk> <unk> <unk> .
-<unk> , wenn andere <unk> <unk> <unk> worden ist , <unk> <unk> <unk> worden .
-&quot; <unk> wurde <unk> als die <unk> <unk> , wenn die USA <unk> , <unk> &quot; <unk> <unk> wurde .
-Die <unk> ist die <unk> , die <unk> <unk> .
-Nach der nächsten <unk> wurden <unk> <unk> als <unk> <unk> als <unk> <unk> .
-Die <unk> des <unk> <unk> <unk> einer <unk> <unk> .
-<unk> der <unk> <unk> ist nun <unk> <unk> .
-Er muss eine Strategie für eine <unk> <unk> , das auf alle <unk> <unk> <unk> haben .
-<unk> <unk> <unk> hat bereits ein <unk> - <unk> <unk> , <unk> auf <unk> <unk> und <unk> zu <unk> .
-Das <unk> jedoch nicht <unk> , dass <unk> nicht <unk> .
-<unk> ist klar , dass <unk> <unk> <unk> müssen .
-Die neue <unk> der <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> zu <unk> .
-Die <unk> <unk> wurde <unk> nur als <unk> <unk> , wenn die <unk> <unk> mit seiner <unk> <unk> <unk> .
-Seit einigen Jahren hat er seine <unk> <unk> und ist nun <unk> <unk> , die <unk> auf <unk> <unk> zu <unk> .
-<unk> <unk> <unk> auf , wo es im <unk> <unk> war .
-Er <unk> <unk> Arbeitsplätze .
-Aber das wird nicht <unk> .
-<unk> <unk> eine <unk> .
-Was ist <unk> ?
-Wie ist es <unk> ?
-<unk> sind die Fragen von <unk> <unk> <unk> <unk> .
-<unk> hat er erst so <unk> , dass er <unk> und seine <unk> <unk> wird , die <unk> in <unk> <unk> wird .
-.
-<unk> der <unk> in Europa <unk> <unk>
-Die <unk> <unk> in Europa hat die <unk> des <unk> in Europa <unk> .
-Die <unk> Regierung in <unk> und <unk> <unk> <unk> .
-<unk> <unk> auf der <unk> <unk> <unk> , dass die <unk> Krise in der <unk> <unk> könnten .
-Die <unk> <unk> der Regierung in <unk> und <unk> wurde nicht <unk> .
-Der <unk> gegen die <unk> .
-Die <unk> und <unk> war noch <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> in der <unk> des <unk> <unk> .
-Die <unk> <unk> <unk> <unk> .
-Die <unk> <unk> zwischen <unk> und <unk> im Bereich der <unk> .
-Die <unk> <unk> &amp; <unk> <unk> <unk> <unk> .
-Die <unk> <unk> <unk> <unk> <unk> und <unk> am <unk> <unk> .
-<unk> <unk> die <unk> <unk> <unk> <unk> .
-<unk> in der <unk> Ländern ist <unk> und <unk> der <unk> <unk> .
-Die <unk> <unk> <unk> , die in <unk> <unk> eine <unk> <unk> weniger als in der <unk> <unk> .
-Die <unk> <unk> <unk> <unk> <unk> .
-Er <unk> auch , dass Europa nicht <unk> ist , wenn ein <unk> <unk> <unk> und <unk> gibt .
-Die <unk> <unk> , <unk> nur <unk> <unk> werden .
-Daher ist es daher <unk> , dass es in europäischer <unk> oder <unk> <unk> <unk> oder <unk> <unk> .
-<unk> , <unk> <unk> eine <unk> <unk> der <unk> in den USA <unk> .
-<unk> von mehr als <unk> <unk> in <unk> <unk> die <unk> des <unk> des <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> auf <unk> <unk> pro <unk> und <unk> hat ein <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> ist <unk> <unk> , dass alle <unk> in <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> .
-Die <unk> <unk> , seine <unk> mit dem <unk> <unk> mit dem <unk> zu <unk> .
-Die <unk> <unk> <unk> , <unk> <unk> auf der <unk> .
-Die <unk> <unk> bis <unk> <unk> nach dem <unk> <unk> .
-Die <unk> <unk> <unk> 50 , <unk> <unk> , <unk> mit einem <unk> Wert von <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> Millionen <unk> <unk> <unk> auf der <unk> <unk> <unk> .
-<unk> <unk> <unk> , <unk> <unk> und <unk> <unk> .
-<unk> <unk> <unk> <unk> , <unk> <unk> und <unk> <unk> auf die <unk> des <unk> .
-<unk> <unk> sind in <unk>
-<unk> sind <unk> Problem <unk> .
-<unk> wie die <unk> , wie die <unk> <unk> möchten , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , aber <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , aber <unk> <unk> <unk> <unk> <unk> in <unk> in <unk> in <unk> <unk> .
-Eine Lösung für die <unk> <unk> , jedoch ist jedoch nicht aus .
-<unk> der ersten <unk> im Osten <unk> <unk> <unk> <unk> <unk> <unk> , dass <unk> keine mehr mehr <unk> kann .
-<unk> <unk> <unk> Lösungen .
-<unk>
-<unk> <unk> <unk> , dass <unk> der <unk> der <unk> in <unk> <unk> , <unk> , dass die <unk> von <unk> in <unk> <unk> <unk> <unk> .
-<unk> , <unk> , <unk> und <unk> <unk> <unk> wurde <unk> für die <unk> .
-<unk> sind <unk> .
-Es gibt <unk> <unk> mit mehr als <unk> <unk> im <unk> von <unk> und in der <unk> , <unk> , <unk> , <unk> und <unk> .
-Ein <unk> <unk> zur <unk> <unk> in <unk> <unk> .
-<unk> <unk> die <unk> des <unk> in <unk> und wie sie <unk> , mit <unk> als <unk> <unk> zu <unk> .
-&quot; <unk> <unk> und <unk> ist nichts , &quot; <unk> &quot; und Land <unk> von <unk> <unk> .
-<unk> <unk> <unk> mit <unk> oder <unk> <unk> <unk> <unk> <unk> , sagte <unk> <unk> von <unk> in <unk> .
-&quot; <unk> <unk> und großen <unk> <unk> bis zu <unk> .
-<unk> würde nur als <unk> in <unk> <unk> , <unk> <unk> und <unk> .
-&quot; Wir möchten <unk> mit ihnen <unk> <unk> werden .
-<unk> der <unk> in der <unk> wird die <unk> nicht <unk> , sagte <unk> <unk> , <unk> <unk> .
-Ein <unk> von <unk> <unk> <unk> und <unk> <unk> für sie <unk> <unk> , um <unk> <unk> zu <unk> .
-&quot; <unk> <unk> <unk> von <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> war ein <unk> des <unk> <unk> <unk> in <unk> , wo <unk> Informationen über die <unk> <unk> <unk> .
-<unk> ist <unk> <unk> .
-<unk> auch die <unk> des <unk> <unk> .
-Die <unk> und <unk> der <unk> sind <unk> <unk> nicht nur die <unk> von <unk> , sondern <unk> , <unk> und <unk> <unk> .
-<unk> <unk> bei der <unk> <unk> <unk> <unk> die <unk> des <unk> " <unk> <unk>
-In einer <unk> <unk> <unk> die <unk> <unk> , dass sie eine <unk> auf <unk> <unk> <unk> .
-Sie <unk> die <unk> und <unk> von <unk> bis <unk> <unk> .
-In einem <unk> <unk> <unk> die <unk> <unk> <unk> eine <unk> <unk> .
-Die <unk> <unk> ein <unk> <unk> mit einem <unk> .
-Die <unk> könnte <unk> nicht <unk> .
-<unk> hatte die <unk> <unk> <unk> .
-Alle vier <unk> <unk> die <unk> mit <unk> und <unk> , die <unk> des <unk> <unk> .
-Die <unk> des vier <unk> <unk> <unk> er auf der ersten <unk> .
-<unk>
-Die <unk> von <unk> und <unk> für ein <unk> <unk> wurden <unk> <unk> .
-Die <unk> <unk> , <unk> und die <unk> <unk> , <unk> <unk> werden im <unk> europäischer <unk> <unk> .
-<unk> , <unk> und <unk> haben die <unk> <unk> der <unk> für die <unk> <unk> in <unk> und <unk> .
-<unk> von <unk> <unk> <unk> , die in der <unk> und <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> ihre <unk> <unk> in den ersten <unk> .
-Die <unk> <unk> nur <unk> <unk> <unk> in den ersten <unk> gegen <unk> <unk> .
-<unk> <unk> <unk> eine <unk> mit der Türkei und <unk> <unk> ein <unk> <unk> gegen <unk> und <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> und <unk> und <unk> <unk> die anderen <unk> für <unk> .
-Die <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> die <unk> mit einem <unk> <unk> und <unk> in der <unk> für <unk> .
-<unk> <unk> <unk> eine <unk> <unk> in der <unk> <unk> .
-<unk> <unk> hatte bereits <unk> des <unk> <unk> <unk> in <unk> gegen <unk> <unk> .
-Die <unk> <unk> <unk> sich im <unk> <unk> <unk> .
-<unk> <unk> ein <unk> <unk> in die <unk> , um ein <unk> <unk> zu <unk> .
-Eine gute <unk> später <unk> <unk> <unk> seine <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> , nicht <unk> im ersten <unk> , hatte sich mit <unk> <unk> <unk> <unk> .
-Die <unk> <unk> <unk> von der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk>
-Die <unk> <unk> <unk> aus <unk> <unk> einige <unk> .
-<unk> <unk> in der <unk> <unk> in der <unk> <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und ihn <unk> <unk> .
-<unk> auch eine <unk> <unk> für <unk> nach <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> , die <unk> <unk> der <unk> mit vier <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> .
-Die europäische <unk> sind durch die <unk> <unk> für die <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> hatte die <unk> <unk> , wenn die <unk> und <unk> <unk> <unk> wurden .
-<unk> <unk> <unk> eine <unk> aus dem <unk> des <unk> , die nur <unk> <unk> <unk> .
-Nach der <unk> <unk> <unk> die <unk> &quot; <unk> &quot; bereits <unk> <unk> in der <unk> <unk> .
-Die <unk> <unk> wurde <unk> <unk> .
-Die Türkei , <unk> <unk> in <unk> <unk> .
-<unk> Tage nach <unk> <unk> <unk> <unk> , könnte die <unk> keine <unk> als eine <unk> <unk> in <unk> <unk> .
-<unk> ist es <unk> eine <unk> , die nationalen <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> <unk> <unk> die <unk> <unk> im <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> die <unk> in der <unk> <unk> und <unk> <unk> <unk> <unk> , um die <unk> in den <unk> zu <unk> .
-<unk> ist es <unk> , die <unk> und <unk> der <unk> .
-Das <unk> <unk> in <unk> und <unk> nach <unk> .
-Die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk>
-<unk>
-Die <unk> in Deutschland waren <unk> ihre ersten <unk> in Deutschland .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> im <unk> <unk> .
-<unk> <unk> <unk> die <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> er auf den letzten <unk> <unk> .
-Die <unk> <unk> in der <unk> <unk> .
-Nach einer <unk> von <unk> <unk> <unk> wurde <unk> auf die <unk> und die <unk> des <unk> <unk> <unk> <unk> .
-<unk>
-Ein <unk> <unk> <unk> <unk> <unk> in <unk> <unk> nach <unk> <unk> nach <unk> <unk> .
-Die <unk> <unk> in einer <unk> <unk> , die <unk> <unk> hat .
-Die <unk> wurde <unk> auf <unk> <unk> , wenn eine <unk> <unk> in <unk> <unk> .
-Die <unk> , die <unk> <unk> und befindet sich im <unk> <unk> .
-Die anderen <unk> über die <unk> waren <unk> .
-<unk>
-Die <unk> <unk> <unk> eine <unk> auf <unk> in <unk> <unk> .
-<unk> <unk> in einer <unk> , die er <unk> <unk> eine <unk> <unk> mit <unk> und <unk> <unk> werden .
-Nach der <unk> <unk> wurde <unk> über <unk> <unk> und mit <unk> <unk> <unk> .
-Die <unk> <unk> aus <unk> .
-<unk> <unk> <unk>
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> auf <unk> <unk> in <unk> .
-Er <unk> , die <unk> des <unk> mit <unk> <unk> zu <unk> .
-<unk> <unk> <unk> , <unk> die <unk> in <unk> <unk> und <unk> in <unk> <unk> .
-Die <unk> wurde <unk> .
-Die <unk> <unk> wurde <unk> .
-<unk> <unk> <unk> und <unk> <unk>
+Die <unk> <unk> in ersten <unk> , und eine <unk> <unk> in der <unk> .
+<unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> auf der Europäischen <unk> .
+<unk> <unk> <unk> <unk> <unk> nur die <unk> <unk> in der <unk> <unk> .
+<unk> und <unk> <unk> <unk> die <unk> des <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> ist eine der <unk> <unk> der <unk> <unk> .
+<unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> Sie sich in der <unk> <unk> , um die <unk> von <unk> zu <unk> .
+Das war auch <unk> , die von der ersten <unk> in den ersten <unk> im ersten <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Sie <unk> eine <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> eine <unk> <unk> in <unk> .
+Die <unk> ist <unk> , ihre <unk> zu <unk> , die <unk> <unk> <unk> zu <unk> .
+<unk> <unk> , <unk> &quot; <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Diese <unk> , sie <unk> ihre <unk> zu <unk> , ihre Land zu <unk> .
+In ihrer Bericht , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , dass es sich nicht <unk> für eine <unk> <unk> <unk> .
+<unk> <unk> auf <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> &quot; <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+In einer <unk> , <unk> im <unk> <unk> <unk> <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
 <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> in einer <unk> <unk> , die <unk> <unk> <unk> , die <unk> auf ihren <unk> <unk> .
-Ein <unk> <unk> in ihrem <unk> , die er <unk> war .
-Die <unk> wurde <unk> und die <unk> für <unk> <unk> in einer <unk> <unk> .
-Auf der <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> war <unk> ein <unk> in <unk> <unk> .
-Er <unk> eine <unk> <unk> und <unk> sie gegen zwei <unk> und drei <unk> .
-<unk> <unk> <unk> .
-Das <unk>
-gegen <unk> <unk> !
-Er <unk> eine <unk> <unk> <unk> und <unk> <unk> der <unk> .
-Das <unk> <unk> auf <unk> und <unk> <unk> .
-<unk> <unk> mit einer <unk> aus <unk> <unk>
-Ein <unk> im <unk> wurde mit einer <unk> von <unk> <unk> .
-Die <unk> <unk> in einer <unk> , die die <unk> <unk> war und über <unk> im <unk> der <unk> <unk> .
-Die <unk> wurde <unk> zu <unk> .
-Die <unk> <unk> vier <unk> - eine <unk> <unk> .
-Ein <unk> <unk> <unk> gibt es keine <unk> zwischen den <unk> und dem <unk> .
+<unk> ein <unk> Kinder zwischen <unk> und <unk> .
+Als <unk> Kinder , <unk> Kinder <unk> <unk> <unk> mit <unk> <unk> .
+<unk> können wir die Bedeutung der <unk> und <unk> eine <unk> <unk> für seine <unk> <unk> .
+Für <unk> <unk> sich <unk> <unk> auf die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> Kinder <unk> <unk> <unk> für <unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> Kinder <unk> <unk> <unk> nicht <unk> .
+Der <unk> war der <unk> <unk> <unk> .
+Im <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Es wurde <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> .
+<unk> ist die <unk> von <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> und <unk> in <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+In den <unk> <unk> , nur <unk> von <unk> <unk> .
+In einer Reihe von <unk> <unk> alle <unk> .
+Die <unk> <unk> wurde <unk> , dass in einer <unk> <unk> Menschen nicht <unk> haben .
+<unk> ist die <unk> <unk> <unk> <unk> .
+Ein <unk> hat sich <unk> , dass <unk> viele in der <unk> Kinder <unk> werden .
+<unk> alle alle <unk> - <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> über <unk> Kinder <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
 <unk>
-Ein <unk> <unk> wurde in einem <unk> <unk> mit einem <unk> <unk> .
-Die <unk> <unk> in einer <unk> , die die <unk> <unk> <unk> <unk> <unk> <unk> die <unk> auf einer <unk> von <unk> und <unk> in einer <unk> <unk> .
-Der <unk> wurde <unk> der <unk> der <unk> und <unk> mit einem <unk> <unk> .
-Die <unk> hat <unk> von seinen <unk> <unk> .
-Er wurde <unk> in einem <unk> <unk> .
-<unk> in <unk>
-Ein <unk> <unk> .
-Die <unk> <unk> in einer <unk> , die <unk> <unk> auf <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> war <unk> <unk> .
-Die <unk> war <unk> von einem <unk> <unk> im <unk> <unk> .
-<unk> und <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> und <unk> .
+&quot; <unk> <unk> ist die <unk> <unk> <unk> <unk> <unk> , &quot; die <unk> <unk> der <unk> <unk> .
+Als <unk> für <unk> , <unk> <unk> <unk> <unk> <unk> .
+Kinder sind <unk> sehr <unk> , <unk> und <unk> <unk> .
+<unk> in der Entwicklung des <unk>
+Das <unk> auch <unk> <unk> , dass <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> werden .
+&quot; <unk> <unk> <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Diese <unk> wurde <unk> <unk> <unk> , wo <unk> <unk> <unk> <unk> werden .
+<unk> <unk> Kinder <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> und <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Im <unk> <unk> <unk> <unk> ich ein <unk> über die <unk> <unk> in der <unk> <unk> .
+Ich habe nicht <unk> , was ich <unk> .
+Die drei <unk> von drei <unk> von drei <unk> <unk> für <unk> <unk> und eine <unk> <unk> , wie er in <unk> <unk> .
+Und <unk> ist <unk> .
+<unk> <unk> wir die <unk> <unk> und <unk> <unk> <unk> .
+Die <unk> <unk> für <unk> und <unk> , aber es ist wirklich <unk> <unk> .
+Diese Zeit , die mit <unk> , <unk> , <unk> , ist nicht ein <unk> <unk> in der <unk> <unk> , wie wir die <unk> nicht <unk> .
+<unk> <unk> <unk> <unk> <unk> .
+<unk> ist ein <unk> <unk> , ohne <unk> <unk> , <unk> , <unk> ist <unk> .
+Ein <unk> muss wissen , wie zu <unk> <unk> <unk> , <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Wir haben <unk> über die <unk> <unk> , die die <unk> <unk> <unk> , <unk> mit <unk> und <unk> <unk> und <unk> <unk> , und nicht <unk> <unk> .
+Für die <unk> und <unk> ist die <unk> zwischen der <unk> und <unk> <unk> , dass die <unk> oder <unk> nicht einer <unk> <unk> <unk> .
+Sie <unk> nicht die <unk> , wie <unk> <unk> <unk> werden .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> oder <unk> .
+<unk> <unk> <unk> <unk> , <unk> <unk> , <unk> ich <unk> , ein <unk> Woche zu <unk> .
+<unk> , ich bin <unk> , mit dem wir <unk> <unk> haben .
+<unk> <unk> war ein <unk> , zwei <unk> zu <unk> und <unk> .
+Wir müssen alle <unk> <unk> , die <unk> <unk> , die <unk> , <unk> und <unk> .
+Ich <unk> mich <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> .
+<unk> <unk> ich <unk> , wie sie <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Wir müssen die <unk> <unk> oder <unk> sie auf die Internet und <unk> <unk> .
+<unk> , wie die <unk> <unk> ist , <unk> unsere <unk> <unk> und <unk> zu <unk> .
+Es ist wichtig , die <unk> Teil der <unk> .
+<unk> <unk> <unk> nicht nur <unk> <unk> , sondern <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Dies ist <unk> , was eine <unk> und <unk> , <unk> <unk> , <unk> wir über <unk> .
+Aber die <unk> von <unk> ist nicht <unk> .
+Eine <unk> <unk>
+<unk> <unk> , <unk> mit <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Ein <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> uns , dass die <unk> ein <unk> , und eine <unk> sollten <unk> werden .
+Ein <unk> <unk> kann mit einem <unk> <unk> <unk> .
+In diesem Fall ist <unk> <unk> .
+Für eine <unk> <unk> können in der <unk> <unk> <unk> werden , <unk> <unk> und <unk> , wie eine <unk> , <unk> , <unk> und <unk> .
+<unk> <unk> ist die <unk> oder <unk> , die <unk> <unk> <unk> .
+&quot; <unk> mit <unk> , <unk> er <unk> .
+Ich <unk> die <unk> <unk> der <unk> &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot;
+<unk> können Sie <unk> <unk> , <unk> sie uns .
+<unk> ich <unk> <unk> , <unk> wir alle alle <unk> und <unk> , die mit Russland und <unk> , während der <unk> in <unk> <unk> <unk> <unk> werden .
+<unk> <unk> <unk> <unk> .
+<unk> <unk> , die <unk> , <unk> ich , dass eine <unk> <unk> haben , müssen er mehr <unk> <unk> als die Zahl der <unk> <unk> ist .
+<unk> ist ein <unk> <unk> <unk> <unk> <unk> <unk> ich für <unk> <unk> .
+<unk> ich , dass in der <unk> , eine <unk> <unk> <unk> <unk> und <unk> in <unk> mit anderen <unk> <unk> <unk> .
+Wir müssen <unk> , dass <unk> eine <unk> <unk> .
+<unk> <unk> <unk> <unk> , dass <unk> und <unk> <unk> wird .
+<unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> , die in einer <unk> <unk> <unk> .
+Die <unk> zwischen <unk> ist ein <unk> <unk> in der <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Und wenn <unk> <unk> uns <unk> , <unk> wir <unk> , dann müssen wir die <unk> uns <unk> <unk> , die uns <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , wir sind <unk> , wenn die <unk> <unk> in einer <unk> <unk> / <unk> <unk> , <unk> .
+Am <unk> , <unk> und <unk> wurde die Tatsache , dass die <unk> nicht <unk> , <unk> und <unk> <unk> .
+Unsere <unk> <unk> von <unk> mit Menschen , die wir <unk> ist , ist es wichtig , ein <unk> zu <unk> .
+Für <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+&quot; <unk> <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> &quot; <unk> <unk> , <unk> und <unk> , was sie mit &quot; <unk> &quot; <unk> &quot; .
+Er <unk> uns , was <unk> eine <unk> <unk> müssen .
+Das <unk> ist der <unk> <unk> , die Sie bitte <unk> , die <unk> <unk> können .
+<unk> <unk> , wie <unk> eine <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Um einige <unk> von <unk> und <unk> <unk> <unk> , <unk> wir <unk> <unk> <unk> , wie <unk> <unk> <unk> <unk> .
+<unk> , wenn die <unk> in einer <unk> , wo die <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Und <unk> sind wir <unk> .
+Sie müssen die <unk> mit der <unk> <unk> , um <unk> zu <unk> .
+Das <unk> <unk> <unk> .
+<unk> <unk> mir mir <unk> <unk> .
+Die <unk> sind wirklich nicht <unk> .
+Das ist nur eine <unk> , die wir in der <unk> <unk> <unk> .
+Ich <unk> mich , dass ein <unk> <unk> ist , nicht <unk> , die <unk> , <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk>
+Ein <unk> <unk> <unk> <unk> <unk> in einer <unk> <unk> , weil von einer <unk> <unk> <unk> und <unk> <unk> werden .
+Die <unk> sind eine <unk> <unk> , aber es ist nicht als <unk> <unk> , aber es ist keine <unk> <unk> .
+<unk> ist es <unk> <unk> , die <unk> <unk> <unk> <unk> .
+Es ist <unk> , die <unk> <unk> für <unk> <unk> <unk> <unk> in einer neuen <unk> <unk> <unk> <unk> <unk> .
+Wir haben <unk> die <unk> , wo die <unk> <unk> der <unk> und <unk> <unk> .
+<unk> für die <unk> <unk> , die in der <unk> <unk> , <unk> wir <unk> .
+Die <unk> <unk> ein <unk> <unk> , aber die gesamte <unk> ist der <unk> von <unk> und <unk> <unk> in der <unk> <unk> .
+<unk> nicht nicht <unk> , sondern die <unk> einer <unk> <unk> der <unk> .
+Die <unk> <unk> sehr gut <unk> .
+Sie <unk> in einer <unk> , wo der <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Sie können im <unk> auf die <unk> <unk> , in <unk> <unk> , und Ihre <unk> ist für <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> ist in <unk> <unk> <unk> , <unk> in <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> die <unk> <unk> die <unk> <unk> .
+<unk> Sie die <unk> auf der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Das ist geschlossen .
+<unk> <unk> , <unk> , <unk> , <unk> oder <unk> in <unk> <unk> <unk> <unk> .
+<unk> sind die <unk> von <unk> , die von einer <unk> <unk> <unk> .
+Für die <unk> finden Sie die <unk> in der <unk> , <unk> die <unk> .
+Auf der anderen Seite , in der <unk> Sie die <unk> <unk> , nicht zu <unk> .
+<unk> sind <unk> <unk> <unk> .
+Es ist ein <unk> <unk> , aber es ist <unk> .
+<unk> Sie eine Reihe von <unk> <unk> <unk> , <unk> Sie die <unk> <unk> <unk> <unk> <unk> oder <unk> <unk> .
+Die <unk> von <unk> sind Ihnen <unk> , die Ihre <unk> <unk> <unk> .
+Die <unk> <unk> die <unk> <unk> <unk> .
+Sie sind nur <unk> <unk> , wo die <unk> der <unk> <unk> ist , ist der <unk> von <unk> und <unk> <unk> .
+<unk> <unk> .
+Es ist ein <unk> <unk> , die <unk> , die drei <unk> <unk> <unk> , <unk> <unk> <unk> werden .
+Es ist <unk> <unk> , um <unk> zu <unk> , weil es bereits gesagt ist , nicht in den <unk> mehr <unk> .
+Die <unk> <unk> die <unk> <unk> <unk> .
+Dies bedeutet , dass es wichtig ist , <unk> <unk> , aber es kann nicht <unk> werden .
+Wenn Sie eine <unk> <unk> <unk> , werden Sie <unk> <unk> .
+Die <unk> <unk> ist <unk> <unk> für die <unk> <unk> <unk> <unk> , <unk> wir die <unk> <unk> .
+Es ist <unk> .
+Die Frage <unk> Probleme .
+In <unk> mit der <unk> <unk> die <unk> <unk> nicht , dass <unk> <unk> .
+<unk> eine <unk> von diesem <unk> <unk> , aber wenn Sie keine <unk> <unk> und <unk> , aber wenn Sie keine <unk> haben .
+<unk> , wenn <unk> oder <unk> <unk> in <unk> <unk> , <unk> <unk> die anderen <unk> .
+<unk> <unk> <unk> <unk> <unk> .
+Dies ist kein <unk> <unk> <unk> , aber ist <unk> die <unk> .
+Die <unk> sind <unk> , dass Sie <unk> oder <unk> <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> .
+<unk> sind nur wenige <unk> <unk> pro <unk> .
+Wenn Sie diese <unk> <unk> , haben Sie die <unk> von <unk> <unk> .
+Dies ist es eine <unk> in <unk> , aber Sie können nicht <unk> .
+Die <unk> sind nicht <unk> und Sie müssen eine Reihe von <unk> <unk> .
+Ein <unk> <unk> der <unk> ist der Tatsache , dass die <unk> oft <unk> <unk> in der <unk> <unk> .
+Für einige <unk> haben einige <unk> zu <unk> <unk> <unk> <unk> , <unk> Sie <unk> nicht in <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Diese <unk> ist für <unk> , wo Sie die beiden <unk> <unk> <unk> , die <unk> <unk> <unk> , während Sie sich in <unk> <unk> <unk> , während Sie sich in <unk> <unk> <unk> .
+Es ist nicht <unk> , wenn Sie <unk> werden , wenn Sie <unk> , wenn die Situation immer nur in <unk> <unk> .
+Die <unk> haben eine <unk> <unk> .
+<unk> <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Dies ist die <unk> <unk> des <unk> , <unk> <unk> , wo Sie in den <unk> <unk> <unk> .
+<unk> <unk> , die <unk> <unk> hat , ist es <unk> .
+Die <unk> ist , dass er <unk> ist , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> kann es die <unk> <unk> , <unk> <unk> und <unk> , aber es ist es <unk> <unk> <unk> .
+Es ist eine <unk> , weil die <unk> <unk> , die <unk> <unk> <unk> , ist <unk> <unk> und <unk> <unk> .
+Es ist nicht wichtig , ob die <unk> mit <unk> <unk> <unk> , <unk> von <unk> oder <unk> <unk> .
+Die <unk> von <unk> ist <unk> <unk> .
+Sie haben die <unk> für <unk> <unk> <unk> <unk> der <unk> , wie Sie die <unk> <unk> <unk> <unk> , dass es sich in der <unk> der <unk> <unk> <unk> .
+<unk> sind in drei <unk> <unk> .
+<unk> sind <unk> für <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> ist <unk> <unk> mit dem <unk> <unk> .
+<unk> , <unk> , <unk> und <unk> <unk> für Ihre <unk> und <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> , die <unk> <unk> mit einer <unk> <unk> , <unk> die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> mit <unk> <unk> , <unk> und <unk> <unk> .
+<unk> anderen <unk> <unk> , ist die <unk> von <unk> in der <unk> .
+Sie und Ihre <unk> in einem <unk> in einem <unk> <unk> <unk> , <unk> Sie die <unk> in der <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Für <unk> Tage <unk> unsere <unk> <unk> , ob die <unk> kein <unk> für eine <unk> <unk> oder ob die <unk> nicht <unk> .
+Die <unk> Teil der <unk> ist nichts <unk> , aber die <unk> <unk> ist <unk> <unk> , aber die <unk> <unk> ist <unk> <unk> .
+Es ist ein <unk> <unk> , das im <unk> <unk> , <unk> <unk> , <unk> .
+Diese <unk> <unk> <unk> mit <unk> <unk> , <unk> <unk> <unk> <unk> <unk> .
+Die <unk> ist alle <unk> <unk> .
+In <unk> <unk> Sie die <unk> <unk> <unk> , ist die <unk> des <unk> in allen <unk> <unk> , weil es <unk> nicht mehr <unk> <unk> , weil sie <unk> werden .
+<unk> von <unk> für <unk> <unk> ist <unk> .
+Wenn die <unk> <unk> <unk> <unk> , können wir <unk> <unk> , dass die <unk> der <unk> für die <unk> Jahren <unk> <unk> .
+Die <unk> <unk> <unk> .
+Die <unk> ist ein <unk> <unk> , aber die <unk> mit der <unk> von <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> <unk> <unk> bietet die internationale <unk> <unk> <unk> <unk> <unk> und <unk> <unk> mit einem <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> .
+Die <unk> der <unk> ist auf zwei <unk> <unk> <unk> .
+&quot; <unk> <unk> hat in den <unk> .
+&quot; <unk> <unk> ist die <unk> der <unk> <unk> und <unk> <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> <unk> der <unk> <unk> .
+Die <unk> werden ein <unk> <unk> von <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> <unk> <unk> , eine <unk> von einer <unk> <unk> , <unk> <unk> ist die <unk> .
+In der <unk> ist der <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Die <unk> der <unk> ist <unk> , die internationale <unk> &quot; <unk> und <unk> die <unk> der <unk> mit <unk> <unk> <unk> , <unk> und <unk> <unk> <unk> <unk> .
+Die <unk> <unk> ist <unk> <unk> <unk> <unk> in der Zusammenarbeit mit <unk> <unk> .
+Die gesamte <unk> ist im <unk> des <unk> <unk> , <unk> <unk> , <unk> , <unk> und <unk> <unk> .
+<unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> .
+Für <unk> Informationen finden Sie <unk> <unk> .
 <unk> <unk>
-<unk> ist <unk> von einer <unk> <unk> in der <unk> <unk> .
-Die <unk> <unk> in einer <unk> , die die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Wenn der <unk> <unk> <unk> , <unk> er ihre <unk> und <unk> mit einem <unk> .
-Er <unk> <unk> <unk> .
+<unk> haben die <unk> von <unk> und <unk> <unk> .
+<unk> <unk> <unk> <unk> zwischen <unk> .
+&quot; <unk> ist nicht .
+Die <unk> oder <unk> Jahre <unk> die Situation <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> wie <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> , <unk> <unk> die <unk> <unk> <unk> <unk> der Europäischen Rates <unk> <unk> <unk> <unk>
+&quot; <unk> &quot; <unk> <unk> hat er <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , <unk> er <unk> <unk> .
+&quot; <unk> ist eine Vielzahl , die alle <unk> <unk> , <unk> <unk> , <unk> mit ihnen <unk> , und die <unk> <unk> <unk> .
+Die neue <unk> der <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> über die EU für die EU für die EU , <unk> und <unk> .
+<unk> <unk> <unk> <unk> von <unk> <unk> <unk> <unk> .
+<unk> wurden mit der <unk> <unk> mit dem <unk> <unk> <unk> .
+<unk> <unk> , <unk> die <unk> des <unk> <unk> <unk> <unk> , um die <unk> <unk> <unk> .
+<unk> <unk> in der EU ist sehr <unk> .
+Was die <unk> <unk> , <unk> der <unk> und die <unk> <unk> <unk> <unk> .
+<unk> ist ein <unk> <unk> <unk> , die <unk> , die <unk> Krise <unk> .
+<unk> die <unk> <unk> werden <unk> und <unk> , die <unk> werden , die <unk> <unk> , die <unk> werden , die <unk> <unk> .
+<unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> , <unk> <unk> , und <unk> keine <unk> .
+Wie gibt es <unk> und <unk> , dass in <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> auch die EU <unk> , die <unk> <unk> , <unk> <unk> zu <unk> .
+<unk> Europa <unk>
+Die <unk> <unk> sind <unk> <unk> , wie <unk> die <unk> <unk> als <unk> <unk> .
+<unk> gibt es <unk> <unk> , die in der Institutionen <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> mit der <unk> <unk> <unk> , <unk> die <unk> und Zusammenarbeit des <unk> .
+<unk> <unk> <unk> ich , dass ich <unk> von <unk> und <unk> <unk> , und eine <unk> ist <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> .
+In der Europäischen Union <unk> <unk> <unk> neue <unk> für die <unk> des <unk> <unk> .
+<unk> als eine neue europäischen <unk> , <unk> die <unk> der <unk> , wenn nicht <unk> <unk> ist , nicht <unk> .
+<unk> sind <unk> und <unk> die <unk> .
+&quot; Wir haben <unk> <unk> , und wir haben bereits ein <unk> <unk> <unk> .
+&quot; <unk> <unk> war es schon gesagt , dass die Länder , die nicht <unk> , während die <unk> nicht <unk> kann .
+&quot; <unk> &quot; <unk> wird es ein <unk> <unk> <unk> , <unk> <unk> <unk> .
+In diesem Zusammenhang <unk> die <unk> der <unk> <unk> und <unk> <unk> in <unk> auf die <unk> <unk> , die alle <unk> <unk> werden sollten .
+<unk>
+Die <unk> <unk> die <unk> <unk> der <unk> <unk> <unk>
+<unk> <unk> <unk> für die <unk> , dass die <unk> der <unk> <unk> <unk> <unk> <unk> werden .
+<unk> ist ein <unk> von <unk> <unk> , <unk> ist ein <unk> <unk> der <unk> <unk> .
+Die <unk> <unk> <unk> sich auf die ersten <unk> , ein <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Er <unk> in seiner <unk> <unk> <unk> , dass eine <unk> <unk> <unk> <unk> werden , wenn <unk> <unk> werden .
+<unk> <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; , die <unk> <unk> , die <unk> <unk> , die <unk> , die <unk> , die <unk> , die <unk> zu <unk> , die <unk> in <unk> zu <unk> , die <unk> in <unk> <unk> zu <unk> , in <unk> <unk> zu <unk> , die <unk> <unk> in <unk> <unk> , in <unk> <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Die <unk> wurde der <unk> Kultur <unk> <unk> <unk> .
+&quot; <unk> <unk> bedeutet uns , dass <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> und <unk> für eine <unk> Jahren , weil es sich nicht <unk> <unk> <unk> , während sie sich nicht <unk> .
+In unserer <unk> Jahrhundert wir uns die <unk> <unk> , die uns <unk> , <unk> und <unk> .
+In der <unk> Jahrhundert ist wir , dass wir mehr mehr <unk> , &quot; <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> als <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> mit dem <unk> <unk> <unk> <unk> eine <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+In der letzten Jahren wurde <unk> <unk> <unk> , <unk> <unk> , die viele Zukunft <unk> und <unk> <unk> .
+Es ist keine <unk> , dass die <unk> <unk> - die <unk> <unk> <unk> <unk> <unk> .
+<unk> mit einem <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> ist nicht ein <unk> <unk> , es ist ein <unk> <unk> , es ist ein <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Als <unk> ist es ein <unk> zwischen <unk> und <unk> .
+Während der <unk> Jahren <unk> , <unk> , <unk> oder <unk> <unk> , ist es <unk> in der USA , weil die <unk> der <unk> in einer der Welt <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> die <unk> <unk> .
+<unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
+Mit <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk>
+<unk> <unk> die <unk> <unk> , die <unk> <unk> , die <unk> mit ihrem eigenen <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Das ist <unk> <unk> <unk> seine <unk> in vielen <unk> - wenn sie nicht <unk> , wenn sie nicht <unk> .
+Dies ist , wie es <unk> , die <unk> , die <unk> , die <unk> , die <unk> und <unk> auf <unk> , die <unk> <unk> .
+<unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> in <unk> , mit dem <unk> <unk> , <unk> er <unk> <unk> .
+<unk> hat <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> hat die <unk> <unk> , wenn die <unk> <unk> , wenn die <unk> der <unk> <unk> .
+<unk> <unk> die <unk> der ersten <unk> , <unk> <unk> , die <unk> der <unk> in der <unk> <unk> .
+<unk> ist <unk> <unk> , um die <unk> Krise zu <unk> .
+Die <unk> des <unk> ist der <unk> der <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> ist die <unk> <unk> , um <unk> zu <unk> .
+Wir können uns von <unk> <unk> , wenn es <unk> ist , <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Es <unk> die <unk> <unk> in <unk> .
+<unk> für die <unk> <unk> wurde <unk> von vier <unk> <unk> , die <unk> <unk> , die <unk> <unk> .
+Sie <unk> <unk> wie die <unk> &quot; <unk> &quot; <unk> <unk> &quot; eine <unk> <unk> der <unk> und <unk> .
+Die <unk> der neuen <unk> wurde <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+<unk> <unk> ein <unk> <unk> <unk> , <unk> <unk> , <unk> mit <unk> <unk> .
+Die <unk> kann die <unk> der <unk> in der <unk> - <unk> der <unk> <unk> der <unk> <unk> und <unk> .
+<unk> <unk> die <unk> und <unk> .
+<unk> , wie seine <unk> <unk> , <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> .
+In den ersten Jahren des <unk> <unk> der <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> <unk> , <unk> und <unk> <unk> <unk> .
+<unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> seine <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+<unk> und <unk> , <unk> und <unk> von <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> und in <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> , <unk> <unk> <unk> die ersten <unk> - die <unk> <unk> / <unk> .
+Die <unk> <unk> , dass die <unk> der <unk> <unk> des <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
+<unk> Jahren <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+Im <unk> drei Jahren wurde <unk> <unk> mit dem <unk> <unk> <unk> .
+<unk> <unk> ist <unk> <unk> von <unk> in <unk> , dass keine <unk> nicht <unk> sind und die <unk> des <unk> <unk> .
+Die <unk> hat <unk> <unk> eine <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> der <unk> ist <unk> <unk> <unk> <unk> <unk> .
+Im <unk> <unk> <unk> , wie die erste Land in <unk> und <unk> <unk> , <unk> <unk> seine <unk> in <unk> .
+<unk> <unk> auch eine <unk> <unk> in <unk> .
+Die <unk> für die <unk> und <unk> Europa in <unk> , wo man auch eine <unk> <unk> <unk> <unk> .
+<unk>
+<unk> <unk> die <unk> , <unk> ich nicht !
+<unk> <unk> <unk> <unk> , es ist sehr <unk> !
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> darf sie nicht mehr <unk> und <unk> <unk> <unk> .
+&quot; <unk> <unk> können nicht mehr als <unk> <unk> , &quot; <unk> <unk> <unk> .
+Wenn <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> kann sie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> , er <unk> <unk> <unk> er <unk> <unk> .
+<unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> ist nicht <unk> , die seine <unk> <unk> mit <unk> <unk> .
+Ein <unk> , wenn ein Tag <unk> und <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist der <unk> <unk> <unk> , wenn er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+&quot; <unk> <unk> wird er nicht als <unk> <unk> , <unk> , <unk> und <unk> <unk> , aber ein <unk> <unk> , aber auch ein <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist <unk> nicht , dass seine <unk> <unk> der <unk> <unk> .
+<unk> <unk> ich <unk> <unk> .
+&quot; <unk> wird mit <unk> , und ich <unk> nicht , dass die <unk> &quot; <unk> &quot; .
+&quot; <unk> <unk> <unk> für <unk> , und ich <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> und ich <unk> im <unk> <unk> <unk> , <unk> wir die <unk> <unk> <unk> , &quot; <unk> <unk> <unk> für <unk> .
+Er <unk> , dass <unk> eine neue <unk> , <unk> er nicht in den <unk> <unk> .
+<unk> &quot; Wir <unk> nicht , und ich <unk> nicht , wo sie nicht <unk> , wo sie <unk> , mit <unk> , und wenn sie eine <unk> <unk> .
+Ich weiß es , <unk> <unk> , <unk> ich in <unk> , und ich <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> die <unk> <unk> <unk> <unk>
+Wenn Sie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> ich Ihnen <unk> <unk> in der <unk> , die <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk>
+<unk> Sie die <unk> <unk> <unk> <unk> .
+<unk> Sie müssen eine <unk> von <unk> <unk> <unk> ?
+<unk> Sie mit <unk> <unk> <unk> ?
+Wenn Sie Ihre <unk> <unk> können , können Sie Ihre <unk> <unk> .
+<unk> <unk> <unk> sie die <unk> <unk> , die <unk> für <unk> <unk> .
+<unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> kann ein <unk> für Frauen <unk> , aber für <unk> , es kann <unk> <unk> werden .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk>
+<unk> <unk> ich &quot; <unk> ?
+<unk> <unk> <unk> <unk> - <unk> <unk> <unk> <unk> <unk> <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> ?
+&quot; <unk> <unk> Sie mir <unk> ?
+<unk> Sie diesen <unk> <unk> ?
+Sie <unk> ?
+<unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> sollten Sie die <unk> <unk> , sondern viele <unk> <unk> , sondern viele <unk> <unk> <unk> zu <unk> .
+Die <unk> <unk> auch die <unk> , die die <unk> der <unk> <unk> , die mehr <unk> <unk> .
+<unk> und <unk> <unk>
+Das ist ein <unk> <unk> <unk> .
+Die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> Sie Ihre <unk> für <unk> <unk> die <unk> <unk> in <unk> <unk> <unk> .
+In diesem <unk> <unk> &quot; <unk> &quot; <unk> &quot; , die nicht <unk> sind und die <unk> <unk> nicht <unk> .
+Diese <unk> <unk> für <unk> <unk> , wie die gesamte <unk> .
+<unk>
+Die <unk> in der <unk> .
+&quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; ?
+&quot; <unk> <unk> ist nicht auf den <unk> .
+Wenn Sie Ihre <unk> <unk> <unk> können , können Sie Ihre <unk> sehr <unk> <unk> .
+<unk> , <unk> , <unk> , <unk> , <unk> !
+<unk> , wenn <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk>
+<unk> <unk> <unk> <unk> , <unk> , <unk> und <unk> .
+<unk> sind die <unk> <unk> , die <unk> , wo sie <unk> , die mit <unk> , wie <unk> und <unk> .
+<unk> jetzt <unk> <unk> , <unk> <unk> <unk> <unk> oder <unk> .
+<unk> <unk> , <unk> ist der <unk> alle Frauen .
+Es gibt <unk> <unk> , die <unk> <unk> und <unk> alle <unk> <unk> .
+<unk> <unk> und <unk> <unk>
+Im <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> in der <unk> auch die <unk> des <unk> , <unk> <unk> .
+<unk> der <unk> , <unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> <unk> möchte ich den <unk> <unk> <unk> .
+<unk> <unk> ich <unk> .
+&quot; Sie <unk> <unk> , &quot; <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Ein <unk> <unk> ist ein <unk> <unk> für die <unk> <unk> .
+Die <unk> <unk> &quot; <unk> und <unk> ist es für <unk> , die <unk> zwischen den <unk> .
+Ein <unk> <unk> , ein <unk> <unk> , ein <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> .
+Die <unk> mit <unk> , <unk> er die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; Ich <unk> <unk> <unk> .
+&quot; Ich <unk> <unk> , dass er die <unk> <unk> <unk> , aber er <unk> die <unk> <unk> <unk> , aber er <unk> <unk> , seine <unk> <unk> .
+<unk> <unk> ich , dass die <unk> meiner <unk> ich <unk> <unk> <unk> .
+<unk> <unk> Dank .
+<unk> Dank .
+&quot; <unk> &quot; <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> <unk> die <unk> <unk> mit <unk> <unk> und <unk> der <unk> von <unk> <unk> , <unk> sie eine <unk> <unk> .
+<unk> <unk> wurde <unk> von <unk> <unk> , die die <unk> <unk> <unk> .
+&quot; <unk> <unk> <unk> in unserem <unk> .
+<unk> <unk> die <unk> , <unk> ich <unk> , und <unk> <unk> über die <unk> <unk> .
+&quot; Ich <unk> <unk> , und ich <unk> <unk> , dass er sich <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> <unk> die <unk> der <unk> <unk> .
+<unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> mit den <unk> <unk> , die <unk> <unk> <unk> <unk> und <unk> 3 von <unk> .
+<unk> <unk> <unk> auf einer <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die Situation ist <unk> .
+&quot; Wir <unk> die <unk> mit einem <unk> <unk> , die <unk> <unk> .
+&quot; <unk> ist es wichtig , dass wir über <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> .
+&quot; <unk> &quot; <unk> ist es <unk> und wir nicht <unk> .
+&quot; <unk> sollte die <unk> <unk> , <unk> die <unk> der <unk> .
+&quot; <unk> ist unser <unk> , <unk> <unk> , <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> &quot; <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk>
+<unk> <unk> nur 10 <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Als <unk> war die <unk> <unk> <unk> <unk> , <unk> <unk> der <unk> <unk> <unk> <unk> .
+<unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> wurde die <unk> von <unk> , wenn wir die Möglichkeit , <unk> zu <unk> , wenn wir die Möglichkeit , <unk> <unk> zu <unk> .
+Ein <unk> <unk> hat die <unk> <unk> , dass die Bürger der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Wenn ein <unk> <unk> <unk> , wie ein <unk> , <unk> , <unk> , <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> .
+<unk> , dass <unk> nicht alle <unk> ist .
+Ein <unk> <unk> <unk> war <unk> für <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> <unk> war nicht <unk> , ohne die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> , <unk> , <unk> , <unk> , <unk> , eine <unk> <unk> .
+<unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> in Ländern über die <unk> .
+Ein <unk> <unk> , <unk> wir nicht <unk> , ist es <unk> , dass die <unk> <unk> nicht die <unk> <unk> <unk> , wie er <unk> ist .
+<unk> auf der <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> können nicht <unk> <unk> von <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> in <unk> <unk> <unk> <unk> in <unk> , weil ihre <unk> in <unk> <unk> nicht <unk> <unk> .
+Ein <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> wichtig hat die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Unsere <unk> <unk> und <unk> wurde <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> nicht <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Als <unk> <unk> in <unk> <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> einer anderen <unk> der <unk> , unsere Entwicklung , die unsere Entwicklung , <unk> in <unk> <unk> .
+Die <unk> <unk> <unk> <unk> <unk> <unk> die <unk> <unk> für <unk> und <unk> .
+Um die ersten <unk> in <unk> <unk> <unk> als eine <unk> der <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk>
+<unk> <unk> , <unk> <unk> <unk> hat keine <unk> <unk> , dass die <unk> der <unk> der <unk> <unk> <unk> <unk> <unk> wird , nicht nur <unk> <unk> .
+Es ist noch nicht , wie <unk> zu <unk> .
+Die drei <unk> wird nicht <unk> .
+<unk> <unk> , <unk> , <unk> und <unk> sind <unk> <unk> <unk> .
+Die <unk> <unk> von <unk> in <unk> <unk> , <unk> er als <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Die <unk> der <unk> <unk> sich in <unk> zwischen <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Dies war <unk> <unk> auf <unk> <unk> , wenn eine neue <unk> <unk> <unk> .
+Die <unk> <unk> <unk> die <unk> in <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> <unk> hat <unk> <unk> als <unk> , ob die <unk> <unk> - ob die <unk> nur <unk> , ob die <unk> nur <unk> <unk> .
+Diese <unk> ist <unk> <unk> <unk> seit <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> auf die <unk> <unk> <unk> <unk> .
+Die <unk> <unk> hat keine <unk> <unk> , <unk> , <unk> und <unk> , es ist <unk> <unk> .
+Die <unk> ist <unk> <unk> <unk> <unk> , aber die <unk> ist der <unk> <unk> .
+Die Frage <unk> werden in der <unk> <unk> , <unk> zu <unk> ?
+&quot; <unk> <unk> <unk> auf , ob die <unk> <unk> oder <unk> <unk> <unk> , <unk> <unk> , die <unk> <unk> in der <unk> <unk> .
+<unk> auf die <unk> von <unk> , die <unk> des <unk> <unk> , ist ein <unk> mit <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist sehr <unk> , ein <unk> mit der <unk> <unk> von <unk> von <unk> von <unk> <unk> <unk> .
+Die <unk> <unk> eine <unk> , die in der <unk> der <unk> <unk> , müssen die <unk> <unk> <unk> .
+<unk> &quot; <unk> <unk> würde die beiden <unk> , die die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> mit seiner <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> Sie die <unk> <unk> , um den <unk> zu <unk> .
+&quot; Ich möchte alle <unk> <unk> , wie in der <unk> <unk> , <unk> die <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> , die <unk> <unk> <unk> <unk> .
+<unk> ist ein <unk> .
+Er <unk> die neue Präsidentin <unk> <unk> in <unk> er auch <unk> , dass die <unk> <unk> wird .
+&quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; mit der <unk> <unk> in der Europäischen <unk> .
+Die <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist <unk> .
+&quot; Ich hoffe für eine Zeit , aber die Situation ist sehr <unk> .
+<unk> ist nicht zwischen <unk> und <unk> , aber es gibt es im <unk> <unk> <unk> .
+Das <unk> <unk> eine <unk> <unk> der <unk> .
+&quot; Ich hoffe , dass die <unk> <unk> , &quot; <unk> <unk> <unk> .
+Es gibt keine <unk> <unk> , die zwischen der <unk> .
+<unk> Verhandlungen <unk> in <unk> <unk> , aber die <unk> , die <unk> , wenn die <unk> <unk> wird .
+Ein <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> und <unk> zu <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> , eine <unk> in <unk> <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> der <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Ein <unk> ist in der <unk> Regierung <unk> <unk> <unk> <unk> <unk> und die <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Wenn es die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> ist ein <unk> <unk> , <unk> ich mich für mich und nicht <unk> .
+&quot; <unk> ist kein <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> .
+<unk> der <unk> , die die <unk> mit <unk> <unk> und <unk> <unk> ist , ist die <unk> der <unk> , der <unk> <unk> der <unk> <unk> .
+<unk> , <unk> <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+In Zukunft , würde er die <unk> <unk> ein <unk> <unk> , nicht <unk> zu <unk> .
+&quot; Ich <unk> <unk> , einige Leute , dass <unk> <unk> werden .
+<unk> <unk> ich mir einige , einige <unk> , <unk> , <unk> , <unk> nicht <unk> <unk> .
+&quot; Ich <unk> mich <unk> , diese Frage , die er <unk> ist .
+<unk> <unk> , <unk> der <unk> mit <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Ich <unk> es <unk> <unk> , die <unk> zu <unk> .
+&quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> und <unk> <unk> <unk> <unk> werden .
+&quot; <unk> mit Unterstützung von <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+Es ist <unk> <unk> , dass einige Jahre <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> ist , ohne eine <unk> .
+&quot; Ich <unk> nicht , was <unk> <unk> <unk> , <unk> <unk> <unk> .
+Die <unk> <unk> und <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+In der Zukunft <unk> <unk> <unk> er <unk> die Zusammenarbeit mit <unk> in der Zukunft .
+Diese <unk> ist der <unk> von einer <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+<unk> möchte ich <unk> <unk> .
+<unk> ist sehr <unk>
+&quot; Ich kann mich <unk> , wie die <unk> <unk> .
+<unk> er nicht <unk> .
+&quot; Ich <unk> nicht <unk> , was ich <unk> , was ich nicht <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> <unk> <unk> er auf <unk> <unk> .
+Er <unk> die <unk> von <unk> aus <unk> <unk> <unk> , <unk> er hat die <unk> <unk> , die <unk> <unk> in <unk> <unk> .
+&quot; Ich habe die <unk> , die die <unk> <unk> , ihre <unk> <unk> zu unterstützen .
+&quot; <unk> &quot; <unk> die <unk> <unk> <unk> die <unk> <unk> , die die <unk> und <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> <unk> würde die <unk> zwischen <unk> und die <unk> <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> zu <unk> .
+<unk> der <unk> wird der <unk> der <unk> <unk> .
+<unk> sind <unk> <unk> , wie die politische <unk> <unk> , <unk> ich auch <unk> , aber sie müssen <unk> , wo die <unk> &quot; <unk> &quot; <unk> wird .
+<unk> <unk> nicht seine <unk> mit dem <unk> <unk> , <unk> er <unk> , dass eine <unk> <unk> <unk> .
+<unk> ist <unk> , und <unk> zu <unk> .
+Es ist nicht <unk> .
+&quot; <unk> , <unk> ich nicht ein <unk> in der <unk> <unk> <unk> , während die <unk> <unk> <unk> , während die <unk> in <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Um die <unk> von <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> die Verhandlungen in <unk> <unk> , eine <unk> und <unk> , dass die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> <unk> in <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> , in den letzten <unk> des letzten <unk> , um die <unk> <unk> in der letzten <unk> .
+<unk> auf alle <unk> haben , haben sie in <unk> <unk> , <unk> und <unk> .
+Die <unk> <unk> <unk> die <unk> <unk> , &quot; die <unk> <unk> mit den <unk> <unk> , aber er <unk> viele Jahre in <unk> und <unk> <unk> .
+Dies gibt es <unk> , dass er <unk> ist , <unk> <unk> zu <unk> .
+<unk> <unk> Probleme mit <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+&quot; <unk> <unk> hat keine <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+Er <unk> die <unk> der <unk> <unk> der <unk> als <unk> für die <unk> .
+<unk> <unk> möchte ich <unk> , wie meine <unk> <unk> , und ich <unk> <unk> , die <unk> zu <unk> .
+&quot; <unk> ist eine <unk> Frage , die <unk> <unk> .
+<unk> als <unk> <unk> er <unk> , <unk> er nicht gegen den <unk> .
+In der <unk> hat er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Für eine <unk> Zeit <unk> er nicht <unk> <unk> , die <unk> <unk> <unk> .
+Die <unk> <unk> in <unk> für <unk> , und <unk> Kinder <unk> .
+<unk> hat seine <unk> nicht <unk> und viele Menschen <unk> , die von der <unk> <unk> <unk> <unk> .
+Die <unk> ist <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Er <unk> seine <unk> <unk> in <unk> <unk> .
+Die <unk> sollte die <unk> <unk> <unk> .
+&quot; <unk> wäre auch <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> möchte ich auf <unk> und <unk> <unk> und <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Er kann <unk> <unk> , dass die <unk> der <unk> <unk> nicht <unk> <unk> .
+&quot; Ich <unk> <unk> , um die Arbeit der <unk> der <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> die <unk> <unk> <unk> , <unk> er <unk> , dass die <unk> nicht <unk> wird .
+<unk> <unk> <unk> ist , wie die <unk> in der <unk> <unk> <unk> ist , dass wir über <unk> &quot; .
+&quot; <unk> <unk> wird es nur durch <unk> <unk> <unk> , &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; , der <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> <unk> ist die <unk> , die <unk> <unk> <unk> <unk> .
+Wenn die <unk> der <unk> <unk> , <unk> <unk> , <unk> <unk> , ist der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> , dass er <unk> ist , <unk> <unk> , <unk> <unk> werden .
+Er <unk> die <unk> <unk> , <unk> <unk> und die <unk> der <unk> <unk> <unk> <unk> .
+<unk> <unk> auch die <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> <unk> .
+<unk> <unk> ich auf <unk> und <unk> <unk> .
+&quot; <unk> " <unk> mit <unk> und <unk> , <unk> , <unk> , <unk> und <unk> für die <unk> .
+&quot; <unk> <unk> ich nicht <unk> , dass ich <unk> , &quot; <unk> <unk> in seiner <unk> <unk> .
+<unk> ein <unk> <unk> , und ich möchte die <unk> in der <unk> <unk> , dass die <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; Das wäre nicht <unk> <unk> , wie sie <unk> <unk> , nicht nur die Arbeit der <unk> , <unk> er <unk> .
+<unk> mit <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> ich 20 Tag .
+<unk> muss ich wissen , wenn es <unk> hat , wenn es <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> mir mich nicht <unk> , <unk> ich mich <unk> <unk> .
+&quot; <unk> eine <unk> <unk> ich nicht nur nur <unk> .
+<unk> , <unk> er seine <unk> <unk> ist , ist das <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> .
+Die <unk> sind <unk> , dass <unk> <unk> in einer <unk> Jahren <unk> <unk> , und ich bin nicht <unk> , dass die <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Die <unk> <unk> , die <unk> <unk> , ist <unk> nicht <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+&quot; Ich kann <unk> <unk> <unk> für viele <unk> .
+<unk> <unk> <unk> .
+Die <unk> für alle , weil sie ihre <unk> <unk> , nicht nur die <unk> <unk> , &quot; <unk> <unk> <unk> .
+<unk> , er <unk> die <unk> <unk> , <unk> er nur ein <unk> Präsidentin .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist es für <unk> <unk> , die zweite <unk> <unk> in <unk> und <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> würde die <unk> <unk> , wo es nur drei <unk> <unk> haben , <unk> <unk> in <unk> , <unk> , <unk> <unk> .
+Was die <unk> <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> nicht , seine <unk> zu <unk> .
+&quot; <unk> , <unk> ich ein <unk> <unk> , in der <unk> <unk> , dass mir seine <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Auf der anderen Seite , er <unk> die Tatsache , dass die <unk> nicht <unk> als seine eigenen <unk> <unk> .
+<unk> <unk> , dass die <unk> von <unk> von <unk> <unk> , <unk> <unk> <unk> , er <unk> die anderen <unk> , die <unk> <unk> <unk> .
+&quot; <unk> eine <unk> kann , dass er ein <unk> <unk> <unk> <unk> ist .
+&quot; <unk> &quot; <unk> Ich hoffe , ich hoffe , dass er sich in der <unk> <unk> <unk> <unk> , ohne <unk> <unk> zu <unk> .
+&quot; <unk> <unk> ist nicht , um seine eigenen <unk> <unk> , &quot; <unk> <unk> zu <unk> .
+Europa der <unk> <unk>
+<unk> in der <unk>
+<unk>
+<unk> <unk> mit <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> , <unk> , <unk> , <unk> <unk> .
+Es war ein <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> mit <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> in <unk> als <unk> <unk> <unk> - und hat jetzt in den <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> &quot; <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Die <unk> ist ein <unk> <unk> Kultur <unk> .
+<unk> ist <unk> für <unk> , <unk> <unk> - aber in der Nähe des <unk> .
+Die <unk> <unk> ist , dass die <unk> von <unk> mit <unk> <unk> <unk> und die <unk> der <unk> in der <unk> <unk> können .
+&quot; <unk> Tag <unk> ich <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+&quot; <unk> <unk> <unk> ich <unk> <unk> .
+<unk> <unk>
+<unk> in der <unk> und <unk> <unk> <unk> - die <unk> <unk> in <unk> ist <unk> , weil alle <unk> <unk> sind .
+Und die <unk> <unk> können für die <unk> , wenn die <unk> die <unk> <unk> , die <unk> <unk> , die <unk> der <unk> in <unk> <unk> .
+Die <unk> ist sehr <unk> , aber auch die <unk> des <unk> .
+<unk> ist <unk> <unk> , <unk> <unk> und <unk> <unk> .
+Die <unk> <unk> die <unk> und <unk> Informationen über die <unk> und <unk> zu <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> der <unk> <unk> in <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Das <unk> <unk> in drei <unk> <unk> <unk> die <unk> <unk> <unk> <unk> .
+<unk> in der <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Ein <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> ist der <unk> von der <unk> in der <unk> <unk> <unk> .
+<unk> <unk> hat sich in einer <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> , die von der <unk> <unk> in <unk> , haben sich <unk> .
+Wenn die <unk> durch die <unk> <unk> der <unk> <unk> , <unk> und <unk> <unk> <unk> und <unk> <unk> <unk> .
+Die <unk> <unk> in den <unk> ist ein <unk> <unk> im <unk> - die <unk> in <unk> <unk> .
+Die <unk> haben sich über drei <unk> <unk> der <unk> <unk> .
+<unk> seine <unk> <unk> in <unk> , ist die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> - und nicht nur als <unk> <unk> .
+&quot; <unk> ist ein <unk> <unk> , die <unk> <unk> <unk> , <unk> <unk> <unk> .
+Ein <unk> in der <unk> <unk> in <unk> <unk> ein <unk> <unk> <unk> .
+<unk> <unk>
+<unk> hat <unk> <unk> <unk>
+<unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> ?
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> auf <unk> <unk> .
+
+Die <unk> ist <unk> <unk> , die <unk> <unk> , die <unk> <unk> , dass <unk> <unk> , dass <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> der <unk> <unk> , dass <unk> <unk> und andere <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> waren in einer <unk> <unk> von der <unk> <unk> für <unk> und <unk> <unk> auf <unk> <unk> <unk> .
+Die <unk> <unk> auf <unk> <unk> in <unk> .
+Die <unk> der Bericht , <unk> <unk> , dass <unk> , dass die <unk> auf <unk> <unk> <unk> <unk> <unk> - und die <unk> sind <unk> in <unk> <unk> .
+Die <unk> von <unk> <unk> ist <unk> im <unk> des <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> wurde <unk> <unk> als eine <unk> <unk> gegen <unk> <unk> .
+Die <unk> <unk> <unk> die <unk> <unk> , dass die <unk> der <unk> und <unk> in der <unk> der <unk> <unk> .
+Im <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , eine internationale <unk> <unk> <unk> , ist eine internationale <unk> in der <unk> <unk> .
+Die <unk> sollte die <unk> der <unk> <unk> , wenn die <unk> der <unk> von <unk> <unk> <unk> <unk> - mit <unk> für <unk> <unk> .
+Die <unk> der <unk> kann die <unk> der <unk> <unk> <unk> <unk> .
+<unk> <unk> werden <unk> oder <unk> <unk> .
+<unk> auf dem <unk>
+Die <unk> von <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> , <unk> hat eine <unk> <unk> .
+&quot; <unk> <unk> müssen alle alle <unk> <unk> , die <unk> <unk> , <unk> <unk> .
+<unk> ist nicht , ob dieses <unk> oder die <unk> der <unk> <unk> .
+<unk> <unk> ist die <unk> <unk> , aber die <unk> würde der <unk> <unk> , die <unk> <unk> <unk> zu <unk> .
+<unk> <unk> <unk> auf <unk> , dass die <unk> nicht die <unk> <unk> als <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> müssen die <unk> - es <unk> , die <unk> <unk> zu <unk> .
+<unk> im <unk> <unk> <unk> <unk>
+<unk> ist die <unk> der <unk> .
+Um mehr als <unk> <unk> <unk> sind die <unk> des <unk> .
+<unk> <unk> die <unk> auf <unk> <unk> .
+<unk> mehr als <unk> <unk> , ist es <unk> für <unk> <unk> , dass die <unk> der <unk> <unk> .
+<unk> <unk> <unk> , wenn sie <unk> , wenn sie <unk> , dass die <unk> <unk> , die <unk> <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> in zwei beiden <unk> <unk> .
+<unk> <unk> würde die <unk> <unk> , <unk> <unk> , <unk> sie <unk> , die <unk> und <unk> zu <unk> .
+<unk> in <unk> <unk>
+Die <unk> <unk>
+<unk>
+Ein <unk> <unk> mit <unk> , <unk> und <unk> .
+Das ist <unk> <unk> <unk> .
+<unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> , ist ein <unk> <unk> <unk> mit dem <unk> <unk> <unk> .
+<unk> <unk> <unk> die <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> .
+Die <unk> ist ein <unk> in <unk> <unk> .
+Es ist die <unk> <unk> , dass er auch die <unk> des <unk> <unk> <unk> <unk> .
+Das <unk> <unk> <unk> <unk> in <unk> mit seiner <unk> <unk> <unk> und seine <unk> <unk> .
+Die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> als <unk> der <unk> <unk> in <unk> - <unk> und <unk> .
+Die <unk> wurde nicht <unk> wie eine <unk> und <unk> <unk> - es hat keine <unk> <unk> und <unk> <unk> .
+<unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> von <unk> und <unk> in einer <unk> und <unk> <unk> der <unk> .
+Die <unk> <unk> <unk> hat nun die <unk> , die die &quot; <unk> <unk> &quot; und wird <unk> <unk> <unk> <unk> .
+Die <unk> ist ein <unk> der <unk> , die <unk> <unk> , die ersten <unk> <unk> - eine <unk> in allen <unk> .
+<unk> <unk> , die <unk> der neuen <unk> der <unk> in 2007 <unk> <unk> wurde .
+<unk> , ein <unk> <unk> mit einem <unk> <unk> in den <unk> als eine <unk> <unk> , die <unk> <unk> , die <unk> <unk> und <unk> <unk> <unk> und <unk> <unk> <unk> .
+Die neue <unk> war <unk> <unk> , die <unk> <unk> <unk> , eine <unk> und eine <unk> <unk> <unk> .
+<unk> &amp; <unk> <unk>
+<unk> <unk> wurde die <unk> <unk> , die <unk> <unk> <unk> .
+<unk> war <unk> , <unk> und <unk> <unk> der <unk> in <unk> , und <unk> die <unk> , aber er auch die <unk> in der <unk> <unk> .
+Er <unk> die <unk> <unk> und <unk> die Probleme der <unk> <unk> , die bereits bereits <unk> <unk> hat , <unk> <unk> und <unk> .
+Die Probleme <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> der <unk> wurde <unk> <unk> , <unk> <unk> <unk> wurde und die <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> oder <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> für die neue <unk> und der <unk> <unk> , eine <unk> <unk> zwischen den <unk> und der <unk> <unk> .
+Die <unk> <unk> haben <unk> und die <unk> <unk> in der <unk> <unk> <unk> .
+Und die <unk> <unk> <unk> ist es <unk> , um <unk> zu <unk> .
+<unk> der <unk> <unk> der <unk> <unk> und mit einem <unk> <unk> .
+<unk> <unk> , <unk> und <unk> mit der <unk> der <unk> <unk> , <unk> und <unk> mit dem <unk> des <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Die <unk> hat <unk> und <unk> <unk> die <unk> , <unk> und <unk> .
+<unk> <unk> <unk> <unk> , dass die <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; in der <unk> &quot; <unk> .
+<unk> <unk> <unk> ist ein <unk> in der <unk> &quot; und <unk> <unk> <unk> .
+Das <unk> <unk> ist sehr <unk> in der <unk> <unk> <unk> <unk> &quot; <unk> &quot; <unk> &quot; mit <unk> und <unk> <unk> .
+Es gibt auch ein <unk> <unk> der <unk> .
+<unk>
+<unk> <unk> hat sich mit einer Krise <unk> <unk> <unk> in der <unk> .
+Die Reihe von <unk> ist für <unk> .
+Die <unk> werden in <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> zu einer <unk> , die <unk> <unk> <unk> , hat die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist <unk> , die <unk> von <unk> und die <unk> <unk> , <unk> in der <unk> <unk> <unk> .
+Die Reihe von <unk> und <unk> <unk> , in <unk> <unk> und <unk> ist <unk> , um <unk> zu <unk> .
+Die <unk> ist <unk> <unk> und <unk> von <unk> und <unk> von <unk> in vier <unk> <unk> .
+<unk> <unk> , <unk> der <unk> , <unk> <unk> , <unk> <unk> und <unk> dieses <unk> auf eine <unk> mit <unk> und <unk> zwei <unk> <unk> .
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> in seiner <unk> <unk> und <unk> <unk> in der <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Es ist auch <unk> <unk> in der <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk>
+<unk> <unk> <unk> <unk> <unk> auf der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+In der <unk> waren nicht <unk> <unk> , die in der <unk> <unk> nicht <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die Frage <unk> die <unk> <unk> <unk> .
+Der <unk> <unk> <unk> <unk> eine <unk> <unk> , die eine <unk> von <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> der <unk> <unk> <unk> in der <unk> und der <unk> .
+&quot; Wir freuen uns , die Frage ohne <unk> <unk> zu <unk> , &quot; <unk> <unk> in neuen <unk> <unk> .
+Der <unk> ist nicht <unk> <unk> in der <unk> .
+<unk> <unk> ist von <unk> , die <unk> , die <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> , <unk> , <unk> , die <unk> der beiden <unk> .
+Das <unk> <unk> <unk> <unk> ist für die USA <unk> und <unk> in <unk> zu <unk> .
+Die <unk> ist <unk> für <unk> , die <unk> in den <unk> <unk> .
+Die <unk> sind die erste <unk> .
+Das <unk> <unk> auch <unk> <unk> <unk> <unk> und <unk> <unk> , die <unk> <unk> und <unk> <unk> in der <unk> .
+Die <unk> <unk> sind <unk> <unk> .
+Sie sind von <unk> <unk> <unk> .
+Dies <unk> die <unk> einer Reihe von <unk> , wenn die <unk> <unk> <unk> in 2007 <unk> .
+Die neue <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+Die <unk> <unk> gegen eine <unk> <unk> in den <unk> Jahren .
+<unk> und <unk> haben eine <unk> von <unk> für <unk> oder <unk> .
+Die <unk> <unk> <unk> <unk> <unk> hat die <unk> <unk> <unk> .
+Das <unk> <unk> <unk> <unk> internationale <unk> in den USA <unk> und <unk> <unk> auf <unk> <unk> .
+<unk> <unk> auch die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> ist <unk> , dass die <unk> <unk> für &quot; <unk> <unk> &quot; <unk> ist , aber nicht <unk> die <unk> <unk> .
+<unk> <unk> hat die <unk> als <unk> <unk> und hat seine <unk> auf <unk> <unk> <unk> .
+<unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> in der <unk> <unk> <unk> .
+<unk> hat er <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> die <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+Das <unk> <unk> <unk> <unk> seine <unk> in der <unk> .
+<unk> möchte er <unk> <unk> , dass <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> von <unk> <unk> ist ein <unk> im <unk> <unk> .
+Die <unk> <unk> hat nun die <unk> &quot; <unk> <unk> &quot; .
+<unk> <unk> , dass er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> seine <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> ich , dass sie <unk> <unk> <unk> <unk> <unk> <unk> .
+Er <unk> die <unk> , die in <unk> als auch die wirtschaftliche Krise <unk> .
+<unk> ist ein <unk> <unk> , &quot; <unk> , <unk> , <unk> , <unk> <unk> .
+Um eine <unk> Zeit <unk> , hat <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> - auch <unk> <unk> - auch <unk> <unk> und <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Er <unk> nur auf <unk> <unk> , deren <unk> er <unk> <unk> .
+<unk> und <unk> in einer <unk> <unk> , für eine <unk> <unk> und eine <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> über die <unk> <unk> <unk> in der <unk> und <unk> <unk> <unk> in der Welt .
+<unk> <unk> , Herr <unk>
+Ich <unk> ein <unk> <unk> für <unk> <unk> .
+<unk> <unk> <unk> <unk> für <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> <unk> , <unk> <unk> <unk> die <unk> der <unk> .
+&quot; <unk> <unk> , &quot; <unk> , <unk> und <unk> ist auch <unk> , ist <unk> <unk> <unk> <unk> .
+Herr Präsident , Herr <unk> sagte , er hat keine <unk> in <unk> <unk> .
+Die <unk> , <unk> , <unk> , <unk> , ist ein <unk> .
+<unk>
+<unk> die <unk> des <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> von <unk> <unk> <unk> <unk> , dass jetzt <unk> <unk> .
+Die <unk> von <unk> und eine <unk> zwischen <unk> und einer <unk> zwischen <unk> und <unk> war der <unk> <unk> <unk> .
+<unk> und <unk> hat die <unk> in Deutschland und in diesem Bereich in Deutschland .
+<unk> <unk> <unk> , die <unk> <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Es war nicht <unk> , dass <unk> <unk> in Deutschland <unk> .
+Die <unk> <unk> <unk> , die jetzt <unk> hat , ist jedoch auf eine <unk> , die nicht <unk> ist .
+Die <unk> der <unk> <unk> <unk> <unk> ist die <unk> des <unk> <unk> <unk> .
+Die <unk> <unk> , die eine <unk> <unk> , <unk> <unk> , dass eine <unk> der <unk> <unk> <unk> für die <unk> und <unk> <unk> , dass die <unk> Behörden <unk> wird .
+Die <unk> der <unk> <unk> <unk> <unk> , die die <unk> der <unk> in <unk> <unk> <unk> <unk> .
+<unk> zwei <unk> <unk> , die <unk> <unk> in <unk> <unk> die <unk> des <unk> <unk> <unk> in <unk> und <unk> .
+<unk> zwischen zwei Ländern <unk> wurde <unk> <unk> - wie ein Erfolg <unk> .
+Die <unk> von <unk> <unk> hat <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> auch nicht die <unk> des <unk> .
+&quot; <unk> ist der <unk> der <unk> der <unk> <unk> .
+Er <unk> <unk> , dass Menschen <unk> , die <unk> <unk> und <unk> eine wichtige Beitrag zu <unk> .
+Die <unk> der <unk> und der <unk> <unk> ist <unk> <unk> <unk> <unk> .
+Die <unk> sind <unk> , die die <unk> Behörden nicht <unk> , in <unk> <unk> zu <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> wird die <unk> <unk> .
+&quot; <unk> in Deutschland <unk> <unk> <unk> , wie die gesamte <unk> ist , <unk> <unk> und <unk> <unk> .
+Die <unk> auf <unk> und <unk> in der <unk> sind ein Beispiel für <unk> <unk> .
+Die <unk> der <unk> <unk> <unk> ist <unk> in <unk> und <unk> <unk> .
+<unk> anderen <unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> die <unk> , die <unk> und <unk> zu <unk> .
+Die <unk> <unk> die <unk> der <unk> <unk> .
+<unk> der <unk> der <unk> <unk>
+Die <unk> <unk> auf der Zeit <unk> der <unk> <unk> der <unk> <unk> <unk> <unk> , um die <unk> in <unk> zu <unk> .
+Er <unk> eine <unk> von <unk> , um die <unk> <unk> in <unk> , aber es wurde <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> , wenn er die <unk> der <unk> eines anderen <unk> <unk> .
+Die <unk> der <unk> <unk> in <unk> <unk> , wie die <unk> der <unk> <unk> , wie <unk> die <unk> <unk> in der <unk> <unk> wird .
+<unk> <unk> ist , was jetzt <unk> , <unk> <unk> , <unk> , <unk> , <unk> und <unk> <unk> in Deutschland .
+Die <unk> <unk> <unk>
+Die <unk> <unk> in Europa ist keine <unk> oder Frankreich , aber in <unk> .
+Die <unk> <unk> <unk> <unk> in der <unk> und hat von einer Krise <unk> <unk> <unk> .
+<unk> ist nun in <unk> <unk> .
+<unk> <unk> hat <unk> nicht , dass die Rolle der Rolle <unk> <unk> <unk> .
+<unk> seine <unk> <unk> von der <unk> <unk> <unk> , war es <unk> in <unk> , dass er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> wurde <unk> <unk> , <unk> <unk> für seine <unk> und <unk> für ihre <unk> <unk> <unk> und <unk> <unk> <unk> .
+&quot; <unk> ist ein <unk> <unk> .
+&quot; Ich <unk> mich über <unk> und <unk> <unk> .
+Aber der <unk> war es bereits <unk> , dass es sehr <unk> ist .
+Ein <unk> <unk> in <unk> <unk> <unk> die <unk> des <unk> und <unk> .
+<unk> <unk> , <unk> <unk> - ein <unk> nicht nur <unk> in <unk> - <unk> .
+Die <unk> <unk> hat <unk> seit seiner <unk> <unk> .
+<unk> ist die <unk> von <unk> <unk> <unk> .
+Und er wird <unk> der Rolle der <unk> in <unk> <unk> , und nicht in <unk> , die <unk> zu <unk> .
+Das wird für <unk> <unk> <unk> .
+Er ist ein <unk> <unk> und <unk> <unk> , nicht ein <unk> <unk> zu <unk> .
+<unk> auf <unk> , <unk> er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist es in der <unk> <unk> , die <unk> <unk> in der Welt , die <unk> - und hat <unk> von einer <unk> <unk> <unk> .
+Die <unk> <unk> <unk> , ist es zu <unk> <unk> .
+Es ist im <unk> <unk> .
+<unk> <unk> hat eine <unk> <unk> und 2007 .
+Die <unk> <unk> die <unk> der <unk> und <unk> , aber <unk> <unk> <unk> <unk> mit <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> wurde <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+In der <unk> des <unk> <unk> <unk> <unk> als <unk> <unk> <unk> .
+Das ist eine <unk> .
+Die <unk> <unk> und <unk> <unk> in der <unk> <unk> der <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> , was wir heute heute haben , haben wir heute <unk> <unk> .
+Er war sehr <unk> .
+Es ist klar <unk> , dass es <unk> ist , um <unk> zu <unk> .
+Im <unk> der <unk> <unk> <unk> <unk> <unk> - eine <unk> <unk> und <unk> <unk> - <unk> <unk> .
+<unk> gibt es <unk> , dass die <unk> <unk> <unk> <unk> .
+Die <unk> <unk> der <unk> <unk> <unk> auf <unk> <unk> und wurde <unk> <unk> <unk> .
+<unk> <unk> eine <unk> <unk> , ist es <unk> oder nicht , die <unk> <unk> zu <unk> .
+<unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Das war nur die ersten <unk> .
+Es ist ein <unk> <unk> im <unk> <unk> .
+Die <unk> wurde <unk> <unk> in der <unk> und <unk> der <unk> <unk> <unk> , <unk> <unk> - die zweite <unk> <unk> <unk> in <unk> <unk> .
+<unk> <unk> im <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> <unk> <unk> <unk> <unk> von <unk> für <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die gesamte <unk> wurde <unk> <unk> - die <unk> <unk> für eine <unk> Land zu <unk> .
+<unk> alle alle <unk> <unk> in 2007 <unk> <unk> die wirtschaftliche <unk> des <unk> <unk> <unk>
+Die zweite <unk> sind nicht zu <unk> <unk> , &quot; <unk> <unk> <unk> <unk> .
+Die zweite <unk> <unk> <unk> auf die <unk> der ersten <unk> .
+Ein <unk> <unk> war <unk> <unk> , <unk> <unk> in der <unk> und <unk> , dass es in der <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> auch <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> Sie mehr oder weniger <unk> .
+<unk> <unk> sind <unk> <unk> , dass eine <unk> für die <unk> <unk> <unk> <unk> - die <unk> <unk> <unk> .
+<unk> <unk> <unk> war nicht <unk> .
+Die <unk> und die <unk> <unk> <unk> und der <unk> kann <unk> und <unk> <unk> .
+Die <unk> sind <unk> <unk> .
+Die <unk> <unk> seine <unk> in seiner <unk> <unk> <unk> in <unk> <unk> <unk> , in <unk> <unk> und <unk> <unk> <unk> .
+Die <unk> <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist <unk> <unk> , <unk> in <unk> <unk> ist nicht <unk> .
+<unk> &quot; <unk> &quot; <unk> &quot; <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> von einer <unk> <unk> <unk> auch keine <unk> <unk> .
+Es war <unk> <unk> , dass die <unk> der <unk> der <unk> <unk> <unk> <unk> <unk> <unk> die <unk> der <unk> <unk> - nicht <unk> <unk> .
+Die <unk> von <unk> <unk> hat eine <unk> von <unk> <unk> , nur als <unk> und <unk> <unk> .
+Die <unk> <unk> in <unk> <unk> <unk> die <unk> der <unk> <unk> <unk> - nur eine <unk> <unk> .
+Die <unk> <unk> ist <unk> .
+Die <unk> hat die <unk> <unk> <unk> auf der <unk> der <unk> <unk> , die von der <unk> <unk> <unk> <unk> <unk> .
+Die <unk> sind <unk> und die <unk> <unk> in Europa .
+<unk> <unk> wie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> sind hier für die <unk> Jahren <unk> - von der <unk> <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> .
+Ein <unk> <unk> <unk> <unk> die <unk> <unk> .
+Die <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , dass die <unk> <unk> <unk> für <unk> - <unk> .
+Doch die <unk> <unk> <unk> , <unk> und <unk> <unk> , um die <unk> <unk> der <unk> <unk> - oder <unk> sie die <unk> von <unk> <unk> <unk> .
+Er <unk> keine <unk> <unk> in der <unk> - er mit dem <unk> <unk> <unk> <unk> <unk> .
+Das <unk> <unk> <unk> <unk> <unk> <unk> - besonders in <unk> <unk> , wo die <unk> auch sehr <unk> <unk> .
+Im <unk> haben die <unk> noch <unk> .
+Die <unk> <unk> und wenn sie <unk> , haben sie <unk> , <unk> <unk> <unk> <unk> .
+Es war sehr <unk> <unk> <unk> , dass <unk> <unk> , dass <unk> <unk> , <unk> <unk> , <unk> in den ersten <unk> und <unk> <unk> <unk> .
+Die <unk> wurde <unk> <unk> <unk> .
+Die <unk> , die <unk> der <unk> <unk> , der <unk> der <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> in seiner <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> sich auf <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Wie kann es <unk> ?
+<unk> zu <unk> , <unk> sie die Frage der <unk> <unk> .
+<unk> des <unk> <unk> <unk> <unk> in einer <unk> , <unk> <unk> in <unk> .
+Ein <unk> <unk> war <unk> , dass ich bereits <unk> <unk> für <unk> <unk> <unk> , wenn die <unk> <unk> <unk> .
+Die Tatsache , dass die beiden <unk> , die <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> und <unk> <unk> .
+Die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> sind mit der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> und <unk> wurde <unk> , dass die <unk> und <unk> eine <unk> <unk> , <unk> <unk> .
+Die <unk> , <unk> , <unk> , <unk> , <unk> mit einem <unk> <unk> und <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Aber <unk> in <unk> <unk> auf <unk> <unk> .
+Und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Das ist <unk> .
+<unk> kann es <unk> werden .
+<unk> ist ein <unk> .
+<unk> von <unk> <unk> <unk> die <unk> , wo die <unk> immer <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> war der <unk> des <unk> <unk> .
+Es <unk> die &quot; <unk> <unk> &quot; , dass <unk> die <unk> in der Zeit <unk> .
+<unk> <unk> sich auf die <unk> der <unk> .
+Es ist einige der <unk> <unk> .
+<unk> war ein <unk> <unk> in <unk> <unk> und <unk> .
+<unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> in den USA <unk> .
+Um die <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> für die <unk> und eine <unk> <unk> von den <unk> <unk> in <unk> <unk> <unk> .
+Es ist ein <unk> <unk> , die <unk> <unk> <unk> , die <unk> <unk> <unk> <unk> und <unk> <unk> <unk> .
+<unk> , wenn andere <unk> <unk> <unk> <unk> <unk> für eine <unk> <unk> <unk> <unk> .
+&quot; <unk> <unk> wurde <unk> als <unk> <unk> , als die <unk> 2007 in <unk> , &quot; <unk> <unk> <unk> .
+Die <unk> der <unk> , die <unk> der <unk> .
+Nach der nächsten <unk> haben die <unk> <unk> , die <unk> <unk> zu <unk> als <unk> .
+<unk> <unk> ist ein <unk> von <unk> <unk> und <unk> <unk> .
+<unk> <unk> die <unk> der <unk> <unk> jetzt <unk> <unk> .
+Er muss ein <unk> für eine <unk> <unk> , die ihre <unk> <unk> <unk> .
+<unk> <unk> hat eine <unk> - <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> und <unk> <unk> .
+Die <unk> , Herr <unk> , <unk> keine <unk> zu <unk> .
+Es ist <unk> , dass <unk> <unk> <unk> werden .
+Die neue <unk> der <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+Die <unk> <unk> <unk> war nur <unk> als <unk> Lösung , wenn die <unk> <unk> mit seiner <unk> <unk> <unk> .
+Für die <unk> hat er seine <unk> <unk> und ist nun <unk> <unk> , die <unk> <unk> zu <unk> .
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Er ist <unk> <unk> <unk> .
+Aber die <unk> <unk> <unk> .
+<unk> ist ein <unk> .
+Was ist <unk> ?
+Wie kann es <unk> <unk> werden ?
+<unk> sind die <unk> <unk> <unk> <unk> .
+<unk> , er hat <unk> <unk> , dass er nur eine <unk> in <unk> <unk> .
+<unk> <unk> .
+<unk> in Europa <unk> seine <unk> <unk>
+Die <unk> <unk> in Europa hat die <unk> der <unk> in Europa <unk> .
+Die <unk> der Regierung in <unk> und <unk> wurde <unk> <unk> .
+<unk> <unk> <unk> die <unk> <unk> <unk> , dass die <unk> in der <unk> <unk> <unk> <unk> .
+Die <unk> <unk> die <unk> <unk> des <unk> in <unk> und <unk> nicht <unk> .
+Die <unk> <unk> gegen die <unk> .
+Die <unk> und <unk> <unk> war immer <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> in <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> mit <unk> <unk> .
+Die <unk> <unk> zwischen <unk> und <unk> in der <unk> .
+<unk> <unk> &amp; <unk> <unk> <unk> <unk> <unk> .
+Das <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Im <unk> <unk> <unk> die <unk> <unk> <unk> <unk> .
+<unk> in den <unk> Ländern hat <unk> <unk> und ist <unk> <unk> der <unk> .
+Die <unk> <unk> <unk> <unk> , die in <unk> <unk> <unk> <unk> <unk> als in der <unk> <unk> <unk> .
+Die <unk> <unk> <unk> <unk> <unk> und <unk> sind nicht eine <unk> .
+Er <unk> auch <unk> , dass Europa keine <unk> <unk> und die <unk> <unk> in der <unk> <unk> .
+Die <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+Im <unk> ist es auch <unk> , um <unk> zu <unk> oder <unk> .
+<unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> von <unk> <unk> in <unk> <unk> die <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> sind <unk> auf <unk> <unk> .
+<unk> <unk> , <unk> <unk> <unk> <unk> pro <unk> und <unk> hat eine <unk> <unk> .
+Die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> der <unk> <unk> <unk> <unk> <unk> <unk> als die <unk> von <unk> <unk> .
+Die <unk> <unk> <unk> <unk> <unk> in China <unk> <unk> in <unk> , <unk> in <unk> <unk> .
+Die <unk> <unk> <unk> auf <unk> <unk> mit dem <unk> des <unk> <unk> <unk> .
+Die <unk> <unk> <unk> <unk> , <unk> <unk> auf die <unk> .
+Die <unk> , die <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> in <unk> <unk> .
+Die <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> auf der <unk> <unk> <unk> .
+<unk> <unk> <unk> , <unk> <unk> und <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> , <unk> <unk> und <unk> auf die <unk> auf <unk> <unk> .
+<unk> sind in <unk> <unk> .
+<unk> sind <unk> Problem in vielen <unk> .
+<unk> wie die <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Eine Lösung von <unk> .
+<unk> im <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> von allen <unk> über <unk> <unk> Lösungen .
+<unk> in der <unk>
+<unk> <unk> , dass <unk> der <unk> <unk> der <unk> in <unk> , <unk> , die <unk> , dass die <unk> der <unk> in <unk> <unk> <unk> wurde .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> sind <unk> .
+Es gibt eine <unk> <unk> mit <unk> <unk> in den <unk> <unk> und in der <unk> in <unk> , <unk> , <unk> , <unk> und <unk> .
+Eine <unk> Liste von <unk> in <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> die <unk> der <unk> in <unk> <unk> und wie sie <unk> <unk> , wie <unk> mit <unk> wie <unk> <unk> .
+&quot; <unk> <unk> und <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+<unk> <unk> <unk> mit <unk> oder <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> .
+<unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> nur als <unk> in <unk> , <unk> und <unk> .
+&quot; Wir haben <unk> mit ihnen <unk> .
+<unk> <unk> die <unk> <unk> , <unk> <unk> , <unk> , <unk> <unk> .
+Ein <unk> der <unk> <unk> von <unk> <unk> und <unk> <unk> für diese <unk> <unk> <unk> <unk> und <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> war ein <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> ist <unk> <unk> .
+<unk> auch die <unk> <unk> , die <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> und <unk> der <unk> sind <unk> <unk> , <unk> <unk> , <unk> , <unk> und <unk> .
+<unk> <unk> auf der <unk> der <unk> <unk> <unk> die <unk> der <unk> <unk> <unk> .
+In einer <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , um eine <unk> zu <unk> .
+Sie <unk> die <unk> und <unk> von <unk> <unk> , ohne die <unk> zu <unk> .
+In einer <unk> <unk> <unk> die <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> ein <unk> mit einem <unk> <unk> in einer <unk> <unk> .
+Die <unk> wird nicht <unk> , mit dem <unk> <unk> .
+<unk> <unk> hat die <unk> <unk> <unk> .
+Alle <unk> <unk> die <unk> <unk> , um die <unk> zu <unk> , um die <unk> der <unk> <unk> .
+<unk> der vier <unk> <unk> <unk> <unk> <unk> <unk>
+<unk>
+Die <unk> der <unk> und <unk> für eine <unk> <unk> wurde <unk> .
+Die <unk> <unk> , <unk> und die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> , die <unk> , <unk> und <unk> haben die <unk> <unk> für die <unk> <unk> in <unk> und <unk> .
+<unk> von <unk> <unk> <unk> , <unk> , <unk> in der <unk> und <unk> ...
+Die <unk> nur <unk> <unk> <unk> in der <unk> <unk> der <unk> <unk> gegen <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk>
+<unk> <unk> hat nicht ein <unk> mit <unk> <unk> gegen <unk> und <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> <unk> die <unk> für <unk> .
+Das <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> ein <unk> <unk> in der <unk> <unk> .
+<unk> <unk> wurde <unk> des <unk> <unk> <unk> .
+<unk> <unk> <unk> sich in Lissabon <unk> <unk> <unk> <unk> .
+<unk> <unk> ein <unk> <unk> in der <unk> von <unk> <unk> .
+Ein <unk> <unk> von einem <unk> <unk> <unk> seine <unk> <unk> , um die <unk> von der <unk> <unk> .
+Die <unk> , mit dem <unk> <unk> in erster Linie mit <unk> <unk> <unk> .
+Die <unk> <unk> <unk> von der <unk> <unk> <unk> <unk> <unk> eine <unk> <unk> der <unk> in der <unk> , aber die <unk> <unk> nicht nur die <unk> <unk> .
+<unk> für die <unk>
+Die <unk> <unk> <unk> von <unk> <unk> <unk> <unk> .
+<unk> eine <unk> auf <unk> <unk> in der <unk> <unk> <unk> , <unk> die <unk> der <unk> <unk> <unk> und <unk> <unk> <unk> .
+<unk> auch ein <unk> <unk> für <unk> , <unk> - <unk> <unk> .
+<unk> <unk> , die <unk> <unk> der <unk> <unk> der <unk> mit <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> für die <unk> in der <unk> .
+Die Europäische <unk> sind die <unk> <unk> für die <unk> <unk> in einer <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> .
+<unk> hat seine <unk> <unk> <unk> , wenn die <unk> <unk> und <unk> <unk> <unk> .
+Die <unk> <unk> der <unk> <unk> <unk> , dass nur die <unk> des <unk> im <unk> <unk> <unk> .
+Die <unk> <unk> , die <unk> <unk> die <unk> <unk> <unk> <unk> , <unk> in der <unk> der <unk> <unk> .
+Die <unk> wurde <unk> <unk> <unk> .
+<unk> wurde <unk> <unk> in <unk> <unk> .
+<unk> Tage über <unk> <unk> in <unk> , kann die <unk> nicht als <unk> <unk> <unk> .
+<unk> ist es eine <unk> , dass die nationalen <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> <unk> <unk> die <unk> <unk> in <unk> der <unk> <unk> .
+Die <unk> <unk> <unk> <unk> die <unk> in der <unk> und <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> und <unk> <unk> .
+<unk> <unk> in <unk> <unk> .
+Das <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk>
+Die <unk> in <unk> wurden ihre ersten <unk> in Deutschland <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> für die <unk> in der <unk> .
+<unk> <unk> <unk> die <unk> , aber <unk> <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> <unk> <unk> , die <unk> in den letzten <unk> im <unk> <unk> .
+Die <unk> <unk> in der <unk> <unk> .
+<unk> ein <unk> <unk> von <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk>
+Ein <unk> <unk> war <unk> <unk> in <unk> auf <unk> <unk> .
+Die <unk> <unk> in einer <unk> auf die <unk> , die <unk> <unk> <unk> <unk> <unk> in <unk> .
+Die <unk> wurde <unk> <unk> auf <unk> , wenn ein <unk> <unk> in <unk> <unk> <unk> .
+Die <unk> , <unk> und <unk> ist - die <unk> <unk> <unk> .
+Die andere <unk> auf die <unk> <unk> <unk> .
+<unk> <unk>
+Ein <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> in einer <unk> , dass er ein <unk> <unk> mit einem <unk> und <unk> <unk> werden .
+Die <unk> <unk> wurde über <unk> , die <unk> <unk> und mit einem <unk> <unk> <unk> .
+Die <unk> <unk> <unk> von <unk> .
+<unk> <unk>
+Ein <unk> <unk> wurde <unk> <unk> auf <unk> <unk> in <unk> .
+Er <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> der <unk> von <unk> <unk> .
+<unk> <unk> , <unk> die <unk> in <unk> <unk> und <unk> in <unk> <unk> .
+Die <unk> wurde <unk> <unk> .
+Die <unk> <unk> wurde <unk> <unk> .
+<unk> <unk> und <unk> <unk>
+Ein <unk> <unk> war <unk> <unk> und <unk> <unk> von <unk> in <unk> .
+Die <unk> <unk> in einer <unk> auf die <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> zu <unk> , die <unk> zu <unk> und <unk> <unk> .
+Ein <unk> <unk> <unk> in den <unk> <unk> <unk> .
+Die <unk> wurde <unk> <unk> und <unk> für <unk> <unk> in einer <unk> <unk> .
+Im <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Ein <unk> <unk> war eine <unk> in <unk> .
+Er <unk> ein <unk> <unk> und <unk> <unk> <unk> , wenn die <unk> <unk> .
+Ein <unk> <unk> <unk> <unk> .
+Die <unk> <unk> die <unk> - die <unk> - <unk>
+<unk> <unk> !
+Er <unk> gegen eine <unk> <unk> <unk> und <unk> <unk> der <unk> .
+Die <unk> , eine <unk> und die <unk> <unk> auf <unk> .
+<unk> <unk> mit einem <unk> <unk> .
+Ein <unk> <unk> in <unk> hat <unk> <unk> <unk> .
+Die <unk> <unk> in einer <unk> , die die <unk> <unk> wurde und über die <unk> in der <unk> <unk> , wenn sie <unk> in der <unk> <unk> .
+<unk> <unk> wurde <unk> <unk> <unk> .
+Die <unk> <unk> <unk> <unk> - eine <unk> <unk> .
+Ein <unk> <unk> <unk> es ist keine <unk> zwischen der <unk> und der <unk> .
+<unk> <unk> in einer <unk> <unk>
+Ein <unk> <unk> ist <unk> <unk> in der <unk> <unk> mit einem <unk> .
+Die <unk> <unk> in einer <unk> , dass die <unk> <unk> <unk> <unk> <unk> <unk> die <unk> der <unk> <unk> <unk> <unk> .
+Die <unk> wurde <unk> <unk> der <unk> <unk> und <unk> mit einem <unk> .
+Die <unk> hat <unk> <unk> , die <unk> <unk> <unk> .
+Er war <unk> <unk> <unk> <unk> .
+<unk> in <unk> auf <unk>
+Ein <unk> <unk> <unk> in <unk> auf <unk> <unk> .
+Die <unk> <unk> in einer <unk> , die in einer <unk> <unk> , <unk> <unk> , <unk> die <unk> auf <unk> <unk> <unk> .
+<unk> war <unk> <unk> .
+Die <unk> war <unk> <unk> , die <unk> <unk> in der <unk> <unk> <unk> .
+<unk> <unk> auf die <unk> <unk> und <unk> <unk> .
+<unk> <unk> <unk> von <unk> <unk>
+Ein <unk> ist <unk> <unk> von <unk> in der <unk> <unk> .
+Die <unk> <unk> in einer <unk> , dass die <unk> <unk> die <unk> in einer <unk> <unk> <unk> <unk> .
+Wenn die <unk> <unk> <unk> , <unk> er die <unk> und <unk> mit einer <unk> .
+<unk> <unk> <unk> <unk> .
 Die <unk> wurde mit <unk> <unk> <unk> .
 <unk>
-Die Leute sind in den letzten <unk> in <unk> <unk> .
-Die <unk> <unk> in einer <unk> , die <unk> , <unk> <unk> , <unk> <unk> und <unk> <unk> wurden in <unk> <unk> <unk> worden .
-Die <unk> wurden <unk> <unk> Frauen <unk> .
-Sie haben ihre <unk> oder <unk> mit <unk> <unk> <unk> .
-Die <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk>
+<unk> <unk> wurden in der <unk> eines <unk> in <unk> <unk> .
+Die <unk> <unk> in einer <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> und <unk> <unk> <unk> <unk> in <unk> <unk> .
+Die <unk> wurde <unk> <unk> Frauen die <unk> <unk> .
+<unk> <unk> oder <unk> <unk> mit <unk> <unk> .
+Die <unk> <unk> <unk> in <unk> <unk> in <unk> <unk> .
+<unk> <unk>
 Die <unk> haben <unk> <unk> <unk> .
-Die <unk> <unk> in einer <unk> , die die <unk> <unk> auf <unk> <unk> wurden .
-Die <unk> , <unk> in <unk> , <unk> <unk> <unk> <unk> <unk> <unk> .
-Sie <unk> eine <unk> zur <unk> und <unk> ein <unk> .
+Die <unk> <unk> in einer <unk> , dass die <unk> <unk> <unk> in <unk> <unk> .
+Die <unk> , <unk> in <unk> <unk> , <unk> eine <unk> <unk> auf <unk> .
+Sie <unk> eine <unk> , um die <unk> und <unk> <unk> zu <unk> .
 <unk> <unk> die <unk> .
-Die <unk> <unk> , wenn <unk> <unk> .
-Aber sie waren nach <unk> zu einem <unk> auf <unk> <unk> .
-<unk> Sie das <unk> von <unk> und <unk> <unk> <unk>
-<unk> <unk> <unk> <unk> ein <unk> in <unk> .
-Die <unk> <unk> in einer <unk> , die die <unk> <unk> auf <unk> <unk> und <unk> nicht von einem <unk> <unk> <unk> wurde .
-Die <unk> <unk> die <unk> und die <unk> <unk> <unk> <unk> .
-Er <unk> auf <unk> <unk> .
+Die <unk> <unk> <unk> wenn <unk> <unk> .
+<unk> hat sie in einer <unk> <unk> <unk> .
+<unk> <unk> von einer <unk> und <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> .
+Die <unk> <unk> in einer <unk> , die die <unk> <unk> , eine <unk> auf die <unk> der <unk> und <unk> nicht <unk> .
+Die <unk> <unk> die <unk> und die <unk> <unk> <unk> die <unk> und <unk> <unk> .
+Er <unk> <unk> zu <unk> <unk> <unk> .
+<unk> <unk> und <unk> von einer <unk> in <unk> <unk>
+Ein <unk> <unk> war <unk> <unk> und <unk> <unk> von <unk> in <unk> <unk> .
+Die <unk> <unk> in einer <unk> , die er <unk> hat , mit <unk> zu <unk> und <unk> .
+Die <unk> <unk> <unk> <unk> die <unk> in <unk> eines <unk> <unk> .
+Die <unk> war nicht , in <unk> und die <unk> <unk> der <unk> .
+Die <unk> war nicht von <unk> .
+<unk> <unk> in <unk> <unk>
+Ein <unk> <unk> war <unk> <unk> und <unk> von <unk> in <unk> <unk> .
+Die <unk> <unk> in einer <unk> auf die <unk> , die er <unk> hat , mit <unk> <unk> und <unk> nicht <unk> .
+Die <unk> der <unk> mit der <unk> von <unk> ist nicht <unk> .
 <unk>
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> in einer <unk> , die er war , mit <unk> zu <unk> und <unk> .
-Die <unk> <unk> <unk> die <unk> in <unk> eines <unk> <unk> .
-Der <unk> war nicht <unk> , dass die <unk> der <unk> <unk> .
-<unk> wurde nicht von <unk> <unk> .
-<unk>
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> in einer <unk> <unk> , die er <unk> hatte , <unk> <unk> und könnte nicht <unk> werden .
-Die <unk> des <unk> mit der <unk> <unk> ist klar <unk> .
-<unk>
-<unk> <unk> auf <unk> <unk> in <unk> <unk> .
-Ein <unk> <unk> <unk> <unk> ein <unk> <unk> , die die <unk> <unk> .
-Er war <unk> und die <unk> <unk> <unk> <unk> .
-Die <unk> wurde <unk> .
-Aber ein <unk> <unk> <unk> .
-<unk> und <unk> <unk>
-Ein <unk> <unk> nach einem <unk> <unk> in <unk> <unk> ohne <unk> <unk> .
-Die <unk> <unk> in einer <unk> , die die <unk> <unk> auf <unk> <unk> und <unk> <unk> auf die <unk> <unk> .
-Ein <unk> <unk> <unk> wurde in <unk> und <unk> die <unk> <unk> .
-Die <unk> wurde <unk> und <unk> ein <unk> <unk> von den <unk> und <unk> ihm .
-Die <unk> des <unk> wurde <unk> , dass die <unk> einige <unk> <unk> worden ist .
-<unk> im <unk> <unk>
-Die <unk> in einem Teil einer <unk> <unk> in einer <unk> <unk> im <unk> .
-Die <unk> <unk> in einer <unk> , die von der <unk> <unk> <unk> <unk> <unk> auf der <unk> und <unk> der <unk> <unk> .
-Ein <unk> , die <unk> in den <unk> <unk> wurde , war <unk> <unk> .
-Aber <unk> war er <unk> nicht <unk> .
-<unk> Menschen in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die Leute in einer <unk> <unk> in <unk> wurden in <unk> <unk> <unk> <unk> .
-Die <unk> <unk> in einer <unk> , die vier <unk> <unk> zwischen <unk> und <unk> <unk> mit zwei <unk> <unk> <unk> .
-<unk> <unk> <unk> , <unk> aber <unk> <unk> und <unk> der vier <unk> .
-<unk> <unk> <unk> <unk> .
-Die vier <unk> waren im Restaurant <unk> .
-<unk>
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> die <unk> <unk> auf <unk> und <unk> <unk> in seiner <unk> nach <unk> .
-Die drei <unk> <unk> das <unk> .
-Die <unk> <unk> in einer <unk> , die eine <unk> <unk> <unk> worden ist .
-Ein <unk> <unk> als die <unk> aus ihrem <unk> .
-<unk> Sie die <unk> in einem <unk> im <unk> .
-Die <unk> <unk> wurde für <unk> <unk> .
-<unk>
-Ein <unk> <unk> in einer <unk> in der <unk> <unk> <unk> <unk> .
-Die <unk> <unk> in einer <unk> , die <unk> <unk> <unk> in <unk> <unk> <unk> in <unk> <unk> .
-Die <unk> <unk> einen großen <unk> , die <unk> <unk> werden kann .
-Die <unk> <unk> <unk> mit vier <unk> und <unk> <unk> mit vier <unk> .
-<unk> <unk> <unk> und eine <unk> <unk> mit dem <unk> .
-Die <unk> <unk> der <unk> würde nun auch <unk> , sagte ein <unk> <unk> <unk> .
-<unk> war <unk> während der <unk> .
-<unk> <unk> , <unk> <unk> während der <unk> <unk> .
-<unk>
-<unk> <unk> <unk> und <unk> <unk> eine <unk> <unk> in <unk> .
-Die <unk> <unk> in einer <unk> <unk> , das er von den drei <unk> und <unk> <unk> <unk> wurde .
-Das <unk> <unk> er , <unk> und <unk> ihre <unk> und <unk> mit seinem <unk> und <unk> .
-<unk> Sie die <unk> <unk> <unk> <unk> auf der <unk> und als <unk> .
-Die <unk> wurde <unk> .
-<unk>
-Ein <unk> <unk> <unk> und <unk> ein <unk> <unk> auf <unk> <unk> in <unk> <unk> .
-Die <unk> <unk> in einer <unk> <unk> , die die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> sich in der <unk> , während ihr <unk> auf .
-<unk> <unk> <unk> <unk> die <unk> <unk> .
+Ein <unk> war <unk> <unk> auf <unk> <unk> in <unk> .
+Ein <unk> <unk> <unk> <unk> ein <unk> <unk> , um die <unk> <unk> .
+Er war <unk> und die <unk> <unk> <unk> , die die <unk> des <unk> <unk> .
+Die <unk> war ein <unk> <unk> .
+<unk> ist <unk> , aber ein <unk> <unk> .
+<unk> und <unk> in <unk> in <unk>
+Ein <unk> <unk> in einem <unk> <unk> in <unk> auf <unk> <unk> <unk> .
+Die <unk> <unk> in einer <unk> , die die <unk> <unk> <unk> , <unk> in einer <unk> <unk> und <unk> auf die <unk> .
+Ein <unk> <unk> wurde in <unk> und <unk> die <unk> <unk> .
+Die <unk> <unk> wurde <unk> und <unk> ein <unk> <unk> von der <unk> und <unk> <unk> <unk> .
+Die <unk> der <unk> wurde <unk> <unk> , dass sich die <unk> <unk> <unk> <unk> <unk> .
+<unk> in einer <unk> in <unk> <unk>
+Es ist eine <unk> in einer <unk> auf ein <unk> <unk> in <unk> <unk> .
+Die <unk> <unk> in einer <unk> , dass die <unk> der <unk> auf <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Ein <unk> , die <unk> <unk> in den <unk> <unk> wurde <unk> <unk> .
+<unk> hat er <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> in <unk> <unk> <unk> <unk> <unk>
+In einer <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> .
+Die <unk> <unk> in einer <unk> , die vier <unk> <unk> , <unk> <unk> und <unk> <unk> mit zwei <unk> <unk> .
+<unk> <unk> , <unk> , <unk> , <unk> <unk> und <unk> von den <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> .
+Die vier <unk> <unk> in den <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> - <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Ein <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> und <unk> <unk> .
+<unk> <unk> die <unk> <unk> auf <unk> und <unk> <unk> in seiner <unk> <unk> <unk> .
+Die erste <unk> <unk> die <unk> .
+Die <unk> <unk> in einer <unk> , dass ein <unk> <unk> ist , <unk> <unk> .
+Ein <unk> <unk> ist die <unk> der <unk> .
+<unk> Sie die <unk> <unk> in einem <unk> <unk> .
+Die <unk> <unk> wurde <unk> für <unk> <unk> .
+<unk> in <unk> in der <unk>
+Ein <unk> <unk> , in einem <unk> <unk> , in einem <unk> <unk> <unk> .
+Die <unk> <unk> in einer <unk> , dass die <unk> <unk> <unk> auf <unk> <unk> <unk> werden .
+Die <unk> <unk> eine große <unk> von <unk> , die <unk> <unk> <unk> werden .
+Die <unk> <unk> <unk> mit vier <unk> <unk> und <unk> <unk> <unk> .
+Ein <unk> <unk> <unk> und eine <unk> von <unk> .
+Die <unk> <unk> der <unk> würde jetzt auch eine <unk> <unk> .
+<unk> ein <unk> <unk> in der <unk> .
+<unk> war ein <unk> und <unk> <unk> .
+<unk> <unk>
+<unk> <unk> und <unk> <unk> eine <unk> <unk> in <unk> .
+Das <unk> <unk> in einer <unk> auf <unk> <unk> , die die <unk> <unk> <unk> und <unk> <unk> <unk> , <unk> er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> werden <unk> , <unk> und <unk> ihre <unk> und <unk> mit seiner <unk> und <unk> .
+<unk> <unk> Sie die <unk> <unk> <unk> <unk> auf die <unk> und <unk> .
+Die <unk> wurde <unk> <unk> .
+<unk> <unk> <unk> <unk> - <unk> <unk> auf <unk> <unk> .
+Ein <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> in einer <unk> auf <unk> , die die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> die <unk> der <unk> in der <unk> <unk> <unk> .
+<unk> <unk> <unk> die <unk> <unk> <unk> <unk> .
 Die <unk> <unk> wurde <unk> <unk> .
 <unk>
-<unk> <unk> <unk> <unk> auf <unk> in einer <unk> in <unk> <unk> <unk> .
-Die <unk> <unk> in einer <unk> , die eine <unk> <unk> <unk> und auch zwei <unk> <unk> <unk> <unk> .
-Die <unk> wurde <unk> und <unk> <unk> .
-<unk>
-Ein <unk> <unk> ist ein <unk> in einer <unk> in einer <unk> / <unk> .
-Die <unk> <unk> in einer <unk> <unk> , die die <unk> <unk> ist , um die <unk> <unk> zu <unk> .
-Die <unk> müssen eine <unk> und <unk> über die <unk> <unk> .
-<unk> auf der <unk> <unk> <unk> .
-Die <unk> <unk> wurde <unk> auf <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> auf <unk> in einer <unk> <unk> <unk> .
+Die <unk> <unk> in einer <unk> , die ein <unk> <unk> , in der eine <unk> <unk> <unk> und auch zwei <unk> <unk> .
+Die <unk> wurde <unk> <unk> und <unk> <unk> .
+<unk> <unk> auf <unk> <unk> - <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Ein <unk> <unk> ist ein <unk> im <unk> / <unk> .
+Die <unk> <unk> in einer <unk> auf die <unk> , die die <unk> <unk> , um die <unk> zu <unk> .
+Die <unk> muss eine <unk> und <unk> auf die <unk> .
+<unk> auf die <unk> <unk> <unk> .
+Die <unk> <unk> wurde <unk> <unk> <unk> .
 Die <unk> <unk> von <unk> <unk> .
-Die <unk> <unk> , die in der <unk> im <unk> <unk> wurde , wird <unk> für <unk> <unk> .
+Die <unk> der <unk> , die in der <unk> des <unk> <unk> ist , ist <unk> für <unk> <unk> .
 <unk>
-Ein <unk> von <unk> <unk> , <unk> und <unk> <unk> .
-Die <unk> von <unk> <unk> <unk> <unk> .
-Die <unk> der <unk> waren nicht <unk> .
-<unk> <unk> <unk> sich in <unk> vier <unk> <unk> .
-<unk>
-Europa <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-Die <unk> <unk> auf <unk> , die auf zwei <unk> <unk> <unk> <unk> <unk> ist , <unk> <unk> von <unk> .
-&quot; Wir werden <unk> und Entwicklung von Menschen und Entwicklung von <unk> , &quot; <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> <unk> ist für <unk> .
-Die <unk> in <unk> zur <unk> des <unk> von <unk> bis hin zu <unk> oder <unk> .
-<unk> ist <unk> , <unk> , <unk> , <unk> und <unk> .
-Die <unk> ist in der <unk> Land , als <unk> Kunden als <unk> Kunden .
-Die <unk> für <unk> in China sind auch eine wichtige <unk> der <unk> <unk> .
-<unk> <unk> auf <unk> <unk> <unk> <unk> <unk> <unk> .
-Die Firma von <unk> wurde <unk> <unk> <unk> .
-<unk> für die Software <unk> ist <unk> als <unk> , mit <unk> <unk> .
-<unk> wurde China für 20 Jahre <unk> .
-&quot; Wir wollen jetzt unsere <unk> <unk> <unk> &quot; <unk> <unk> .
-<unk> , <unk> &quot; <unk> &quot; <unk> in China .
-<unk>
-<unk> <unk> und <unk> neue <unk> , &quot; <unk> , &quot; <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> ist <unk> für <unk> <unk> .
-Sie werden wissen , diese Menschen zu <unk> , um die <unk> <unk> zu <unk> und dieses <unk> <unk> zu <unk> , <unk> , <unk> und <unk> in der <unk> <unk> .
+<unk> <unk> <unk> , <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> der <unk> <unk> wurde nicht <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> .
+<unk> <unk> in China <unk> <unk> .
+Europa <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> auf China in China in China Jahren <unk> .
+Die <unk> <unk> <unk> auf <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Die <unk> <unk> ist <unk> zu <unk> .
+Die <unk> <unk> in <unk> <unk> <unk> auf <unk> <unk> zu <unk> oder <unk> .
+<unk> ist im <unk> , <unk> , <unk> , <unk> und <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> für die <unk> in China sind auch eine wichtige <unk> des <unk> .
+<unk> <unk> auf <unk> <unk> <unk> <unk> <unk> .
+Die <unk> von <unk> ist <unk> <unk> <unk> <unk> .
+<unk> für die <unk> <unk> ist <unk> als <unk> <unk> .
+<unk> ist China für 20 Jahren <unk> .
+Die <unk> , die unsere <unk> , <unk> <unk> , <unk> <unk> .
+&quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; <unk> &quot; , um <unk> <unk> in China .
+<unk> auf ein <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> und <unk> neue <unk> <unk> , &quot; <unk> mit einem <unk> <unk> der <unk> <unk> , <unk> <unk> <unk> .
+<unk> ist <unk> für <unk> <unk> diese Seite <unk> .
+Sie werden <unk> , diese Menschen zu <unk> <unk> <unk> , und dieses <unk> wird die <unk> <unk> , die <unk> <unk> , <unk> und <unk> in der <unk> <unk> .
 <unk> <unk> ist ein <unk> <unk> und <unk> .
-Er ist auch neue <unk> der <unk> <unk> , die die <unk> <unk> in <unk> <unk> .
-Was er hier <unk> ist , ist ein <unk> <unk> , der er <unk> ist , nicht als &quot; <unk> &quot; .
-Es <unk> heute <unk> <unk> , <unk> <unk> oder <unk> <unk> <unk> und <unk> .
-Es ist nicht so viel <unk> , was <unk> , wie <unk> , wie <unk> , wie <unk> , <unk> und <unk> <unk> .
-&quot; Der <unk> und die <unk> &quot; <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Ein <unk> dieser Menschen wird <unk> .
-Ein <unk> wird <unk> von <unk> oder <unk> <unk> , <unk> <unk> oder <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> ist eine <unk> von <unk> <unk> .
-Es ist ein <unk> <unk> , das <unk> ich nur <unk> , dass die <unk> <unk> <unk> war .
-&quot; Der <unk> und die <unk> &quot; <unk> <unk> in anderen <unk> der <unk> , der <unk> , <unk> <unk> .
-In diesem <unk> haben die <unk> <unk> auf einer <unk> <unk> <unk> <unk> <unk> <unk> .
-Dies ist ein <unk> <unk> , <unk> aus dem <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Wann mit <unk> <unk> in der <unk> und Sie sind <unk> <unk> ?
-<unk> ist <unk> <unk> ?
-<unk> , was der <unk> <unk> , auch <unk> diese <unk> ist .
-&quot; <unk> <unk> , &quot; <unk> , &quot; <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
-&quot; Der <unk> und die <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> sind von <unk> , <unk> und andere bereits <unk> <unk> .
-Die <unk> des <unk> können <unk> oder <unk> <unk> werden , aber <unk> sind in <unk> <unk> <unk> <unk> , <unk> <unk> <unk> .
-<unk> sind die <unk> von <unk> und <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> .
-&quot; <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> .
-Er <unk> die <unk> <unk> in Deutschland .
-Er <unk> &quot; <unk> von <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> .
-Es gibt <unk> , <unk> &quot; <unk> <unk> <unk> <unk> in der <unk> von <unk> , <unk> <unk> <unk> <unk> .
-<unk> <unk> sind über <unk> und <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> eine <unk> <unk> , die er <unk> <unk> wird , und dass keine <unk> <unk> wird .
-&quot; <unk> <unk> ist <unk> , dass es in <unk> einer <unk> der <unk> <unk> , wenn er <unk> <unk> <unk> , <unk> &quot; <unk> <unk> .
-<unk> , es ist <unk> <unk> <unk> <unk> .
-<unk> <unk> über eine <unk> <unk> und über <unk> <unk> <unk> .
-&quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Er <unk> die <unk> , was er &quot; <unk> &quot; <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> in <unk> <unk> gibt es als <unk> <unk> .
-<unk> <unk> <unk> die <unk> , die <unk> <unk> , eine <unk> von <unk> zu <unk> .
-&quot; Der <unk> <unk> können in der <unk> des <unk> <unk> werden , die <unk> und <unk> in die <unk> <unk> , &quot; er <unk> <unk> .
-&quot; <unk> , die wirklich <unk> sind , dass sie <unk> in ihre <unk> <unk> <unk> &quot; <unk> <unk> &quot; .
-In diesem <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , aber <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> die <unk> <unk> <unk> .
-Die besten <unk> über <unk> <unk> habe ich oft oft oft oft <unk> , wie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> ein <unk> <unk> .
-<unk> <unk> <unk> ich in einem <unk> <unk> .
-Ich <unk> nicht .
-Doch wenn er von seiner <unk> <unk> <unk> hat , <unk> <unk> <unk> von seiner <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> von <unk> <unk> wurden <unk> <unk> <unk> .
-Die <unk> zwischen <unk> <unk> wurden <unk> <unk> , weil <unk> <unk> <unk> würde .
-Die <unk> wurde von allen <unk> <unk> , aber ein <unk> <unk> <unk> <unk> <unk> , dass sie <unk> auf eine <unk> <unk> wurden .
-<unk> Kommissarin <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Es gibt keine <unk> <unk> <unk> , wie die <unk> , <unk> und <unk> <unk> , die <unk> <unk> und <unk> ein <unk> <unk> für die <unk> .
-<unk> die <unk> <unk> <unk> der <unk> der <unk> und <unk> .
-<unk> hatte <unk> von <unk> wie <unk> in anderen <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> - <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> war am <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> , die <unk> in den letzten <unk> <unk> , <unk> &quot; <unk> mit dem <unk> , <unk> &quot; <unk> <unk> <unk> mit dem <unk> , der nur &quot; <unk> <unk> " <unk> .
-&quot; Der <unk> , die ich <unk> , dass es in diesem <unk> in diesem <unk> <unk> hat , wurden sie <unk> <unk> , <unk> , <unk> , die auf der <unk> der <unk> <unk> .
-&quot; <unk> " nur Menschen , die sie in <unk> <unk> wurden , wurden <unk> <unk> <unk> des <unk> <unk> .
-Die <unk> war für die <unk> eines <unk> <unk> .
-Auf der <unk> <unk> <unk> die <unk> , <unk> <unk> , aber <unk> <unk> der <unk> in <unk> der <unk> .
-Die <unk> auf <unk> , <unk> von verschiedenen <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> viele Menschen , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Es war <unk> , wenn die Zahl der Menschen in der <unk> <unk> , wenn er bereits gesagt hat .
-<unk> <unk> <unk> <unk> mit <unk> <unk> und <unk> auf <unk> <unk> und <unk> .
-Die <unk> und <unk> <unk> aus dem <unk> <unk> <unk> vielen <unk> .
-Die Gemeinschaft <unk> <unk> in der <unk> <unk> in den <unk> <unk> <unk> <unk> <unk> <unk> ihre <unk> und <unk> .
-<unk> <unk> waren <unk> bis <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-<unk> von <unk> wurden die <unk> auf die <unk> <unk> , wenn die <unk> in den <unk> <unk> wurden .
-<unk> im <unk> waren <unk> <unk> .
-<unk> <unk> , die <unk> der <unk> <unk> , <unk> er war für ihre <unk> .
-Aber viele <unk> sagte , dass sie von <unk> <unk> <unk> wurden , in den <unk> , <unk> und <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Wie die <unk> <unk> durch die <unk> <unk> <unk> <unk> <unk> , <unk> <unk> und <unk> <unk> und <unk> <unk> mit <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-<unk> <unk> <unk> , die auf <unk> <unk> wurden , wurden die <unk> auf dem Internet <unk> .
-Ein <unk> Gruppe von <unk> <unk> auf die <unk> des <unk> .
-<unk> <unk> <unk> eine <unk> , und die <unk> <unk> in den <unk> <unk> .
-<unk> <unk> im <unk> des <unk> <unk> <unk> <unk> haben .
-Und zwei <unk> , zwei <unk> , <unk> <unk> <unk> <unk> .
-<unk> <unk> wurden im <unk> <unk> <unk> .
-<unk> <unk> wurden in der <unk> bis <unk> <unk> Uhr <unk> .
-Die <unk> <unk> <unk> über <unk> Minuten , die <unk> sagte .
-<unk> <unk> <unk> über <unk> Personen in der <unk> .
-<unk> der <unk> für &quot; <unk> <unk> und <unk> <unk> , &quot; er <unk> <unk> .
-Das <unk> <unk> auf der <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> , die <unk> des <unk> <unk> wurde <unk> .
-<unk> <unk> , während <unk> <unk> wurde , war es &quot; <unk> , &quot; <unk> <unk> .
-Ein <unk> Gruppe von <unk> <unk> die <unk> von <unk> <unk> , zwischen <unk> und <unk> in <unk> <unk> , in <unk> <unk> , in <unk> <unk> , in <unk> <unk> , in <unk> <unk> <unk> <unk> <unk> .
-<unk> wurden auf <unk> <unk> <unk> , ein <unk> der <unk> und im <unk> <unk> , ein <unk> <unk> .
-<unk> <unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Bei einer Frage <unk> <unk> sich <unk> mit <unk> <unk> <unk> .
-<unk> Menschen wurden die <unk> <unk> <unk> .
-<unk> der <unk> <unk> <unk> hat <unk> der <unk> .
-<unk> 5 , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> von der <unk> <unk> .
-<unk> , wenn eine <unk> und eine <unk> <unk> .
-<unk>
-Die <unk> <unk> der <unk> <unk> <unk> , die ihre <unk> <unk> <unk> , um den <unk> <unk> zu <unk> , <unk> die <unk> <unk> und <unk> <unk> , weil sie die <unk> <unk> <unk> .
-Die <unk> ist <unk> der letzten <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> , <unk> <unk> und andere <unk> , die die <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> haben <unk> <unk> , dass <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> <unk> er mir , daß nichts in den <unk> <unk> <unk> , die <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> sie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> wird <unk> <unk> und die Stadt <unk> von <unk> als <unk> , <unk> , <unk> und <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> , ein <unk> für die Stadt <unk> , sagte die <unk> <unk> nicht die <unk> und daher nicht auf seine <unk> <unk> .
-Ein <unk> der <unk> von <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Es <unk> <unk> , dass es keine <unk> <unk> haben und einige <unk> in den <unk> Osten <unk> , <unk> , <unk> , <unk> , <unk> und <unk> wurden in <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> ist auch die neue <unk> der <unk> , die die <unk> in <unk> <unk> .
+<unk> hat es hier ein <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+Das <unk> <unk> <unk> , <unk> <unk> oder <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Es ist nicht mehr <unk> , was <unk> , was er &quot; <unk> <unk> ist , als <unk> <unk> , was es &quot; <unk> ist .
+&quot; Die <unk> und der <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> <unk> und <unk> <unk> , <unk> , <unk> und <unk> .
+<unk> dieser <unk> werden <unk> .
+Ein <unk> wird <unk> von <unk> oder <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> ist ein <unk> von <unk> <unk> <unk> .
+Es ist ein <unk> <unk> , die <unk> <unk> , die ich nur die <unk> <unk> <unk> <unk> .
+&quot; <unk> und die <unk> &quot; <unk> <unk> , die <unk> , <unk> , <unk> , <unk> .
+<unk> in diesem <unk> haben <unk> auf <unk> <unk> in der <unk> <unk> <unk> .
+Das ist eine <unk> <unk> , <unk> von der <unk> .
+<unk> <unk> diese Menschen , <unk> <unk> <unk> , <unk> <unk> , dass <unk> <unk> <unk> <unk> .
+Wann sind <unk> in der <unk> , und Sie sind in <unk> mit Ihrem <unk> oder <unk> <unk> ?
+<unk> ist die <unk> ?
+<unk> keine <unk> , was die <unk> , <unk> <unk> , <unk> diese <unk> ist .
+&quot; <unk> <unk> &quot; <unk> <unk> &quot; hat mit <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
+Die <unk> und die <unk> &quot; <unk> <unk> und der <unk> &quot; <unk> &quot; <unk> <unk> und <unk> <unk> , eine <unk> <unk> <unk> .
+<unk> <unk> sind <unk> von <unk> , <unk> und andere <unk> <unk> .
+Die <unk> <unk> können <unk> oder <unk> <unk> , aber <unk> werden in <unk> <unk> <unk> <unk> <unk> .
+<unk> sind <unk> und <unk> <unk> .
+Im <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+Er <unk> auf die <unk> <unk> in Deutschland .
+<unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> sind er <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> sind <unk> und <unk> .
+<unk> <unk> seine eigenen <unk> <unk> und <unk> über <unk> &quot; <unk> &quot; <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> eine <unk> <unk> <unk> , <unk> er <unk> <unk> <unk> , und die <unk> <unk> oder <unk> .
+&quot; <unk> eine <unk> <unk> , um die <unk> der <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> .
+<unk> ist es <unk> und <unk> <unk> <unk> .
+<unk> sind ein <unk> <unk> <unk> , und über neue <unk> von <unk> .
+&quot; <unk> ist ein <unk> <unk> , &quot; <unk> <unk> , &quot; ein <unk> zwischen <unk> .
+Er <unk> die <unk> , was er <unk> &quot; <unk> <unk> &quot; eine neue <unk> in der <unk> der <unk> und <unk> <unk> .
+<unk> <unk> in <unk> <unk> <unk> <unk> ist als <unk> <unk> .
+<unk> <unk> <unk> die <unk> , die <unk> <unk> , eine <unk> <unk> von <unk> zu <unk> .
+&quot; Die <unk> <unk> dieses <unk> können in den <unk> <unk> <unk> werden , die <unk> <unk> und <unk> in den <unk> <unk> , <unk> <unk> <unk> .
+Die <unk> wirklich <unk> ist es <unk> , dass es in <unk> <unk> <unk> <unk> werden .
+In diesem <unk> wird die <unk> von <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Im <unk> <unk> <unk> er die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
 <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> <unk> , dass <unk> <unk> durch die <unk> der <unk> <unk> <unk> .
-Die <unk> <unk> die <unk> &quot; <unk> &quot; , <unk> &quot; <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-&quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> , &quot; und <unk> <unk> .
-<unk> über <unk> <unk> werden .
-Es <unk> <unk> wie <unk> und <unk> auf <unk> <unk> <unk> .
-Alle <unk> war für <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> und <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Der <unk> ist darin , die <unk> Bevölkerung von <unk> als <unk> <unk> zu <unk> , um ihre Land <unk> , &quot; <unk> sagte .
-&quot; Es ist eine <unk> von <unk> für ihre <unk> <unk> .
-Die <unk> kann <unk> <unk> , aber nichts <unk> ist nichts <unk> .
-Das <unk> , <unk> , <unk> , <unk> von <unk> <unk> mit <unk> <unk> und die <unk> <unk> über den <unk> eines <unk> , die <unk> der <unk> Rolle in <unk> <unk> .
-In Juni <unk> und <unk> <unk> die <unk> <unk> <unk> <unk> in <unk> .
-Der <unk> wurde im <unk> von einem <unk> <unk> <unk> und es <unk> <unk> für eine <unk> .
-Aber auf der gleichen Tag zu <unk> , ist die <unk> auch für eine <unk> , die <unk> in <unk> <unk> haben .
-<unk> die <unk> <unk> in einem <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> wurde <unk> von <unk> <unk> .
-Die <unk> <unk> in <unk> und <unk> wurde <unk> <unk> <unk> .
-Die <unk> <unk> <unk> <unk> <unk> .
-<unk> die <unk> <unk> werden .
-Die <unk> &quot; <unk> der <unk> für ihre <unk> <unk> und <unk> <unk> in <unk> und &quot; <unk> <unk> <unk> <unk> und <unk> der Vereinigten Staaten <unk> <unk> und <unk> der Vereinigten Staaten <unk> <unk> <unk> .
-Die Entschließung &quot; <unk> die nationalen <unk> der Vereinigten Staaten in einer <unk> und <unk> <unk> in <unk> .
-<unk> Sie den <unk> <unk> der neuen <unk> der <unk> <unk> oder wird der <unk> <unk> <unk> ?
-Die <unk> wurde <unk> von <unk> <unk> <unk> <unk> <unk> die <unk> <unk> .
-Die <unk> <unk> <unk> <unk> , dass er nicht die <unk> Version des neuen <unk> ist .
-<unk> die <unk> , die <unk> ist der Abstimmung über eine <unk> <unk> <unk> , ein <unk> <unk> <unk> <unk> <unk> und einige <unk> <unk> .
-Die <unk> , <unk> von <unk> <unk> <unk> <unk> wird die erste <unk> auf dem <unk> oder <unk> anderen <unk> <unk> .
-<unk> <unk> haben sich in <unk> <unk> <unk> , und nicht für <unk> <unk> .
-<unk> ist nur eine der <unk> von <unk> <unk> , die eine <unk> <unk> von <unk> .
-<unk> sind die gleichen <unk> - die gleichen <unk> in sowohl der <unk> und andere sind <unk> <unk> <unk> .
-<unk> gibt es um ein <unk> der <unk> <unk> in den <unk> <unk> , und eine <unk> , die <unk> <unk> <unk> .
-Die <unk> dieser <unk> sind <unk> <unk> , aber sie werden ihre <unk> <unk> - <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> , die in <unk> <unk> , <unk> <unk> , die in <unk> <unk> und <unk> <unk> .
-In <unk> <unk> <unk> die <unk> in <unk> einer <unk> <unk> .
-<unk> Sie die <unk> Mitglieder der <unk> der <unk> <unk> <unk> , während <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> .
-Ein <unk> <unk> <unk> <unk> ist ein <unk> <unk> , als eine <unk> <unk> .
-<unk> <unk> wollen auch die <unk> der <unk> <unk> , wenn sie von der <unk> der <unk> <unk> .
-Wie die Mitglieder von <unk> <unk> sind , <unk> sie nicht an <unk> <unk> <unk> als in <unk> Jahren <unk> .
-Im <unk> <unk> <unk> <unk> die <unk> <unk> , und sie <unk> in der <unk> .
-Die <unk> <unk> in <unk> , die Mitglieder des <unk> <unk> , als die <unk> von <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> sie nicht mehr <unk> als sie <unk> .
-Die letzte <unk> zur <unk> - die <unk> - das <unk> <unk> , aber es gibt eigentlich <unk> von <unk> in <unk> .
-&quot; <unk> <unk> , aber nicht <unk> , &quot; <unk> in erster Linie <unk> .
-<unk> <unk> nach einem <unk> in <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> auf <unk> <unk> <unk> <unk> 20 , <unk> mit <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-Die <unk> <unk> ihr <unk> aus dem <unk> <unk> <unk> , die <unk> <unk> und die <unk> der <unk> <unk> ihrer <unk> <unk> .
-Vor einigen Jahren <unk> sie eine <unk> an die <unk> <unk> , um ihre <unk> <unk> zu <unk> .
-In ihrem ersten <unk> <unk> die <unk> <unk> , dass <unk> <unk> und <unk> <unk> , <unk> , <unk> und <unk> <unk> .
-<unk> von <unk> , wie sie <unk> <unk> , <unk> &quot; <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> .
-Die <unk> <unk> <unk> seit der <unk> der <unk> <unk> .
-In der <unk> des ersten <unk> ist <unk> <unk> , sie ist in ihrer <unk> <unk> , die <unk> und ein <unk> <unk> in ihrem <unk> <unk> .
-<unk> ist <unk> nur einer <unk> oder zwei <unk> .
-<unk> <unk> , <unk> <unk> ist <unk> in einer <unk> als <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> eine <unk> <unk> .
+<unk> ist die <unk> <unk> , <unk> ich in einer <unk> <unk> .
+Ich <unk> nicht .
+Doch es ist der <unk> , wie er <unk> hat , die <unk> <unk> , die <unk> <unk> von <unk> , <unk> und <unk> mit einem <unk> .
+<unk> ein <unk> <unk> , ein <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> zwischen <unk> in <unk> waren <unk> , weil <unk> <unk> <unk> <unk> werden .
+Die <unk> war <unk> <unk> von allen <unk> , mit anderen <unk> , dass sie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> Herr Kommissar , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Es gibt keine <unk> von <unk> in den <unk> , wie die <unk> <unk> , die <unk> <unk> und <unk> <unk> <unk> , die <unk> <unk> und <unk> zu <unk> .
+Und so so <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> und <unk> .
+<unk> <unk> <unk> , wie <unk> in anderen <unk> <unk> .
+Ein <unk> <unk> war <unk> <unk> , mit einem <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> - <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> wurde <unk> <unk> , um die <unk> <unk> des <unk> <unk> .
+Die <unk> der <unk> in den <unk> <unk> , &quot; <unk> <unk> mit dem <unk> , der <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+&quot; Die <unk> <unk> , die ich in diesem <unk> haben , haben sie nicht <unk> , dass sie sich nicht in <unk> <unk> <unk> , &quot; <unk> <unk> <unk> .
+&quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> <unk> .
+<unk> <unk> war ein <unk> <unk> der <unk> .
+<unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+Die <unk> <unk> , <unk> von <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> war es <unk> , wenn die <unk> von Menschen in der <unk> &quot; <unk> <unk> &quot; <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> und <unk> <unk> <unk> von der <unk> <unk> <unk> <unk> .
+Wie die <unk> <unk> <unk> in den <unk> in ihrer <unk> <unk> , <unk> die <unk> ihre <unk> und <unk> .
+<unk> <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> der <unk> <unk> hat <unk> auf die <unk> , <unk> <unk> <unk> <unk> in der <unk> .
+<unk> in der <unk> wurde <unk> <unk> .
+<unk> <unk> <unk> , die <unk> der <unk> <unk> <unk> , <unk> er sich für ihre <unk> .
+Aber viele <unk> <unk> , dass sie von <unk> <unk> <unk> hat , <unk> die <unk> in der <unk> , und die <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Wie die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> auf .
+Ein <unk> <unk> <unk> <unk> in der <unk> des <unk> .
+<unk> ist ein <unk> , und die <unk> <unk> in <unk> <unk> .
+<unk> <unk> <unk> , <unk> <unk> , <unk> <unk> .
+Und zwei <unk> zu <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> wurden in <unk> die <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> war <unk> <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> <unk> <unk> <unk> , <unk> <unk> in der <unk> .
+<unk> hat die <unk> <unk> , <unk> <unk> und <unk> <unk> , <unk> er <unk> .
+Die <unk> <unk> <unk> wurde <unk> <unk> , die <unk> <unk> , die <unk> <unk> in der <unk> .
+<unk> <unk> <unk> , die <unk> der <unk> <unk> , war auch <unk> .
+<unk> <unk> , während der <unk> <unk> ist nicht <unk> <unk> , &quot; <unk> <unk> <unk> <unk> .
+Ein zweiten <unk> der <unk> <unk> der <unk> <unk> der <unk> <unk> <unk> , zwischen <unk> und <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Ein <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> der <unk> der <unk> <unk> <unk> <unk> der <unk> .
+<unk> &#124; <unk> <unk> , <unk> der <unk> <unk> , eine <unk> <unk> <unk> , <unk> und andere <unk> <unk> der <unk> <unk> .
+<unk> ist ein <unk> , ein <unk> <unk> von der <unk> .
+In der <unk> ist eine <unk> <unk> .
+<unk> <unk> " <unk> " <unk>
+Die <unk> <unk> <unk> der <unk> der <unk> <unk> , die ihre <unk> <unk> <unk> , die <unk> <unk> , die <unk> <unk> und <unk> <unk> <unk> , weil die <unk> <unk> <unk> <unk> <unk> .
+Die <unk> ist der <unk> <unk> , die <unk> , <unk> <unk> , <unk> <unk> , in den <unk> zu <unk> .
+<unk> <unk> <unk> <unk> <unk> , <unk> <unk> und andere <unk> , die die <unk> des <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> haben <unk> , dass <unk> <unk> .
+Im <unk> der <unk> <unk> <unk> <unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> die <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> , <unk> ich , dass es in der <unk> <unk> <unk> , die <unk> <unk> <unk> werden .
+<unk> Rat <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> werden <unk> <unk> und die <unk> des <unk> als <unk> <unk> , und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , eine <unk> für die <unk> der <unk> <unk> , <unk> die <unk> <unk> , nicht <unk> <unk> <unk> .
+<unk> Sie eine <unk> der <unk> <unk> , die <unk> <unk> <unk> , hat die <unk> in <unk> <unk> <unk> <unk> , weil sie sich <unk> <unk> <unk> .
+Es gibt <unk> <unk> , dass es keine <unk> <unk> , <unk> <unk> und <unk> <unk> in <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> die <unk> von <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> sich <unk> , dass die <unk> in einer <unk> <unk> der <unk> <unk> <unk> werden .
+Die <unk> <unk> die <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> <unk> &quot; <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> über <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk>
+Es ist <unk> <unk> , <unk> und <unk> auf <unk> <unk> zu <unk> .
+<unk> <unk> war es für die <unk> , <unk> <unk> <unk> <unk> zu <unk> und <unk> zu <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+&quot; <unk> ist <unk> <unk> , die <unk> Menschen , die <unk> , die <unk> , die <unk> , die <unk> , <unk> , <unk> <unk> .
+<unk> ist ein <unk> von <unk> für ihre <unk> <unk> .
+Die <unk> sind <unk> <unk> , aber auch die Aussprache Aussprache <unk> hat .
+Diese <unk> , <unk> von <unk> <unk> mit <unk> und die <unk> <unk> über die <unk> der <unk> in <unk> .
+Im Juni <unk> und <unk> <unk> ein <unk> <unk> die <unk> <unk> in <unk> .
+Die <unk> war im <unk> der <unk> <unk> <unk> , und es ist nicht für eine Abstimmung in der <unk> .
+Aber die <unk> Tag , dass die <unk> auch die <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Dies ist die <unk> <unk> in einer <unk> <unk> - mit <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> wurde <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> werden auf <unk> <unk> .
+Die <unk> <unk> <unk> &quot; <unk> die Menschen für ihre <unk> <unk> und <unk> <unk> in <unk> , die <unk> in <unk> <unk> und <unk> <unk> <unk> .
+Die Entschließung und <unk> &quot; <unk> die nationalen <unk> die nationalen <unk> in einer <unk> und <unk> .
+<unk> die neue <unk> <unk> die <unk> der <unk> <unk> <unk> <unk> oder werden die <unk> <unk> <unk> <unk> ?
+Die <unk> wurde von <unk> <unk> <unk> <unk> <unk> <unk> die <unk> <unk> .
+<unk> der <unk> <unk> <unk> <unk> , dass er die <unk> Version des neuen <unk> <unk> .
+<unk> der <unk> , die <unk> <unk> ist , ist dieser Debatte auf eine <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> .
+Die <unk> , die von <unk> <unk> <unk> <unk> <unk> wird , wird erste ersten <unk> in der <unk> oder andere <unk> <unk> .
+<unk> <unk> haben sich <unk> <unk> , die <unk> <unk> , aber nicht für <unk> von <unk> .
+<unk> ist ein <unk> von <unk> <unk> , die in diesem <unk> <unk> , <unk> <unk> .
+<unk> sind <unk> - die <unk> <unk> in seiner <unk> und <unk> .
+Es gibt eine <unk> <unk> der <unk> <unk> in der <unk> <unk> und anderen <unk> , dass die <unk> &quot; <unk> &quot; <unk> .
+<unk> dieser <unk> sind <unk> <unk> , aber sie <unk> ihre <unk> - besonders <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> <unk> <unk> , die in <unk> <unk> , eine <unk> <unk> , um die <unk> <unk> <unk> .
+Im <unk> <unk> <unk> <unk> <unk> <unk> die <unk> <unk> ein <unk> <unk> .
+<unk> Sie die <unk> , <unk> und <unk> , die <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Ein <unk> <unk> <unk> <unk> <unk> ist ein <unk> <unk> , als <unk> <unk> .
+<unk> <unk> auch für die <unk> der <unk> <unk> , wenn sie durch die <unk> des <unk> <unk> .
+Wir <unk> als <unk> <unk> , <unk> sie nicht auf <unk> <unk> <unk> als in <unk> Jahren <unk> .
+Im <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> oder <unk> in der <unk> .
+Die <unk> <unk> in <unk> auf die <unk> der <unk> , wenn sie <unk> als <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Aber sie <unk> nicht mehr <unk> als sie <unk> .
+Die letzte <unk> , die <unk> - die <unk> - war der <unk> - war es <unk> , der <unk> in <unk> .
+&quot; <unk> &quot; <unk> &quot; , nicht <unk> <unk> , <unk> <unk> <unk> <unk> in ersten <unk> seit <unk> <unk> .
+<unk> <unk> ich ein <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> über <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> sich auf die <unk> <unk> von <unk> , die <unk> <unk> , dass die <unk> <unk> und die <unk> der <unk> <unk> , <unk> von der <unk> <unk> .
+Ich <unk> eine <unk> <unk> , um die <unk> <unk> zu <unk> .
+Das <unk> <unk> seit <unk> seit <unk> <unk> , die <unk> <unk> und <unk> <unk> , <unk> , <unk> und <unk> .
+<unk> von <unk> , wie sie <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+Die <unk> mit <unk> und <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> die <unk> der <unk> <unk> .
+Im ersten <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist <unk> nur von einer <unk> <unk> als <unk> <unk> .
+<unk> <unk> ist das <unk> in einer <unk> als <unk> <unk> <unk> , wie <unk> <unk> <unk> .
 <unk> der <unk> .
 <unk> der <unk> .
-Und dann <unk> sie das <unk> &quot; <unk> .
-<unk> Tage , <unk> <unk> eine <unk> <unk> - &quot; <unk> , &quot; <unk> , &quot; <unk> , <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Im <unk> mit <unk> , <unk> , <unk> , die durch zwei Stunden <unk> <unk> , sagte sie keine <unk> des <unk> .
-<unk> <unk> sagte , dass er <unk> ein <unk> <unk> <unk> war , wenn sie <unk> <unk> <unk> , <unk> , wenn sie <unk> <unk> in der <unk> <unk> wurde .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; <unk> , <unk> , <unk> .
-<unk> im <unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; <unk> <unk> ich Ihnen <unk> , <unk> Sie nicht <unk> , &quot; <unk> &quot; <unk> <unk> .
-Sie <unk> nur <unk> .
-Und Sie haben sich durch diese <unk> und Sie <unk> , wie Sie <unk> und <unk> <unk> werden .
-<unk> <unk> <unk> mehr als <unk> .
-Der <unk> war ein <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> über <unk> , <unk> und <unk> .
-Auf <unk> , <unk> , <unk> , <unk> und <unk> in <unk> <unk> .
-Die <unk> <unk> auf <unk> und <unk> .
-&quot; Die <unk> und Frauen waren <unk> als <unk> , &quot; sagte <unk> <unk> , der die <unk> <unk> <unk> .
-Ein <unk> <unk> <unk> in der <unk> , auch von der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Sie sind <unk> wie einige <unk> von <unk> <unk> , &quot; die <unk> <unk> in einem <unk> .
-Ich <unk> die <unk> <unk> <unk> .
-Ich weiß es .
-Aber es ist nicht <unk> .
-Die <unk> <unk> <unk> <unk> die <unk> <unk> , die zwischen <unk> und <unk> <unk> <unk> <unk> .
-Die <unk> sind mit <unk> für <unk> .
-<unk> ist die <unk> mit einer Art , <unk> und <unk> .
-Die <unk> <unk> als <unk> <unk> , die <unk> in <unk> <unk> .
-&quot; Wir <unk> nicht auf alle , &quot; <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-&quot; Aber es scheint , dass einige in der Rolle <unk> , dass einige uns <unk> können , uns zu <unk> .
-Die <unk> ist ein <unk> für <unk> , <unk> <unk> oder <unk> mit den öffentlichen <unk> .
-Sie <unk> auch , dass die <unk> <unk> in der <unk> Jahren <unk> <unk> wurde .
-In <unk> Hinsicht <unk> die <unk> über <unk> <unk> und <unk> die <unk> <unk> .
-Nach seiner beiden <unk> <unk> die <unk> <unk> von <unk> mit dem <unk> , <unk> <unk> <unk> <unk> , dass die <unk> <unk> ihre <unk> <unk> würde .
-<unk> wäre die <unk> mit einem <unk> <unk> , weil sie <unk> <unk> und <unk> <unk> <unk> .
-<unk> wäre es <unk> , ob ein &quot; <unk> &quot; , <unk> &quot; , <unk> &quot; <unk> <unk> , der in <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Während seiner <unk> <unk> er sagte , dass einige <unk> <unk> <unk> <unk> , ob er <unk> <unk> <unk> würde , ob er <unk> <unk> , ob er unter dem <unk> des <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Wenn Sie sich über Ihre <unk> <unk> , müssen Sie die <unk> <unk> , &quot; <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> , der <unk> <unk> , aus der <unk> <unk> .
-<unk> <unk> sind <unk> für <unk> von <unk> , die mit dem <unk> und <unk> <unk> <unk> <unk> <unk> <unk> von der <unk> und <unk> <unk> <unk> .
-&quot; Wir , als eine <unk> , nicht mehr als <unk> <unk> in <unk> , die die <unk> <unk> <unk> <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> ,
-<unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-Die <unk> sind <unk> für die Anzahl der <unk> , <unk> sie <unk> <unk> oder die <unk> ihres <unk> <unk> haben .
-<unk>
-Diese Woche <unk> eine <unk> <unk> , ob <unk> Frauen und <unk> haben , die <unk> für <unk> <unk> auf <unk> <unk> .
-Wenn nicht , <unk> der <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Es war <unk> 2008 , und sie hat noch <unk> <unk> , um <unk> <unk> zu <unk> , <unk> , <unk> mit <unk> , <unk> , <unk> mit einem <unk> <unk> <unk> .
-Er <unk> <unk> , wenn er <unk> in ihren <unk> <unk> , <unk> .
-&quot; Ein <unk> <unk> <unk> <unk> , &quot; <unk> <unk> <unk> .
-Aber die <unk> <unk> <unk> ihre <unk> .
-Ich <unk> , dass er nicht <unk> .
-&quot; Er von <unk> , &quot; sie <unk> .
-&quot; Ich habe <unk> <unk> .
-<unk> <unk> von <unk> <unk> , das <unk> <unk> aus ihrem <unk> , <unk> sie sich <unk> .
-Diese Woche <unk> auf <unk> <unk> , <unk> und <unk> andere <unk> und <unk> <unk> <unk> <unk> werden .
-Die <unk> <unk> , dass die <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> im <unk> von <unk> <unk> , ein <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> oder drei <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> ist nach <unk> <unk> .
-&quot; Der <unk> ist ein <unk> <unk> , &quot; sie <unk> .
-&quot; <unk> <unk> sind die <unk> , die in <unk> <unk> <unk> , <unk> <unk> <unk> .
-Die <unk> hat <unk> von <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> , als das <unk> in diesem Fall <unk> - <unk> alle alle <unk> in diesem Fall , - <unk> sie <unk> <unk> werden , wenn die Druck auf <unk> <unk> werden müssen .
-Die <unk> <unk> für die <unk> , <unk> von <unk> <unk> <unk> , hat <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> , <unk> die <unk> der <unk> - <unk> , dass die <unk> nicht durch <unk> oder <unk> <unk> <unk> werden kann .
-<unk> ein <unk> <unk> , als die <unk> <unk> <unk> ist , <unk> die <unk> Regierung nicht für <unk> <unk> .
-&quot; Die <unk> sind <unk> , <unk> &quot; <unk> <unk> , <unk> &quot; <unk> .
-Der <unk> von <unk> <unk> für dieses <unk> .
-<unk> haben sich seit &quot; <unk> <unk> .
-<unk> Frauen sind noch immer <unk> <unk> von <unk> in <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> in <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-Die <unk> zwischen diesen beiden <unk> , zwei <unk> , zwei <unk> , zwei <unk> von ihnen während <unk> <unk> .
-<unk> <unk> , <unk> <unk> , <unk> <unk> .
-<unk> <unk> nicht in ihrer <unk> drei anderen <unk> .
-Bei <unk> <unk> <unk> <unk> die <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> , die <unk> <unk> von <unk> ist <unk> ein <unk> gegen den <unk> <unk> , dass die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , um sie zu <unk> , die <unk> von <unk> , <unk> und <unk> <unk> zu <unk> .
-<unk> <unk> eine <unk> in den <unk> <unk> , <unk> sie mit <unk> in den <unk> <unk> <unk> , <unk> sie mit <unk> im Bereich der <unk> <unk> <unk> , die Leute in der <unk> <unk> .
-<unk> <unk> haben in <unk> von einer <unk> <unk> <unk> und <unk> , <unk> eine <unk> von <unk> .
+<unk> <unk> &quot; <unk> &quot; <unk> .
+<unk> Tage <unk> <unk> , <unk> <unk> <unk> <unk> <unk> &quot; <unk> <unk> &quot; <unk> <unk> <unk> &quot; <unk> <unk> <unk> &quot; <unk> <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> , dass <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+In der <unk> mit <unk> , <unk> , <unk> , <unk> , <unk> , <unk> hat sie keine <unk> <unk> , der <unk> <unk> <unk> .
+<unk> <unk> <unk> , dass er sich <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
 <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Das <unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Der Bericht , <unk> auch <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> in <unk> <unk> ihre <unk> als nur die ersten von <unk> <unk> .
-<unk> <unk> sie die <unk> <unk> <unk> weniger als ein <unk> nach dem <unk> .
-Das <unk> , sie wurde <unk> , sie war <unk> , die <unk> zu <unk> , die <unk> <unk> zu <unk> , <unk> , <unk> und <unk> .
-<unk> <unk> ist ein <unk> <unk> und ihre <unk> <unk> - von einem <unk> <unk> - wurde <unk> <unk> .
-<unk> <unk> Monate , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-im Namen der <unk> <unk> , die <unk> <unk> .
-&quot; Ich <unk> die Tag , wenn die <unk> <unk> kann , kann &quot; <unk> <unk> .
-&quot; Ich bin <unk> in <unk> - ich bin in den <unk> - <unk> <unk> , <unk> ich mich aus dem <unk> <unk> .
-&quot; , <unk> ich mich in den <unk> <unk> , und wenn ich <unk> <unk> , <unk> ich <unk> <unk> , <unk> &quot; <unk> <unk> , nicht <unk> .
-<unk> <unk> , <unk> ein <unk> <unk> , der mit einem <unk> <unk> <unk> , <unk> sie ihre <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Als ob die <unk> von <unk> und ihre <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Allerdings <unk> er &quot; <unk> , &quot; <unk> meine <unk> <unk> , <unk> <unk> <unk> .
-<unk> <unk> zwischen <unk> und <unk> ist dieses <unk> , dass es seit <unk> <unk> wurde .
-Ich <unk> ein <unk> der <unk> <unk> .
-<unk> ist die <unk> der gleichen <unk> und <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> , &quot; <unk> Die <unk> sind gegen sie <unk> ...
-<unk> werden wir <unk> , wenn die Menschen <unk> sind .
-Wenn die <unk> nicht <unk> , <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Wir werden das <unk> auf dieser Frage <unk> , um <unk> , &quot; <unk> <unk> .
-<unk> bis zu <unk> <unk> , wenn wir <unk> , <unk> <unk> .
+<unk> &quot; <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> , <unk> , <unk> .
+<unk> in seiner <unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> , <unk> ich <unk> <unk> .
+&quot; <unk> möchte ich &quot; <unk> , <unk> , <unk> , <unk> <unk> <unk> .
+<unk> <unk> <unk> .
+Und Sie werden mit dieser <unk> <unk> und Ihnen <unk> <unk> , um <unk> zu <unk> .
+<unk> <unk> <unk> .
+<unk> <unk> war ein <unk> <unk> <unk> , die <unk> <unk> <unk> für <unk> <unk> in <unk> <unk> .
+<unk> <unk> <unk> ein <unk> über <unk> , <unk> und <unk> .
+Am <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> in <unk> auf die <unk> .
+Die <unk> <unk> <unk> auf die <unk> und <unk> .
+Die <unk> und Frauen <unk> <unk> , <unk> , <unk> , <unk> , <unk> , die <unk> <unk> .
+Ein <unk> <unk> <unk> in der <unk> , <unk> und <unk> von den <unk> <unk> <unk> <unk> , <unk> die <unk> &quot; <unk> &quot; <unk> .
+&quot; Sie <unk> <unk> , wie einige <unk> von <unk> <unk> , &quot; die <unk> in einer <unk> .
+Ich <unk> die <unk> <unk> gut .
+Ich weiß , <unk> <unk> .
+Doch es <unk> nicht .
+Die <unk> <unk> <unk> <unk> die <unk> , dass die <unk> und eine <unk> <unk> , <unk> <unk> <unk> <unk> .
+Die <unk> sind mit <unk> für ihre <unk> .
+Aber die <unk> <unk> mit einem <unk> , <unk> <unk> .
+Die <unk> <unk> als <unk> <unk> , wenn sie in <unk> <unk> <unk> .
+<unk> &quot; <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> ist es , dass einige <unk> <unk> <unk> werden kann , uns in der Rolle der <unk> <unk> .
+Die <unk> ist ein <unk> für die <unk> <unk> , die nicht zu <unk> <unk> oder <unk> mit dem <unk> <unk> .
+Sie <unk> auch , dass die <unk> , die <unk> <unk> in den <unk> Jahren <unk> <unk> wurde .
+Als <unk> der <unk> über <unk> <unk> , <unk> und <unk> <unk> .
+<unk> seine <unk> <unk> <unk> von <unk> <unk> mit dem <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> wäre es mit einem <unk> <unk> , weil sie <unk> <unk> und <unk> <unk> <unk> .
+<unk> wäre , ob es eine <unk> <unk> , <unk> <unk> , <unk> <unk> die <unk> , <unk> <unk> , die <unk> in <unk> und <unk> zu <unk> .
+Im <unk> <unk> <unk> er <unk> <unk> , dass er einige <unk> <unk> <unk> , ob er <unk> <unk> , ob er <unk> werden , um <unk> <unk> zu <unk> .
+&quot; Wenn Sie über Ihre <unk> über Ihre <unk> <unk> , müssen Sie die <unk> <unk> , &quot; <unk> <unk> <unk> <unk> .
+Die <unk> der <unk> <unk> , in einem <unk> <unk> , der <unk> <unk> <unk> .
+Die <unk> sind <unk> , die von einem Land <unk> <unk> , <unk> <unk> , <unk> <unk> und <unk> <unk> <unk> .
+<unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> in <unk> .
+<unk> , <unk> , <unk> und <unk> <unk> auf der <unk> eines <unk> .
+<unk> sind <unk> für die Anzahl der <unk> <unk> , <unk> sie <unk> oder die <unk> ihrer <unk> .
 <unk>
-<unk> wurde <unk> der neuen <unk> in Europa , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Im <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> Sie diesen <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Aber wie soll sie ?
-- <unk> Sie auf <unk> .
-&quot; Wir <unk> , dass der <unk> nicht <unk> , dass der <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> der persönlichen Daten ist so <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Wenn die <unk> durch <unk> , <unk> und seine Kolleginnen und Kollegen !
-&quot; Es ist eine neue Art , die <unk> <unk> <unk> .
-<unk> der Ergebnisse <unk> nicht alle , dass <unk> <unk> <unk> <unk> , <unk> und <unk> <unk> .
-Aber in <unk> einer <unk> , die <unk> , die <unk> , die in <unk> <unk> <unk> , sind mehr <unk> und weniger <unk> , <unk> , <unk> , <unk> , <unk> , die nur <unk> <unk> .
-<unk> <unk> ist nur ein Beispiel , wie <unk> ist <unk> eine <unk> neue <unk> in der <unk> .
-<unk> <unk> , <unk> <unk> und politische <unk> sind von <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Für einige <unk> , <unk> die <unk> , die Sie mit einem <unk> auf der <unk> <unk> ist .
-&quot; <unk> , wenn Sie bei der <unk> der <unk> <unk> <unk> , wäre es sehr <unk> .
-&quot; <unk> <unk> haben sich durch die <unk> und sie nicht <unk> , &quot; <unk> <unk> <unk> <unk> .
-&quot; <unk> <unk> <unk> alle , die Sie direkt <unk> .
-<unk> wäre es <unk> , dass die <unk> eines <unk> <unk> und <unk> Probleme zu <unk> .
-Ein <unk> in den <unk> von <unk> <unk> <unk> der <unk> , <unk> und <unk> , die <unk> <unk> , die ihre <unk> <unk> <unk> , <unk> , <unk> , <unk> , die <unk> <unk> <unk> , <unk> , <unk> , die <unk> <unk> <unk> .
-<unk> , wenn die <unk> <unk> , wie <unk> <unk> , könnte die <unk> und <unk> zur <unk> der <unk> <unk> .
-&quot; Sie können nicht <unk> , wenn Sie nicht <unk> können , dann können Sie es <unk> , &quot; <unk> und <unk> <unk> der <unk> für <unk> , <unk> und <unk> .
-&quot; Wir <unk> uns eine <unk> <unk> , um <unk> zu <unk> , die nicht <unk> würde .
-<unk> ist ein <unk> in die <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> der <unk> ist die <unk> <unk> , ob sie oder nicht die <unk> für <unk> <unk> mit einem <unk> <unk> <unk> <unk> .
-Aber was über wenn die <unk> der <unk> <unk> werden , eine <unk> <unk> werden ?
-<unk> haben die <unk> <unk> über die <unk> <unk> <unk> , wie sie ihre <unk> <unk> .
-&quot; Ich denke nicht , dass ein <unk> <unk> <unk> über die Tatsache <unk> , dass ein <unk> <unk> <unk> <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> sie sich als <unk> <unk> , war es nur zwischen ihnen und ihre <unk> .
-<unk> gibt es der Frage der <unk> .
-<unk> <unk> , gibt es keine <unk> , dass ein <unk> Thema <unk> wird .
-<unk> <unk> , wie viel der <unk> <unk> und <unk> <unk> <unk> <unk> .
-&quot; <unk> &quot; <unk> Sie zwei <unk> , &quot; <unk> <unk> <unk> .
-<unk> ist ein <unk> und eine <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Es gibt keine <unk> <unk> für <unk> in den <unk> <unk> und <unk> &quot; , &quot; er <unk> <unk> .
-&quot; <unk> <unk> ist <unk> , um die <unk> - und eine <unk> von <unk> <unk> <unk> <unk> .
-&quot; <unk> und <unk> <unk> <unk>
-<unk> <unk> , die <unk> , die <unk> , die <unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> .
-&quot; Ich bin ein <unk> <unk> in der <unk> <unk> und <unk> <unk> <unk> , &quot; er sagte , bevor er <unk> mit <unk> Menschen <unk> .
-&quot; Ich <unk> mich auf die <unk> , weil Sie Ihre <unk> von <unk> <unk> <unk> und weil es <unk> <unk> &quot; .
-&quot; Ich <unk> die <unk> , aber ich bin nicht <unk> .
-<unk> <unk>
-<unk> <unk> er zu <unk> , die eine <unk> <unk> mit ihm <unk> , der mit ihm <unk> des <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> für <unk> <unk> .
-<unk> 30 und <unk> &quot; <unk> <unk> die <unk> .
-<unk> <unk> <unk> sich auf die <unk> <unk> , die er <unk> wird , <unk> unter <unk> und <unk> .
-Alle <unk> mit der <unk> <unk> <unk> <unk> .
-&quot; Ich <unk> er <unk> und <unk> , &quot; ich <unk> <unk> und <unk> &quot; <unk> <unk> <unk> <unk> .
-&quot; Es war <unk> , aber für mich <unk> auf einem wenig <unk> , die nach <unk> und die <unk> <unk> .
-<unk> in einer <unk> <unk> und <unk> <unk> , <unk> <unk> <unk> und <unk> <unk> und <unk> in der <unk> als er <unk> und <unk> .
-<unk> <unk> der <unk> von <unk> &quot; Teil einer <unk> &quot; <unk> , der <unk> <unk> ist , dass er nicht <unk> ist , und sagte , dass keine <unk> nicht <unk> ist .
-Es kann einige <unk> , dass die <unk> <unk> <unk> <unk> <unk> werden .
-Aber das <unk> <unk> nicht die <unk> und <unk> , dass ein <unk> <unk> <unk> ist .
-&quot; Ich <unk> er zu einem <unk> , aber er <unk> nicht , &quot; <unk> <unk> <unk> .
-&quot; Es wäre so viel <unk> , wenn er <unk> ist .
-<unk> <unk>
-<unk> Sie die <unk> <unk> auf <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Aber was <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Er war <unk> ein <unk> , <unk> und <unk> <unk> , aber auch <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> in <unk> Jahren <unk> seit <unk> <unk> von <unk> , und er hat <unk> bereits <unk> <unk> , um <unk> <unk> zu <unk> .
-<unk> ein <unk> <unk> von <unk> <unk> in <unk> , <unk> er <unk> , dass die <unk> der <unk> <unk> <unk> <unk> <unk> .
-Es war nur <unk> &quot; , dass ein <unk> <unk> <unk> wurde .
-Diese <unk> , <unk> <unk> , ist der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Und <unk> <unk> <unk> .
-Im <unk> gibt es viele <unk> zwischen <unk> während der <unk> <unk> , es gibt <unk> zwischen <unk> und <unk> - 10 <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-Es gibt auch auch die <unk> , wo er <unk> ist , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> der <unk> , die <unk> oder die <unk> , gibt es etwas <unk> über die <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-Es ist ein <unk> , die <unk> von <unk> <unk> <unk> &quot; <unk> , aber es gibt <unk> und <unk> über die <unk> <unk> <unk> <unk> .
-Er hat eine <unk> für den Weg , <unk> und sollte <unk> werden .
-Nach <unk> <unk> nach <unk> <unk> er hier <unk> , und <unk> sie <unk> .
-Eine <unk> <unk> von <unk> <unk> <unk> <unk>
-<unk> <unk> er ein <unk> <unk> .
-&quot; <unk> &quot; in <unk> <unk> ich <unk> &quot; <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk>
-<unk> <unk> , was sie in <unk> <unk> werden .
-Das <unk> ich .
-<unk> <unk> seine <unk> zu <unk> .
-<unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> , dass sie mit einem &quot; <unk> <unk> &quot; <unk> <unk> , das <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk>
-<unk> <unk> die <unk> <unk> &quot; , dass er mit <unk> <unk> <unk> <unk> , ein <unk> <unk> , die <unk> <unk> und <unk> <unk> für <unk> <unk> zu <unk> .
-Die <unk> wurde <unk> über <unk> <unk> , aber <unk> &quot; <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Er <unk> , wie er und <unk> <unk> würde , <unk> die <unk> einer <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> sich in der <unk> ein <unk> <unk> und Sie <unk> durch die <unk> <unk> und <unk> <unk> <unk> .
-&quot; Wir waren <unk> und was wir <unk> , dass wir etwas <unk> <unk> , dass die <unk> von <unk> <unk> <unk> werden kann .
-Wir wissen zwei , aber wir wissen , dass ein <unk> <unk> <unk> <unk> , die eine <unk> <unk> <unk> , die <unk> <unk> , <unk> und ich <unk> nicht <unk> hätten .
-<unk> Sie auf ein <unk> <unk> , der er und <unk> <unk> <unk> , <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Als <unk> der <unk> <unk> waren in den <unk> der <unk> <unk> , um die beiden <unk> zu <unk> , die <unk> <unk> zu <unk> .
-Auf <unk> <unk> mit <unk> <unk> <unk> <unk>
-Auf dem <unk> 12 12 , am <unk> für <unk> , eine <unk> <unk> in der <unk> <unk> und <unk> er <unk> in der <unk> <unk> und <unk> .
-<unk> <unk> <unk> nach <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Das <unk> eine <unk> <unk> auf mir , es war <unk> <unk> , dass die einzige <unk> <unk> und meine <unk> <unk> hat .
-<unk> <unk> später hat eine der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , wo er &quot; <unk> &quot; <unk> <unk> &quot; <unk> .
-Es war <unk> als <unk> , <unk> ein <unk> <unk> <unk> <unk> <unk> , und ich <unk> in <unk> mit mir .
-Ich bitte eine <unk> auf die <unk> und <unk> <unk> , um die <unk> und <unk> <unk> für die <unk> <unk> .
-<unk> <unk>
-Bei <unk> Punkte in der <unk> <unk> <unk> <unk> neue Produkte auf die <unk> .
-<unk> in seiner <unk> , wie er <unk> <unk> , ein <unk> von <unk> <unk> <unk> war , war er von den <unk> <unk> <unk> .
-<unk> Sie nur 30 Tage von <unk> , er habe <unk> und <unk> der <unk> <unk> .
-<unk> <unk> , wenn er die <unk> <unk> in <unk> <unk> .
-&quot; Ich <unk> <unk> <unk> ...
-<unk> Tage <unk> wir eine <unk> , die <unk> <unk> , die <unk> <unk> wurde .
-<unk> <unk> und <unk> <unk>
-<unk> <unk> er <unk> die <unk> der <unk> , <unk> <unk> <unk> der <unk> , in dem so viele <unk> <unk> <unk> , und <unk> Kontrolle ihrer <unk> <unk> würden .
-&quot; <unk> <unk> oder <unk> , so <unk> Sie eine <unk> oder <unk> , so <unk> ?
-Sie haben eine <unk> der <unk> , so dass es sich nicht <unk> .
-<unk> und <unk> <unk> es <unk> , die <unk> <unk> und die Unterstützung der <unk> <unk> <unk> .
-Die <unk> , die <unk> , die <unk> <unk> ist , <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Das <unk> <unk> <unk> ...
-<unk> könnte die gesamte <unk> <unk> .
-Es könnte <unk> <unk> ihre <unk> der <unk> ...
-Sie <unk> <unk> aus .
-<unk> <unk> <unk> <unk>
-&quot; Es gibt eine <unk> <unk> zwischen einem <unk> und ein <unk> <unk> ...
-Sie <unk> einen <unk> über die <unk> .
-Es gibt <unk> , die Sie zu <unk> haben - <unk> Dinge ist <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
-Sie haben <unk> <unk> <unk> , diesen <unk> - diese <unk> <unk> ...
-<unk> ist es in der <unk> <unk> - es ist <unk> , die <unk> <unk> zu <unk> , um die <unk> <unk> zu <unk> und dann <unk> .
-<unk> sagte , dass <unk> <unk> <unk> , <unk> <unk> <unk> .
-Wir sind <unk> über <unk> <unk> <unk> .
-<unk> der <unk> hat das <unk> <unk> , dass die Menschen in den <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
-Wenn nicht zu <unk> , würde sie in anderen <unk> <unk> .
-<unk> und <unk> mit <unk> <unk> .
-Die <unk> <unk> sich auf die <unk> <unk> <unk> , ob sie ein <unk> <unk> würde , <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> wurde <unk> <unk> , wenn alle <unk> <unk> für die <unk> <unk> .
-Die <unk> im <unk> wurde <unk> durch die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> sich auf die <unk> <unk> , <unk> 5 / <unk> <unk> in <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-Die <unk> , die die <unk> und <unk> , die <unk> <unk> werden sollte , <unk> die <unk> <unk> <unk> , die <unk> <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> , <unk> <unk> , war es zwei <unk> zwei <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> , dass die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> der <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> wurde <unk> am <unk> <unk> <unk> .
-In <unk> war die <unk> der <unk> <unk> und eine <unk> <unk> der <unk> .
-Die <unk> ist im <unk> ?
-Es ist nichts <unk> , <unk> <unk> <unk> <unk> für Jahre <unk> .
-Das ist nichts <unk> .
-<unk> werden von der <unk> <unk> , dass die <unk> von <unk> <unk> <unk> <unk> .
-Wenn sie unter <unk> <unk> <unk> , <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> , die <unk> <unk> von <unk> und <unk> auf zwei des <unk> im Fall , als auch auf eine <unk> <unk> <unk> <unk> .
-&quot; Diese <unk> <unk> von <unk> und <unk> , die <unk> von <unk> <unk> , die von der <unk> <unk> <unk> , <unk> &quot; <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-&quot; Die <unk> waren <unk> und <unk> im <unk> mit der <unk> <unk> , die <unk> <unk> <unk> .
-<unk> <unk> und <unk> im <unk> für dieses <unk> <unk> und ist <unk> .
-<unk> und <unk> haben sich <unk> <unk> für die <unk> , die sagen , <unk> <unk> die <unk> mit <unk> <unk> <unk> .
-Und <unk> &quot; Und <unk> <unk> ist ein <unk> <unk> .
-<unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> und <unk> .
-<unk> <unk> als <unk> <unk> in der <unk> <unk> , wenn die <unk> <unk> auf die <unk> <unk> wurden .
-<unk> haben die <unk> <unk> für die <unk> von <unk> <unk> , <unk> , <unk> , <unk> <unk> war , dass sie <unk> war .
-<unk> hat sich <unk> <unk> <unk> werden .
-<unk>
-<unk> <unk> <unk> <unk> 50 <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> , wenn ein Unternehmen ein <unk> <unk> für Kinder <unk> .
-Das ist es ein <unk> <unk> , wenn die Unternehmen <unk> <unk> und die Liste der <unk> <unk> <unk> ist .
-Die <unk> <unk> ist <unk> , wo der <unk> die <unk> Osten <unk> , ein <unk> <unk> <unk> .
-In einer <unk> <unk> <unk> die <unk> <unk> , dass <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> werden .
-<unk> über die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> von <unk> in <unk> .
-Die <unk> hat eine <unk> <unk> , 20 mehr <unk> , die die <unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> zu <unk> .
-<unk> auf <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> ist für <unk> dieser <unk> .
-&quot; Dies ist auch ein <unk> <unk> <unk> <unk> , &quot; <unk> <unk> <unk> <unk> <unk> .
-&quot; <unk> &quot; <unk> ist <unk> .
-<unk> <unk> ist <unk> von seinen <unk> <unk> <unk> .
-<unk> <unk> sie sich nicht nur <unk> , sondern eine <unk> zur <unk> von <unk> - <unk> <unk> zu <unk> , weil sie die <unk> der <unk> <unk> - <unk> ist , nicht als die <unk> der <unk> .
-Das ist <unk> , dass sie weniger <unk> als andere <unk> <unk> , <unk> oder <unk> <unk> <unk> , wenn <unk> <unk> .
-&quot; Sie haben einen <unk> <unk> , &quot; er <unk> <unk> .
-Die <unk> zur <unk> der <unk> in der <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> im <unk> Mai <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Es <unk> die <unk> <unk> nach <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> auf <unk> <unk> .
-<unk>
-<unk> <unk> <unk> <unk> , dass <unk> <unk> <unk> <unk> der <unk> in der <unk> <unk> .
-Herr Präsident , <unk> <unk> der <unk> <unk> ihre <unk> <unk> , die für die <unk> des <unk> <unk> <unk> , und sie <unk> <unk> , dass <unk> <unk> die <unk> <unk> <unk> <unk> <unk> .
-<unk> Ergebnisse <unk> die <unk> für die <unk> des <unk> <unk> , die <unk> des <unk> <unk> , oder <unk> .
-&quot; Der <unk> von <unk> <unk> während der gesamten <unk> und besonders <unk> ist <unk> , nicht nur für die gesamte <unk> , &quot; <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-&quot; Er <unk> unsere <unk> , unsere <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> für <unk> <unk> , <unk> die <unk> in 2000 .
-Aber es ist <unk> eine <unk> , und <unk> in <unk> ist ein wichtiger Schritt in diesem <unk> .
-Die <unk> ist <unk> , die <unk> <unk> in <unk> <unk> .
-<unk> Sie nur <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> .
-<unk> , ein <unk> für ihre <unk> der <unk> <unk> <unk> , oder <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
-<unk> <unk> , die <unk> für die <unk> <unk> <unk> <unk> , oder <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> auch die <unk> <unk> <unk> .
-<unk> <unk> <unk> die <unk> <unk> der <unk> <unk> , <unk> <unk> <unk> und <unk> die anderen <unk> zu <unk> .
-<unk> ist <unk> von <unk> <unk> in <unk> , <unk> und <unk> .
-Es ist <unk> .
-<unk> hat <unk> <unk> .
-Ein <unk> <unk> war vor der <unk> als <unk> , wie er <unk> für <unk> <unk> <unk> und einen <unk> <unk> <unk> <unk> .
-Für den <unk> <unk> jedoch jedoch die <unk> <unk> , eine <unk> <unk> zu <unk> .
-<unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
-<unk>
-Die <unk> <unk> <unk> hat <unk> und China zu <unk> , um die <unk> von <unk> zu <unk> , die die <unk> der <unk> <unk> <unk> .
-Die <unk> <unk> , die <unk> <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Er <unk> <unk> &#91; <unk> &#91; <unk> , <unk> , China , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> <unk> <unk> <unk> , wenn ein <unk> <unk> in der <unk> Wirtschaft <unk> .
-&quot; Wir sind uns in diesem <unk> .
-&quot; <unk> <unk> <unk> <unk> , der kann Europa für die <unk> ist , &quot; er <unk> das <unk> in einem <unk> auf der <unk> <unk> in <unk> .
-&quot; <unk> <unk> <unk> sein , aber es kann &quot; <unk> &quot; .
-&quot; <unk> <unk> wenn China sagen und <unk> <unk> können .
-Europa ist <unk> von einem <unk> <unk> in <unk> Monate <unk> .
-In den letzten Tagen <unk> Tage <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> Krise hat <unk> , dass es die <unk> der <unk> <unk> , die die <unk> Wirtschaft in <unk> und <unk> <unk> für <unk> <unk> <unk> , um die <unk> zu <unk> .
-Herr <unk> <unk> , dass alle <unk> <unk> durch die <unk> , aber sagte <unk> <unk> wie <unk> <unk> wie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; <unk> <unk> <unk> die <unk> für <unk> und <unk> &quot; <unk> <unk> &quot; .
-&quot; Wir haben <unk> <unk> und haben ein <unk> <unk> <unk> <unk> .
-&quot; Es ist nicht ein <unk> , es ist kein <unk> , weil wir <unk> , denn <unk> wir die <unk> der <unk> und Frauen <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> , ein <unk> in den USA , sagte sie sehr <unk> , dass Europa <unk> <unk> <unk> , um die <unk> Bevölkerung zu <unk> , <unk> <unk> zu <unk> .
-&quot; <unk> <unk> werden <unk> , dass <unk> auf der <unk> <unk> 50 und <unk> zu <unk> und <unk> <unk> .
-<unk> <unk> , die <unk> <unk> der <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Herr <unk> sagte , dass der <unk> eine <unk> Antwort auf <unk> <unk> <unk> .
-Die <unk> der <unk> von <unk> pro <unk> in <unk> für <unk> / 12 Euro <unk> die <unk> von Europa .
-Er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> von <unk> über <unk> <unk>
-<unk> <unk> <unk> <unk> die <unk> auf <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> ist <unk> <unk> über die nächsten <unk> , aber die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-&quot; Der <unk> dieser <unk> würde <unk> für die <unk> <unk> &quot; <unk> <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-Er sagte , dass <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; <unk> eine große <unk> , <unk> in diesem <unk> <unk> , würde <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-&quot; Wir würden auch <unk> <unk> , viele viele unserer <unk> zu <unk> und weil die <unk> <unk> wäre , <unk> wir <unk> <unk> <unk> in <unk> zu <unk> .
-&quot; Diese <unk> wäre mit <unk> , die unsere <unk> <unk> und <unk> <unk> .
-Die <unk> würde <unk> <unk> <unk> , <unk> <unk> .
-&quot; <unk> <unk> <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; <unk> <unk> wäre <unk> , <unk> in der <unk> und die <unk> <unk> , die die <unk> <unk> .
-&quot; <unk> <unk> würde <unk> <unk> , <unk> in <unk> <unk> , <unk> und <unk> <unk> <unk> <unk> .
-Die zwei <unk> hatte <unk> 10 Tage vor <unk> <unk> , <unk> , <unk> für die <unk> <unk> .
-&quot; Der <unk> eines <unk> über die <unk> <unk> wäre <unk> eine <unk> <unk> der Vereinigten Staaten als <unk> <unk> .
-&quot; Wir werden uns <unk> <unk> , <unk> &quot; <unk> in einer <unk> <unk> <unk> , wenn sie <unk> <unk> <unk> .
-&quot; Dies ist nicht ein <unk> , dass wir mit der <unk> <unk> , und es ist <unk> nicht , dass wir über &quot; <unk> <unk> sollten .
-&quot; Der <unk> ist ein <unk> , die nationalen <unk> <unk> , und es sollte nicht <unk> werden .
-<unk> die <unk> <unk> und die <unk> <unk> von <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> ist <unk> über die <unk> <unk> <unk> , <unk> er sich <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> und <unk> <unk> , dass er <unk> <unk> <unk> wurde .
-Bei einem <unk> <unk> in Woche der <unk> <unk> eine <unk> <unk> von <unk> , was <unk> <unk> eine <unk> mit einem <unk> mit <unk> , aber keine <unk> <unk> .
-&quot; Es ist eine <unk> ohne <unk> .
-&quot; Es ist eine <unk> ohne <unk> .
-&quot; Es ist eine <unk> ohne <unk> <unk> .
-&quot; Es ist eine <unk> <unk> , ein <unk> von <unk> , <unk> und <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Es ist ein <unk> , dass <unk> <unk> und <unk> <unk> <unk> , um <unk> mit <unk> <unk> .
-&quot; Im <unk> <unk> <unk> &quot;
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Und <unk> sagte , dass einige der <unk> <unk> <unk> haben , könnte <unk> die <unk> , die bereits <unk> und einige <unk> in <unk> <unk> <unk> .
-Das Liste der <unk> <unk> <unk> , eine <unk> neue <unk> , die <unk> <unk> , die neue <unk> , die neue <unk> <unk> und die neue <unk> der neuen <unk> <unk> müssen .
-<unk> <unk> die Entwicklung und <unk> der <unk> könnte einige <unk> <unk> <unk> <unk> <unk> , aber die <unk> <unk> <unk> ist es ein <unk> <unk> <unk> und <unk> <unk> .
-Wie <unk> ein <unk> <unk> , um eine <unk> <unk> und <unk> zu <unk> .
-Ein <unk> im <unk> <unk> <unk> nur , wie <unk> und <unk> <unk> und <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> ist <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> haben mit <unk> für <unk> <unk> <unk> , die eine <unk> <unk> <unk> wurde .
-Die Woche <unk> <unk> <unk> <unk> <unk> auf ein <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> hat <unk> <unk> und <unk> Länder .
-<unk> <unk> <unk> und Internet <unk> <unk> ein <unk> von <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Und dann hat keine <unk> , die durch es wird , die durch <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> auf <unk> und <unk> <unk> sind <unk> .
-Es gab <unk> , wo die <unk> <unk> <unk> <unk> haben , um den <unk> zu <unk> .
-<unk> sollte die <unk> <unk> <unk> werden , die eine <unk> <unk> und <unk> sind .
-<unk> viel <unk> <unk> wir <unk> ?
-<unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> sind <unk> <unk> .
-<unk> <unk> <unk> <unk> , dass <unk> drei <unk> in erster 10 Minuten von <unk> .
-<unk> <unk> , oder &quot; <unk> <unk> , &quot; <unk> ist ein <unk> <unk> für alle <unk> , <unk> und <unk> <unk> .
-<unk> , <unk> , <unk> , <unk> , wo der <unk> <unk> ist , ist eine <unk> <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> ist , dass die <unk> <unk> <unk> <unk> .
-<unk> <unk> Sie im <unk> .
-Sie sind nicht <unk> , <unk> , <unk> , <unk> oder <unk> .
-<unk> Sie sich von dieser <unk> <unk> , die <unk> <unk> sind und <unk> <unk> .
-Ein <unk> <unk> <unk> können auf die <unk> von <unk> <unk> <unk> <unk> , <unk> , <unk> und <unk> .
-Ich <unk> mehrere Jahre <unk> die <unk> <unk> in den <unk> und <unk> <unk> <unk> , und es ist klar , dass <unk> ein <unk> <unk> ist , <unk> oder <unk> <unk> .
-<unk> <unk> sind <unk> auf <unk> <unk> , <unk> sie ihre eigenen <unk> und <unk> <unk> .
-Wir wissen , dass <unk> <unk> mehr als <unk> , die sich <unk> &quot; <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Wir wissen auch , wenn Sie <unk> , wenn Sie als <unk> , andere <unk> <unk> .
-Wie <unk> Sie , wenn <unk> <unk> ist ?
-<unk> Sie Ihre Frage der <unk> <unk> .
-Das ist eine <unk> <unk> .
-Es ist ein <unk> <unk> für <unk> <unk> .
-<unk> Sie Ihre Frage der <unk> .
-Sie haben <unk> <unk> , <unk> <unk> ihr <unk> alle <unk> <unk> , wenn Sie nicht in der <unk> der <unk> <unk> .
-<unk> <unk> die <unk> von <unk> und <unk> <unk> .
-<unk> diese <unk> <unk> <unk> , nicht von <unk> .
-Die <unk> , die <unk> <unk> , wenn die <unk> ihre <unk> <unk> <unk> , <unk> sie ihre <unk> <unk> <unk> , <unk> sie ihre <unk> <unk> , <unk> <unk> und <unk> <unk> .
-<unk> oft <unk> oft <unk> , dass ein <unk> <unk> ist , die <unk> <unk> .
-<unk> <unk> die <unk> des <unk> .
-<unk> <unk> <unk> <unk> und <unk> die <unk> während der <unk> während der <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> sind <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Diese <unk> <unk> die Antwort , die <unk> und <unk> <unk> ist .
-Es gibt keine <unk> <unk> <unk> für <unk> <unk> , sondern <unk> auf <unk> <unk> ist möglich .
-Diese <unk> wird <unk> von <unk> von <unk> <unk> in ihrem <unk> und <unk> <unk> <unk> .
-<unk>
-<unk> nach dem <unk> <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> sagte <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die Firma <unk> sich auf ein <unk> im <unk> <unk> .
+Diese Woche ist eine <unk> <unk> , ob die <unk> <unk> , ob die <unk> der <unk> für die <unk> <unk> <unk> <unk> .
+Wenn nicht von <unk> <unk> werden , sind nicht <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Es war <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Er <unk> , wenn er sich <unk> , wenn er die <unk> für eine <unk> <unk> .
+<unk> &quot; <unk> <unk> <unk> <unk> &quot; <unk> <unk> <unk> .
+Doch die <unk> <unk> <unk> die <unk> <unk> <unk> .
+Ich <unk> keine <unk> , nicht <unk> .
+<unk> &quot; <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> .
+&quot; Ich möchte meine <unk> <unk> .
+<unk> <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Diese Woche muss über <unk> <unk> , <unk> und <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> <unk> , dass <unk> und <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> in der <unk> von <unk> <unk> , eine <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> sie <unk> <unk> , weil die <unk> <unk> mit ihnen <unk> .
+&quot; <unk> ist ein <unk> <unk> , &quot; sie <unk> <unk> .
+&quot; <unk> sind die <unk> , die in der Nähe des <unk> <unk> <unk> <unk> .
+<unk> auch die <unk> , die seit <unk> <unk> , hat sie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> die <unk> in diesem Fall - <unk> die <unk> in einem <unk> , <unk> , <unk> - <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Die <unk> <unk> für die <unk> von <unk> , <unk> von <unk> <unk> , hat eine <unk> , die <unk> <unk> <unk> .
+Die <unk> <unk> , die von <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> ein <unk> <unk> <unk> <unk> die <unk> <unk> <unk> , ist die <unk> nicht für <unk> <unk> .
+&quot; <unk> <unk> sind <unk> , <unk> <unk> , &quot; <unk> &quot; <unk> &quot; .
+Die <unk> der <unk> <unk> auf dieser <unk> .
+<unk> haben die <unk> der <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> in <unk> , dass <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+In <unk> und <unk> , <unk> von <unk> <unk> sind <unk> <unk> , besonders in <unk> <unk> <unk> <unk> .
+Die <unk> zwischen den beiden <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Es ist für die <unk> , die <unk> , <unk> <unk> .
+<unk> <unk> nicht <unk> in den <unk> drei <unk> <unk> .
+Im <unk> <unk> <unk> <unk> die <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> , die <unk> <unk> , ist eine <unk> gegen die <unk> , die die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> ein <unk> in <unk> gegen die <unk> <unk> , <unk> sie mit <unk> <unk> in den <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> in der <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> gibt es <unk> <unk> <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+<unk> sind <unk> <unk> , und von der <unk> der <unk> <unk> , die <unk> <unk> , dass <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die Bericht , <unk> auch in <unk> <unk> , <unk> auch <unk> <unk> in <unk> <unk> <unk> , <unk> die <unk> der <unk> <unk> <unk> .
+Die <unk> in <unk> <unk> ihre <unk> als nur die ersten <unk> der <unk> .
+In der Nähe des <unk> <unk> <unk> die <unk> <unk> weniger als eine <unk> von <unk> .
+Das <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist ein <unk> <unk> , und die <unk> der <unk> - der <unk> - <unk> im <unk> <unk> .
 <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Das ist nach der <unk> der vergangenen Woche , dass es ein <unk> <unk> für die <unk> bis <unk> neue <unk> <unk> , die <unk> <unk> <unk> , <unk> und <unk> <unk> .
-&quot; Dies ist ein <unk> <unk> , &quot; <unk> <unk> , &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die neue <unk> der <unk> <unk> würde <unk> <unk> <unk> , wenn nach dem <unk> <unk> <unk> <unk> <unk> wurde .
-<unk> , in einer <unk> letzten Woche <unk> die <unk> des <unk> <unk> und <unk> Unterstützung für <unk> .
-Die <unk> <unk> wäre aus dem <unk> der <unk> <unk> .
-Es wäre <unk> <unk> pro Tag aus dem <unk> von <unk> zu <unk> .
-Für <unk> wäre es <unk> <unk> .
-Es ist <unk> von <unk> , aber <unk> durch <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Aber <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> .
-Die <unk> der <unk> <unk> <unk> <unk> die <unk> <unk> nur <unk> <unk> <unk> <unk> , sondern die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> ist , ob eine <unk> von <unk> <unk> <unk> wurde , <unk> eine <unk> <unk> in <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-Mit anderen <unk> ist es <unk> , dass die <unk> <unk> , die <unk> <unk> war , die <unk> zu <unk> .
-<unk>
-Ein <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> in einer <unk> in der <unk> ihrer <unk> , <unk> ihre <unk> <unk> , <unk> ihre <unk> <unk> .
-Das &quot; <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> , dass sie &quot; <unk> <unk> <unk> <unk> <unk> , <unk> &quot; und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Es war <unk> <unk> , wenn ein <unk> <unk> <unk> <unk> , seine <unk> <unk> , <unk> und <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> die <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> sie <unk> , sagte sie <unk> , dass ein <unk> <unk> und ihre <unk> für eine <unk> .
-&quot; <unk> <unk> <unk> möchte ich &quot; <unk> , was Ihre <unk> wissen ?
-<unk> <unk> <unk> die <unk> <unk> .
-&quot; <unk> <unk> in einer <unk> <unk> , &quot; Sie haben keine <unk> durch den <unk> , &quot; <unk> <unk> <unk> <unk> .
-&quot; Ich habe <unk> <unk> , dass man sagen , dass wir &quot; <unk> &quot; .
-<unk> <unk> <unk> <unk> und <unk> <unk> <unk> die <unk> in einer <unk> <unk> ...
-<unk> hatte von <unk> und <unk> <unk> aus dem <unk> <unk> .
-<unk> sagte <unk> <unk> <unk> .
-&quot; Ich habe in diesem Haus <unk> &quot; , <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; .
-<unk> <unk> bei der <unk> <unk> , die noch <unk> <unk> und <unk> <unk> <unk> <unk> <unk> durch ihre <unk> und <unk> <unk> <unk> .
-Die <unk> wurde so <unk> , sie <unk> <unk> .
-<unk> , <unk> <unk> eine <unk> <unk> für eine <unk> aus , aber <unk> keine Antwort .
-<unk> <unk> und <unk> <unk> <unk> nicht für <unk> .
-Die <unk> <unk> <unk> , aber die Familie , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> zu <unk> .
-&quot; Der <unk> ist für <unk> <unk> <unk> <unk> für ihre <unk> <unk> <unk> .
-&quot; Das <unk> ist <unk> <unk> , <unk> , wenn <unk> ein <unk> <unk> <unk> .
-<unk>
-Während der ersten Jahr von <unk> <unk> <unk> , in <unk> <unk> die <unk> <unk> und die <unk> <unk> <unk> <unk> .
-<unk> ist ein Jahr , die in der <unk> Geschichte von <unk> <unk> , mit dem ersten Jahr von <unk> <unk> <unk> , die <unk> <unk> der <unk> , die <unk> der <unk> und der Entwicklung der <unk> <unk> , <unk> wurde .
-Die <unk> <unk> , nicht nur <unk> , sondern die <unk> der <unk> der <unk> <unk> , aber sie <unk> die <unk> der <unk> der <unk> und <unk> <unk> , die die <unk> anderer <unk> in <unk> <unk> <unk> .
-Die <unk> des Berichts <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> im <unk> hat <unk> , <unk> , <unk> , ein <unk> <unk> der <unk> in der <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk>
-<unk> im Jahr <unk> in <unk> <unk> im Jahr <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-&quot; <unk> <unk> wir <unk> jetzt ist ein <unk> der <unk> , die mit <unk> <unk> , <unk> <unk> , <unk> die <unk> der <unk> in der <unk> der <unk> <unk> <unk> .
-<unk>
-<unk> <unk> <unk> , dass in der <unk> eine <unk> <unk> <unk> ist .
-&quot; Die Zahl der Menschen , die die <unk> in den Vereinigten Staaten <unk> wurde , in den Vereinigten Staaten von <unk> , in den Vereinigten Staaten von Menschen , <unk> , <unk> , <unk> , <unk> und <unk> Arbeitsplätze zu <unk> .
-<unk>
-Die <unk> , <unk> , wenn die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> <unk> <unk> .
-Die <unk> <unk> der <unk> <unk> <unk> wurde <unk> <unk> , was <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-<unk> von <unk>
-<unk> <unk> die <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Für die <unk> , die <unk> <unk> der <unk> Regierung der <unk> Regierung eine <unk> <unk> der <unk> Regierung , die in <unk> <unk> und <unk> <unk> <unk> .
-<unk>
-<unk> der <unk> Regierung <unk> die Regierung <unk> in <unk> während der <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk>
-Für <unk> , die erste Jahr von <unk> <unk> <unk> eine <unk> von <unk> <unk> .
-<unk> <unk> , <unk> der <unk> <unk> der <unk> <unk> , <unk> , dass während der <unk> ein <unk> <unk> der <unk> <unk> wurde .
-&quot; <unk> der Wirtschaft in diesem Jahr gewesen ist ein wirklich wirklich <unk> , ein <unk> , ein <unk> und <unk> <unk> zu <unk> , dass wir unsere <unk> <unk> und alle <unk> <unk> der neuen Regierung <unk> , <unk> wir müssen unsere <unk> <unk> .
-<unk>
-<unk> <unk> <unk> , dass die <unk> <unk> diese Jahr als <unk> der <unk> und seine <unk> <unk> wurden .
-&quot; Der <unk> <unk> <unk> ist der <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-<unk>
-<unk> <unk> <unk> , <unk> der <unk> &quot; <unk> in <unk> , <unk> , dass die <unk> <unk> ist , die <unk> <unk> <unk> .
-&quot; <unk> , wir haben uns darauf , dass es für notwendig ist , eine <unk> <unk> <unk> , die die <unk> und die <unk> <unk> der <unk> <unk> <unk> , <unk> er <unk> sagte .
-<unk>
-<unk> Präsidentin <unk> die Bedeutung von <unk> eine Zukunft <unk> , die <unk> der Regierung <unk> .
-&quot; <unk> <unk> möchte ich sagen , dass die Regierung in den verschiedenen <unk> <unk> werden soll , <unk> , <unk> er <unk> , wichtig ist .
-Er <unk> , dass die <unk> <unk> Fortschritte in ihrer eigenen <unk> <unk> hat .
-&quot; Es gibt <unk> , dass wir uns <unk> <unk> , dass die <unk> <unk> mehr <unk> ist und was ich sagen , dass es &quot; <unk> <unk> ist , &quot; <unk> &quot; <unk> &quot; .
-<unk> <unk>
-<unk> <unk> in <unk> und eine <unk> von <unk> Tage <unk> .
-Die <unk> <unk> <unk> , dass die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> / <unk> / <unk> / <unk> / <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> wurde <unk> ein <unk> <unk> , wo er <unk> ein <unk> <unk> in der <unk> der <unk> und der <unk> <unk> <unk> <unk> .
-Für diese <unk> war die <unk> an der <unk> der <unk> <unk> und die <unk> Person der <unk> <unk> <unk> <unk> <unk> .
-<unk> müssen <unk> <unk> werden .
-Die soziale <unk> <unk> sich in der <unk> <unk> wie <unk> , <unk> von <unk> und <unk> für <unk> , <unk> von <unk> und <unk> für <unk> <unk> <unk> <unk> .
-Die <unk> von <unk> <unk> <unk> , die so weit <unk> ist , wie die <unk> Regierung in allen drei <unk> <unk> , die eine <unk> <unk> <unk> , die eine <unk> <unk> <unk> , die eine <unk> <unk> <unk> .
-Er <unk> , dass die <unk> in dieser drei drei <unk> <unk> <unk> <unk> <unk> und so nur die <unk> und die <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Sie müssen <unk> mit <unk> <unk> <unk> <unk> und sogar <unk> <unk> , da er mit <unk> <unk> <unk> , da er <unk> &quot; <unk> <unk> <unk> , da er <unk> &quot; <unk> <unk> , <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> <unk> , <unk> er sich <unk> <unk> .
-Er <unk> <unk> , dass letzten Jahr während der <unk> <unk> nicht mit dem <unk> <unk> <unk> , so dass die <unk> der <unk> <unk> nicht mit dem <unk> <unk> , um <unk> Millionen Euro zu <unk> .
-&quot; Es <unk> uns in der <unk> <unk> , weil die <unk> nicht die <unk> <unk> haben und die <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
-<unk> gibt es eine <unk> der <unk> <unk> <unk> , er hat <unk> , dass die <unk> <unk> <unk> <unk> , <unk> er <unk> , dass die <unk> , die <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Sie müssen sich mit <unk> <unk> <unk> <unk> und noch noch nicht <unk> haben .
-<unk>
-Der <unk> von <unk> mit <unk> ist eines der größten <unk> , dass die <unk> in den letzten Jahren <unk> Jahren <unk> hat .
-Die <unk> hat die <unk> <unk> der <unk> <unk> und <unk> gegen die <unk> <unk> , die den <unk> <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Ein <unk> von vier <unk> , <unk> die Präsident der <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Mit diesem <unk> <unk> <unk> die <unk> von der <unk> <unk> <unk> <unk> <unk> <unk> <unk> für die <unk> des <unk> , <unk> und <unk> zu <unk> .
-Die <unk> Projekt von <unk> <unk> <unk> , <unk> <unk> , weil die Verordnung <unk> <unk> und <unk> <unk> <unk> ist , weil die Verordnung <unk> <unk> und <unk> <unk> <unk> .
-<unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> und <unk> <unk> für den <unk> .
-Mit dieser <unk> , sowohl der <unk> und der <unk> <unk> <unk> zwei <unk> <unk> die <unk> , die <unk> , die <unk> , die <unk> der <unk> und alle <unk> <unk> <unk> .
-Im <unk> &quot; <unk> <unk> es auch die <unk> der <unk> <unk> , ohne die <unk> der <unk> , <unk> <unk> zu <unk> .
-In seiner <unk> <unk> <unk> er <unk> <unk> , dass er nicht <unk> ist , dass die <unk> <unk> durch die <unk> der <unk> nicht durch <unk> <unk> .
-&quot; <unk> <unk> ich , dass <unk> die <unk> des <unk> <unk> , &quot; und <unk> , dass die <unk> <unk> <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> der <unk> <unk> hat .
-Die <unk> für die <unk> ist ein der <unk> <unk> , die die <unk> in den letzten Jahren <unk> , <unk> <unk> und <unk> <unk> .
-<unk> <unk> er sagte , würde der <unk> <unk> , die <unk> , die nicht nur eine <unk> <unk> , &quot; und <unk> , <unk> und <unk> <unk> <unk> .
-Diese Fragen , er sagte , &quot; <unk> der gesamten <unk> <unk> unter dem <unk> der <unk> <unk> <unk> .
-Er <unk> , dass eine große Reihe von Ländern <unk> <unk> ist , und hat es durch die <unk> , <unk> <unk> <unk> <unk> .
-Es gibt nicht <unk> , dass die Regierung , die von der <unk> <unk> , <unk> <unk> , dass <unk> in <unk> Weise die <unk> des <unk> <unk> , <unk> er <unk> .
-Sie <unk> die Möglichkeit einer &quot; <unk> in <unk>
-<unk> die <unk> zwischen den ersten und dem <unk> ist der <unk> <unk> nur <unk> <unk> , <unk> ohne <unk> die <unk> <unk> des <unk> <unk> .
-Die Möglichkeit <unk> &quot; <unk> &quot; in <unk> , wo nach dem <unk> der <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-In diesem Zusammenhang hat die Präsident der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-Wie es <unk> wird , wird <unk> <unk> nicht die <unk> oder die <unk> der <unk> <unk> oder die <unk> <unk> <unk> , da er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> , die <unk> <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , da er keine richtig &quot; <unk> &quot; .
-<unk> über die Möglichkeit der &quot; <unk> &quot; <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> , dass mit der <unk> der <unk> <unk> der <unk> <unk> <unk> <unk> <unk> wird .
-<unk> , die <unk> <unk> eines oder <unk> <unk> <unk> <unk> <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> die <unk> der <unk> in allen <unk> der <unk> <unk> <unk> , wenn es einen <unk> <unk> , ist es eine <unk> , die die <unk> zwischen den <unk> und / <unk> <unk> , die die zweite <unk> <unk> .
-Die Abstimmung findet auch im Ende des <unk> <unk> .
-Es gibt <unk> , dass in diesem Situation <unk> die <unk> zwischen den ersten und den <unk> zwischen den ersten und dem zweiten Ort ist <unk> <unk> <unk> .
-<unk>
-<unk> <unk> wird in der <unk> <unk> , <unk> die Familie .
-Der <unk> der <unk> <unk> <unk> in <unk> waren <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Nach dem <unk> <unk> mit anderen <unk> , die in der <unk> der <unk> <unk> , die <unk> der <unk> <unk> , die <unk> <unk> der <unk> <unk> <unk> , die <unk> <unk> <unk> <unk> .
-Auf <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> und <unk> <unk> <unk> .
-<unk> <unk> 30 im <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; <unk> <unk> <unk> <unk> zu <unk> , und <unk> <unk> in den <unk> von <unk> , er ist <unk> von <unk> , die <unk> der <unk> <unk> .
-<unk> <unk> <unk> <unk> seine <unk> <unk> , <unk> er , dass er bei der <unk> der <unk> seiner <unk> <unk> war , <unk> &quot; <unk> war , <unk> &quot; <unk> <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> hat er sagte , dass er <unk> , dass er <unk> <unk> in den <unk> <unk> , aber es ist <unk> , seine <unk> zu <unk> , dass der <unk> ein <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> , die er <unk> <unk> war , <unk> er <unk> <unk> <unk> er <unk> <unk> <unk> er <unk> <unk> <unk> er <unk> <unk> <unk> er <unk> <unk> <unk> <unk> <unk> , <unk> er <unk> <unk> .
-<unk> <unk>
-Die <unk> waren <unk> für die <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-<unk> <unk> <unk> die <unk> <unk> , wenn die <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> und andere anderen <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> Sie <unk> im <unk> <unk> <unk>
-<unk> <unk> <unk> in <unk> <unk> <unk> , die <unk> <unk> in <unk> <unk> <unk> , die in <unk> <unk> <unk> , die in der <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> in <unk> <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> Menschen , die durch die <unk> <unk> , die durch den <unk> <unk> , deren <unk> <unk> ist , wurde <unk> <unk> .
-<unk> , in drei <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> der <unk> <unk> eine <unk> <unk> mit <unk> <unk> , <unk> und <unk> war es war eine <unk> mit <unk> <unk> .
-<unk> ist ein <unk> <unk> <unk> mit <unk> <unk> und <unk> <unk> .
-Die drei <unk> wurden <unk> <unk> .
-<unk> Sie auf die <unk> <unk> <unk> <unk> , die in einem anderen <unk> wurden , da es keine <unk> haben .
-Auf der <unk> des Landes gibt es <unk> von einem <unk> <unk> <unk> <unk> , die in der <unk> <unk> und in der <unk> <unk> .
-<unk> sind in <unk>
-Die <unk> <unk> <unk> <unk> den <unk> der <unk> Menschen , <unk> <unk> eine <unk> , die im <unk> der <unk> und der <unk> <unk> <unk> , die in der <unk> der <unk> und der <unk> <unk> sind , die in der <unk> der <unk> und der <unk> <unk> werden .
-<unk> <unk> <unk> <unk> <unk> <unk> in der <unk> des <unk> <unk> <unk> <unk> <unk> in der <unk> von <unk> <unk> <unk> <unk> <unk> <unk> und einer Person , die <unk> <unk> .
-<unk> <unk> drei <unk> und eine <unk> <unk> , die durch den <unk> <unk> <unk> <unk> &quot; <unk> <unk> .
-Der anderen <unk> <unk> auf <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> sie und die <unk> , die <unk> , ein <unk> und <unk> <unk> .
-<unk> , nach denen nach dieser <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> wurde .
-Er ist <unk> von <unk> <unk> , China und <unk> .
-<unk> gibt es <unk> <unk> <unk> <unk> <unk>
-Die <unk> <unk> , wird morgen mit dem <unk> von <unk> in <unk> <unk> , um die neue Regierung <unk> , die den <unk> eines <unk> <unk> <unk> hat .
-Die <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> mit dem <unk> des <unk> in <unk> zu <unk> , die neue Regierung <unk> , die auf der Krise eines <unk> <unk> und <unk> ist .
-Ein <unk> von den <unk> <unk> <unk> , dass <unk> auf <unk> mit dem <unk> , <unk> , <unk> , <unk> , <unk> , dass er ein <unk> <unk> .
-<unk> <unk> ist <unk> ein <unk> <unk> <unk> , <unk> es ist <unk> , wenn die neue <unk> <unk> .
-<unk> sagte <unk> , wie er <unk> wird , wird der <unk> <unk> mit den politischen <unk> in seiner <unk> <unk> .
-&quot; Ich möchte meine <unk> <unk> in den <unk> unserer Landes <unk> &quot; , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
-<unk> <unk> hat nicht <unk> , dass er ein <unk> <unk> , aber die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; <unk> <unk> ist nun <unk> , &quot; er <unk> .
-<unk> hat die <unk> eines Regierung in weniger als drei Tage <unk> , <unk> weniger weniger als die <unk> , während <unk> <unk> <unk> <unk> .
-Die neue <unk> <unk> der Europäischen Kommissar <unk> müssen <unk> eine <unk> <unk> von der Europäischen <unk> <unk> , um die <unk> in <unk> zu <unk> .
-<unk> die <unk> auf <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> , <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Wir <unk> , dass <unk> Regierung die letzte <unk> für dieses <unk> <unk> ist , <unk> sich <unk> .
-Der <unk> von Erfolg wurde <unk> durch die Unterstützung des <unk> von <unk> <unk> <unk> , die von den Krise <unk> <unk> wurde .
-&quot; Wir sind davon überzeugt , dass die <unk> <unk> <unk> <unk> , eine gute <unk> , <unk> , <unk> der <unk> <unk> <unk> .
-Die Unterstützung der <unk> , der größte <unk> im <unk> ist <unk> , weil es viele der <unk> <unk> <unk> <unk> , die die Regierung Mehrheit der <unk> <unk> <unk> .
-<unk>
-<unk> neue Regierung muss eine <unk> Unterstützung für <unk> die <unk> <unk> , die <unk> <unk> <unk> .
-<unk> <unk> oder <unk> in ihrer <unk> könnte ein <unk> und <unk> <unk> <unk> .
-Die <unk> <unk> der <unk> <unk> , die eine <unk> von <unk> wäre .
-<unk> <unk> auf <unk> <unk> mit den politischen <unk> , <unk> und <unk> sowie <unk> <unk> <unk> .
-Er <unk> seine <unk> auf <unk> <unk> .
-<unk> war <unk> auf <unk> von <unk> , die eine sehr <unk> <unk> <unk> hat .
-Nach einem <unk> im letzten letzten Woche hat <unk> <unk> <unk> , wenn <unk> <unk> <unk> <unk> zwischen <unk> <unk> <unk> , ob die neue <unk> <unk> zwischen <unk> <unk> .
-<unk> mit einer <unk> <unk> <unk> würde viel für die <unk> <unk> der <unk> <unk> .
-<unk> hat bereits <unk> , dass seine Regierung die <unk> <unk> für <unk> <unk> <unk> , <unk> die <unk> , die nur mit dem <unk> <unk> <unk> , <unk> die <unk> , die nur mit dem <unk> <unk> würde .
-<unk> wäre er <unk> , wie er <unk> würde , <unk> die <unk> <unk> , die nur von <unk> <unk> <unk> werden muss , eine <unk> von den <unk> <unk> <unk> .
-<unk> <unk> sagte , dass der <unk> <unk> und <unk> <unk> der <unk> <unk> <unk> <unk> .
-<unk> der <unk> ist <unk> als , dass der <unk> der <unk> <unk> ist .
-Die <unk> <unk> als in <unk> , <unk> <unk> 50 internationalen <unk> .
-Am <unk> <unk> <unk> nur einer <unk> <unk> <unk> 50 <unk> <unk> .
-<unk> in <unk> <unk> , <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> die Welt und Europa <unk> , wenn eine <unk> in der <unk> <unk> , haben einen <unk> <unk> <unk> , die nur <unk> <unk> <unk> , die nur <unk> <unk> <unk> .
-<unk> war <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> in der <unk> <unk> und in <unk> <unk> der <unk> <unk> <unk> <unk> <unk> und <unk> <unk> und <unk> <unk> und <unk> <unk> <unk> und <unk> <unk> .
-<unk> ist das <unk> <unk> <unk> in <unk> für <unk> und <unk> <unk> .
-<unk> <unk> sich jedoch internationale <unk> in eine <unk> <unk> wie <unk> , die <unk> <unk> <unk> ist .
-Wir freuen uns , dass die <unk> der <unk> <unk> <unk> ist , <unk> der letzten <unk> gegen <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> wird heute gegen die <unk> und wird eine neue <unk> der internationalen <unk> für <unk> <unk> .
-<unk> <unk> , die <unk> der <unk> <unk> <unk> .
-<unk> und <unk> wurden durch <unk> <unk> mit den anderen <unk> des <unk> <unk> , <unk> mit <unk> und <unk> <unk> <unk> .
-Das <unk> <unk> ist <unk> <unk> , mit <unk> <unk> .
-<unk> <unk> <unk> sie mit <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> , sowohl mit <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> die <unk> <unk> <unk> mit <unk> , <unk> <unk> mit <unk> , <unk> , <unk> und <unk> <unk> mit <unk> und <unk> <unk> .
-Die <unk> .
+<unk> <unk> wie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> <unk> ist die <unk> <unk> , wenn die <unk> <unk> <unk> .
+Die <unk> <unk> ich in <unk> - ich <unk> von der <unk> .
+<unk> in den <unk> <unk> , und wenn ich <unk> , <unk> ich <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> für ob die <unk> und ihre <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> hat er <unk> &quot; <unk> <unk> <unk> &quot; <unk> <unk> <unk> <unk> .
+Was <unk> , <unk> und eine <unk> ist dieses <unk> <unk> , die er <unk> wurde .
+Ich <unk> eine <unk> <unk> der <unk> .
+Die <unk> ist <unk> <unk> <unk> , weil sie nicht die <unk> <unk> und <unk> <unk> werden .
+Er <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , aber es für <unk> <unk> .
+Diese Frage nur nur wenn <unk> Menschen zu <unk> .
+Wenn die <unk> nicht <unk> , sind <unk> , <unk> , <unk> , <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; für <unk> <unk> .
+&quot; <unk> <unk> wird die <unk> auf diesem Thema <unk> , <unk> &quot; <unk> <unk> .
+<unk> , wenn wir <unk> , <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> er die neuen <unk> in Europa , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , seine <unk> <unk> <unk> .
+<unk> <unk> sind <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> Sie diese <unk> <unk> , <unk> <unk> , <unk> , <unk> .
+Aber wie sie es ?
+<unk> - <unk> auf <unk> .
+<unk> &quot; Wir <unk> , dass die <unk> nicht alle <unk> , <unk> &quot; <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> <unk> <unk> ein <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> die <unk> von <unk> , <unk> und seine Kollegen <unk> <unk> , <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> in <unk> <unk> in <unk> <unk> .
+&quot; <unk> ist ein neue <unk> <unk> , die <unk> <unk> .
+<unk> des <unk> <unk> nicht alle , dass <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> und <unk> .
+Aber in einer <unk> , <unk> , die die <unk> mit <unk> <unk> sind , die <unk> <unk> mit <unk> <unk> sind , <unk> <unk> und weniger <unk> .
+<unk> <unk> ist eine <unk> <unk> , wie <unk> ist eine <unk> neuen <unk> in der <unk> .
+<unk> <unk> , <unk> <unk> und politische <unk> sind die <unk> , <unk> und politische <unk> zu <unk> , wie <unk> <unk> und <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Für einige <unk> , die <unk> der <unk> ist , ist es <unk> , dass Sie nicht <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> , wenn Sie <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+&quot; <unk> <unk> <unk> sich auf den <unk> und <unk> <unk> <unk> .
+&quot; <unk> <unk> <unk> alle , die <unk> , <unk> <unk> .
+<unk> würde die <unk> <unk> ein <unk> <unk> und <unk> <unk> <unk> .
+Ein <unk> der <unk> von <unk> <unk> , <unk> und <unk> <unk> , die <unk> , die ihre <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> , dass die <unk> <unk> , so <unk> <unk> , so dass die <unk> und <unk> <unk> , um eine vielen <unk> zu <unk> .
+&quot; <unk> &quot; <unk> , <unk> <unk> , <unk> , <unk> , <unk> und <unk> der <unk> für <unk> <unk> , <unk> , <unk> und <unk> der <unk> für <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+&quot; Wir <unk> <unk> eine <unk> , die <unk> zu <unk> , die nicht <unk> werden .
+<unk> , <unk> , <unk> , <unk> , <unk> , <unk> in seiner eigenen <unk> und <unk> .
 <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Am <unk> gibt es <unk> <unk> mit weniger als 30 <unk> , gibt es <unk> <unk> mit 25 und <unk> <unk> <unk> mit 25 und <unk> <unk> .
-Die <unk> <unk> nicht aus dem 20 .
-<unk> <unk> <unk> hat nur vier <unk> und <unk> <unk> zwei <unk> und <unk> <unk> <unk> .
-Die <unk> <unk> der <unk> ist <unk> , mit 50 <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-Für <unk> ist die <unk> , zwei mehr als <unk> <unk> und drei <unk> und <unk> .
-<unk> Sie den <unk> auf die <unk> von <unk> <unk> .
-<unk> <unk> ist ein <unk> <unk> .
-In einer <unk> mit <unk> , die <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Es gab mehr als 20 Jahre <unk> , aber die <unk> <unk> <unk> , dass die <unk> der <unk> <unk> ist .
-Dies war <unk> von der <unk> und der <unk> des <unk> <unk> , der <unk> <unk> mit <unk> , <unk> <unk> <unk> .
-Die Gruppe ist der <unk> <unk> im <unk> <unk> zwei <unk> im <unk> von <unk> und <unk> <unk> .
-Das Tag <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Das ist ein <unk> der <unk> , deren <unk> <unk> <unk> werden .
-<unk> Sie aus <unk> <unk> , ist eine <unk> <unk> , das <unk> <unk> <unk> , <unk> und <unk> <unk> .
-<unk> <unk> <unk> ist ein <unk> <unk> <unk> <unk> für uns .
-Das ist nur die zweite Zeit im <unk> und in <unk> <unk> und <unk> .
-Ich <unk> mich auf die <unk> <unk> , die <unk> , <unk> , ist es ein <unk> Land , und ich denke , wir werden uns in einigen <unk> Tage <unk> .
-Wir sind uns <unk> , unsere <unk> zu <unk> .
-Ich <unk> dies , weil es ein <unk> für die <unk> <unk> mit <unk> der <unk> <unk> .
-Was <unk> Sie im <unk> <unk> ?
-<unk> Dank für <unk> dieser Jahre <unk> .
-Es <unk> uns , dass wir uns <unk> Jahre <unk> , um <unk> <unk> , <unk> , <unk> und <unk> <unk> , dass wir uns <unk> <unk> <unk> .
-<unk> Leute , wie die <unk> der <unk> <unk> .
-<unk> Sie eine <unk> von Druck auf Ihrem <unk> ?
-<unk> der <unk> <unk> wir über die <unk> <unk> <unk> in den letzten <unk> der <unk> .
-Wir haben einige <unk> in <unk> <unk> und wir <unk> , dass dieses <unk> uns in <unk> <unk> <unk> .
-Darüber hinaus sind wir uns sehr <unk> , es gibt <unk> .
-Wir <unk> dieses Land , wir <unk> , und die <unk> , für die <unk> , <unk> <unk> ist eine der besten Länder in der Welt .
-<unk> <unk> <unk> <unk> und seine <unk> für <unk> ?
-Wir haben viele <unk> , die in <unk> und <unk> <unk> haben , und ich habe <unk> <unk> , die in <unk> und die <unk> <unk> .
-<unk> <unk> sind <unk> <unk> und <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> , wie wir über <unk> <unk> haben .
-<unk> Sie die <unk> , einem kann mit <unk> <unk> <unk> .
-<unk> haben Sie die <unk> in <unk> <unk> ?
-Wie wir nicht <unk> haben , dann haben wir keine <unk> auf , was wir tun können .
-Wir werden auf eine gute <unk> mit einem <unk> <unk> <unk> , <unk> wir uns eine gute und <unk> <unk> .
-Sie haben nicht die <unk> .
-Wie ist <unk> ?
-Ich denke , dass wir als <unk> <unk> haben , und wir können mehr mehr als <unk> <unk> und alle <unk> <unk> und mehr <unk> , so dass es die <unk> <unk> <unk> .
-Wenn wir uns zwei oder drei <unk> in die <unk> <unk> haben , die uns <unk> haben , dass wir uns <unk> und <unk> <unk> , weil es uns <unk> haben .
-<unk> <unk> ich , dass es auch mehr <unk> und ich <unk> auch mehr für die Menschen <unk> .
-Mit diesem <unk> <unk> Sie 20 Jahre .
-<unk> es nun <unk> <unk> , ist es <unk> ?
-<unk> , <unk> .
-<unk> , ich denke , dass wir die <unk> <unk> , <unk> wir in einer <unk> <unk> und <unk> <unk> <unk> , die wir in einem <unk> Jahren <unk> .
-Wir <unk> unsere <unk> und wir sind sehr <unk> , daß wir gemeinsam <unk> können .
-Wir alle <unk> alle <unk> und <unk> <unk> .
-Wir <unk> uns an der Welt in der Welt , wo wir immer <unk> wollen .
-<unk> könnte wir <unk> <unk> .
-<unk> es ein <unk> Teil des <unk> <unk> ?
-Die <unk> <unk> ist immer ein <unk> , der Gruppe <unk> .
-Wir sind <unk> des <unk> , <unk> und <unk> in <unk> .
-Es ist <unk> , wenn ein <unk> <unk> von Gruppe und es ist <unk> .
-<unk> <unk> , <unk> eine <unk> von Stadt , aber es ist viel <unk> , wenn fünf oder <unk> <unk> <unk> .
-Wir <unk> und <unk> zu <unk> <unk> .
-Ich <unk> noch einige <unk> <unk> .
-Wir waren im <unk> mit <unk> in <unk> und in <unk> <unk> waren , wir waren <unk> mit allen <unk> <unk> <unk> , die wir mit allen <unk> <unk> sind , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-Es ist auch sehr <unk> , dass ein <unk> <unk> ist , dass ein <unk> wie <unk> <unk> ist .
-<unk> , vier <unk> Jahren <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> Ansicht nach sind wir alle <unk> <unk> , doch wir alle über den anderen <unk> <unk> .
-Wir alle alle <unk> und <unk> , gibt es auch ein <unk> <unk> , die die <unk> <unk> <unk> , <unk> .
-Wir <unk> jeder <unk> mit der <unk> Ihres und dieses <unk> nicht <unk> .
-<unk> Sie sich auf die <unk> <unk> nicht <unk> , aber <unk> haben Sie <unk> <unk> .
-Wie <unk> eine <unk> ?
-Wie wir <unk> haben , hat es ein <unk> <unk> .
-<unk> nicht zu <unk> , weil es <unk> ist , die <unk> zu <unk> und Menschen , die Ihr <unk> <unk> .
-<unk> eines <unk> , die Menschen , die Sie <unk> müssen , müssen Sie die <unk> und die <unk> <unk> , ohne die <unk> <unk> , ohne <unk> <unk> zu <unk> und eine <unk> <unk> zu <unk> .
-Wie <unk> Sie Ihre <unk> <unk> <unk> ?
-Ich denke , wir <unk> sehr sehr <unk> und auf dem <unk> <unk> .
-<unk> <unk> wir drei Jahre <unk> und nie <unk> ein <unk> bis nach dem <unk> <unk> <unk> <unk> <unk> .
-Es gab noch viele <unk> <unk> , weil sie so lange <unk> und den <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
-Es war eine <unk> <unk> und <unk> <unk> .
-Die nationalen <unk> <unk> <unk> wird für <unk> das <unk> in <unk> <unk> .
-<unk> es <unk> , dass Sie seine Arbeit , besonders <unk> <unk> , <unk> <unk> und <unk> <unk> .
-<unk> , die <unk> <unk> und die <unk> <unk> , die wir <unk> , dass wir <unk> , was wir <unk> , was <unk> <unk> und <unk> <unk> können .
-<unk> immer immer <unk> die <unk> der <unk> <unk> <unk> ?
-Das ist eine Frage für <unk> <unk> , so weiß ich nicht .
-Er <unk> es , und ich denke , dass er das mit dem ersten <unk> <unk> ist .
-Wie eine <unk> , was Ihre <unk> <unk> ?
-Es gibt so viele .
-<unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> ...
-Es gibt so viele <unk> , dass ich alle <unk> <unk> , daß ich <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Ich denke , dass alle uns eine <unk> <unk> aus dem <unk> <unk> .
-Als der Meinung , es ist <unk> , es ist <unk> , <unk> , <unk> , <unk> und alle <unk> <unk> , die jetzt in der <unk> <unk> ist , und wenn ich denke , weil es <unk> <unk> als <unk> <unk> .
-Bei den ersten <unk> hat sich <unk> <unk> <unk> und nun <unk> werden .
-Wie <unk> dieses <unk> ?
-Die <unk> , weil ich denke , gibt es eine <unk> <unk> , die <unk> <unk> , aber es gibt <unk> , wie sehr <unk> <unk> wie <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Mit einem <unk> <unk> <unk> ich ihnen , wenn ich sie <unk> , und diese <unk> sind <unk> <unk> .
-Ich denke , wenn Sie <unk> , dass Sie <unk> <unk> und einige <unk> in Ihrem <unk> war , und Sie <unk> einen <unk> oder <unk> , diese Dinge <unk> zu <unk> .
-<unk> , ich denke , Sie können einen <unk> und noch <unk> werden , die <unk> ist .
+Aber <unk> <unk> , <unk> die <unk> , ob sie <unk> , ob sie <unk> ist , ob sie <unk> , ob sie <unk> <unk> , <unk> <unk> <unk> <unk> .
+Doch was die <unk> <unk> <unk> <unk> ist , <unk> sie nicht über <unk> , <unk> , <unk> , <unk> <unk> werden ?
+<unk> sind <unk> <unk> , wie sie die <unk> <unk> , <unk> sie <unk> , <unk> , <unk> <unk> .
+&quot; Ich <unk> nicht ein , dass eine <unk> von <unk> zu <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist es als <unk> , die <unk> und ihre <unk> &quot; <unk> &quot; .
+<unk> sind die Frage der <unk> .
+<unk> <unk> ist die <unk> der <unk> , die eine <unk> , <unk> <unk> <unk> .
+Am <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> &quot; <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> ist <unk> <unk> , die eine <unk> <unk> , <unk> <unk> , <unk> <unk> und eine <unk> <unk> <unk> <unk> .
+&quot; <unk> ist nicht für die <unk> in der <unk> <unk> und <unk> <unk> , er <unk> <unk> .
+&quot; <unk> <unk> ist <unk> , um die <unk> und eine <unk> von <unk> zu <unk> .
+<unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; Ich bin <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; Ich <unk> die <unk> , weil Sie Ihre <unk> von <unk> <unk> , die <unk> <unk> und weil es <unk> <unk> .
+&quot; Ich <unk> die <unk> , aber ich bin nicht <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> in der <unk> , weil er &quot; <unk> <unk> ist , nicht <unk> , die <unk> <unk> , die <unk> <unk> zu <unk> .
+<unk> er er <unk> <unk> , <unk> <unk> , die eine <unk> <unk> mit dem <unk> des <unk> <unk> .
+<unk> auch <unk> <unk> , <unk> ich <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> für <unk> <unk> .
+<unk> <unk> und <unk> &quot; <unk> <unk> die <unk> .
+<unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> mit dem <unk> <unk> <unk> <unk> .
+Die <unk> <unk> er <unk> <unk> und <unk> , &quot; eine <unk> <unk> <unk> <unk> .
+Die <unk> war <unk> , aber für mich <unk> , die <unk> <unk> .
+<unk> in einer <unk> <unk> und <unk> <unk> , <unk> <unk> und <unk> in der <unk> und <unk> <unk> und <unk> in der <unk> als <unk> <unk> .
+<unk> <unk> <unk> der <unk> <unk> der <unk> <unk> <unk> <unk> , die er nicht <unk> hat , und ich , dass es keine <unk> <unk> ist .
+Es kann einige <unk> <unk> , dass die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> werden .
+Doch die <unk> nicht <unk> <unk> die <unk> und <unk> , dass ein <unk> <unk> <unk> .
+Die <unk> <unk> ich ein <unk> , aber er <unk> nicht <unk> , &quot; <unk> <unk> <unk> .
+<unk> würde <unk> , wenn er <unk> ist .
 <unk>
-<unk> <unk> <unk> <unk> <unk>
-Die <unk> Präsidentin <unk> wurde <unk> <unk> , um die <unk> von <unk> <unk> zu <unk> , dass seine Familie in der <unk> <unk> , <unk> seine Familie .
-<unk> <unk> , <unk> Jahre <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> , die seine <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> , dass in seiner <unk> eine <unk> für die <unk> des <unk> auf <unk> <unk> <unk> würde , <unk> er sagte , <unk> er sagte , <unk> er <unk> er <unk> <unk> <unk> , weil er er gesagt hat , dass er <unk> <unk> <unk> .
-Er hat <unk> vier <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> ist in <unk> Hinsicht <unk> 2007 in der <unk> <unk> <unk> <unk> .
-Die <unk> 2009 <unk> er zu den 25 Jahren <unk> <unk> <unk> <unk> <unk> <unk> , die in der <unk> Jahren von <unk> <unk> <unk> .
-<unk> <unk> auf <unk> <unk> <unk> <unk>
-Ein <unk> <unk> <unk> von den <unk> <unk> <unk> <unk> , <unk> <unk> und <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Als <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> zwischen <unk> in der Stadt wird im Zentrum der <unk> &quot; <unk> für die <unk> der <unk> und <unk> der politischen Fragen zwischen zwei <unk> <unk> .
-<unk> die <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-In seiner <unk> <unk> <unk> die internationale Gemeinschaft , die <unk> , die <unk> <unk> , eine <unk> , die die <unk> der <unk> und der <unk> <unk> <unk> <unk> .
-<unk> <unk> seit <unk> <unk> der Welt der <unk> <unk> und <unk> Länder mit <unk> <unk> , und hat dies mit der <unk> <unk> <unk> , eine <unk> <unk> zu <unk> .
-Die Regierung hat in <unk> Jahren <unk> , um die <unk> von <unk> <unk> in <unk> zu <unk> , um die &quot; <unk> &quot; <unk> in <unk> zu <unk> .
-Am <unk> , <unk> und <unk> haben seit <unk> eine <unk> <unk> <unk> , die die <unk> zwischen beiden Ländern <unk> .
-Die <unk> <unk> ist mit &quot; <unk> <unk> &quot; .
-<unk> <unk> hat <unk> für <unk> Jahre <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> , die in der <unk> <unk> werden , hat sich die <unk> der <unk> <unk> <unk> <unk> , die <unk> <unk> <unk> , <unk> <unk> <unk> <unk> .
-&quot; <unk> ist die <unk> , die <unk> <unk> <unk> , ohne die <unk> zu sagen , ohne die <unk> der <unk> in <unk> <unk> , während der <unk> des <unk> <unk> .
-<unk> gesagt , dass &quot; <unk> <unk> <unk> &quot; ist das erste <unk> .
-<unk> <unk> <unk> <unk> , dass <unk> in <unk> <unk> &quot; <unk> <unk> &quot; ist eine &quot; <unk> &quot; und <unk> <unk> .
-<unk> sagte , dass &quot; <unk> <unk> &quot; <unk> <unk> &quot; <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> , <unk> <unk> <unk> eine &quot; <unk> des <unk> , das <unk> dieses <unk> <unk> .
-<unk> <unk> <unk> die <unk> zwischen &quot; <unk> &quot; oder einer <unk> , die nur den <unk> der <unk> <unk> , aber die <unk> der <unk> sind in drei <unk> zu <unk> .
-Diese <unk> <unk> <unk> in drei <unk> <unk> auch die <unk> des <unk> , <unk> <unk> , dass keine <unk> nicht <unk> hat .
-In diesem <unk> <unk> <unk> die <unk> des <unk> und <unk> die <unk> <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> Sie die neue <unk> , die <unk> , <unk> und <unk> und auch eine &quot; <unk> &quot; .
-<unk> <unk>
-Herr Präsident , <unk> auf <unk> , dass die <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> , um <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> die <unk> für <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> zu <unk> .
-Bei einem <unk> <unk> , <unk> sagte , dass seine Entscheidung nach dem <unk> der <unk> und <unk> <unk> <unk> , die bereits <unk> <unk> , die bereits <unk> bereits <unk> haben .
-Er <unk> <unk> , dass seine <unk> er nicht &quot; <unk> <unk> &quot; in <unk> <unk> und alle <unk> <unk> hat , <unk> er <unk> .
-<unk> , <unk> <unk> wird <unk> für <unk> und <unk> <unk> <unk> und <unk> <unk> <unk> und <unk> <unk> <unk> <unk> .
-Was von <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> .
-Im <unk> mit der <unk> <unk> <unk> und der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> war <unk> von <unk> Millionen <unk> in der <unk> <unk> , wenn er eine <unk> , die <unk> <unk> , aber die <unk> <unk> und die Fall .
-<unk> <unk> <unk> <unk> <unk> Menschen in <unk> <unk>
-Die <unk> wurde <unk> , die <unk> auf die <unk> der <unk> <unk> der Gesellschaft <unk> .
-Die <unk> der ersten Jahre <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Um dieses <unk> gibt es über die <unk> <unk> <unk> <unk> .
-Die <unk> zur <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> wurde in <unk> mit dem Ziel der <unk> <unk> in <unk> mit <unk> <unk> , <unk> und <unk> Probleme oder <unk> Probleme oder <unk> .
-Die <unk> <unk> am <unk> <unk> <unk> eine großen Zahl der <unk> und <unk> , dass in diese 25 Jahren mit dem <unk> <unk> haben .
-Die <unk> politische <unk> , in der <unk> <unk> , <unk> die <unk> <unk> der <unk> Arbeit zu <unk> .
-<unk> Sie die <unk> der <unk> , <unk> , <unk> und seine <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> in der <unk> <unk> <unk> die <unk> <unk> für <unk> und <unk> , <unk> <unk> und <unk> der <unk> <unk> , <unk> <unk> .
-Er <unk> <unk> in einem <unk> Zeit und <unk> , dass die <unk> <unk> ist , aber <unk> , dass die <unk> Arbeit <unk> .
-Die <unk> <unk> <unk> als Beispiel für <unk> <unk> und <unk> , <unk> mit <unk> .
-&quot; Die Krise ist nicht <unk> , die <unk> und die <unk> zu <unk> .
-Die <unk> <unk> , wo <unk> <unk> <unk> wurde .
-Das <unk> <unk> <unk> der <unk> <unk> , <unk> , <unk> , <unk> , <unk> <unk>
-12 <unk> <unk> die <unk> am <unk> <unk> <unk> <unk> .
-Es scheint , dass die <unk> von den <unk> in <unk> <unk> <unk> <unk> hat .
-<unk> Menschen , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , wo sie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Wenn die <unk> auf dem <unk> <unk> war , wurde <unk> <unk> , um ein <unk> <unk> zu <unk> .
-&quot; <unk> jetzt auf <unk> wird eine <unk> Kontrolle , " sagte , <unk> <unk> .
-Die <unk> <unk> , die <unk> <unk> der <unk> <unk> <unk> , <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die erste drei <unk> waren die <unk> des <unk> <unk> , die <unk> auf zwei Tagen <unk> und die <unk> .
-<unk> die <unk> <unk> ist ein <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
-Die <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> der <unk> <unk> , dass die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , da sie <unk> <unk> für drei <unk> <unk> , während sie in den <unk> 10 <unk> <unk> .
-<unk> ist der <unk> der <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-Die <unk> der <unk> , dass der <unk> so sehr <unk> hat , dass der <unk> so sehr <unk> hat , da <unk> eine <unk> <unk> mit dem <unk> des <unk> und es gibt es <unk> <unk> &quot; <unk> " , da sie &quot; <unk> &quot; <unk> &quot; <unk> .
-Die <unk> <unk> auch <unk> , dass in den letzten <unk> mehr mehr als <unk> <unk> <unk> .
-Die <unk> der <unk> Gruppe , der <unk> <unk> <unk> <unk> in <unk> Woche auf <unk> <unk> , um die <unk> in <unk> zu <unk> und die <unk> der <unk> zu <unk> .
-Die <unk> <unk> <unk> , dass die <unk> <unk> nur eine der <unk> <unk> war , aber über die <unk> <unk> in allen letzten <unk> <unk> und <unk> .
-In diesem Sinne <unk> er , dass es &quot; <unk> ist , ein <unk> zu <unk> und zu <unk> und <unk> gegen den <unk> , die auf der <unk> <unk> wurde .
-<unk> <unk> , die Mitglieder des <unk> <unk> eine <unk> in <unk> <unk> .
-<unk> 30 <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die vier <unk> am <unk> .
-<unk> oder <unk> <unk> ?
-Die <unk> sind über <unk> der <unk> über die <unk> .
-Die <unk> <unk> auf der <unk> <unk> <unk> <unk> .
-Im <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> die <unk> der <unk> <unk> .
-<unk> war es von einem <unk> , in <unk> , <unk> mit dem <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> von <unk> als <unk> <unk> in diesem <unk> .
-Die <unk> wurde nicht <unk> , aber <unk> mit dem <unk> <unk> <unk> <unk> <unk> .
-Das war alle über <unk> , in <unk> <unk> , die <unk> als <unk> <unk> für eine <unk> <unk> <unk> .
-Eine <unk> zur <unk> , keine <unk> .
-<unk> Sie die <unk> oder <unk> <unk> , um die <unk> zu <unk> .
-Die Frage ist <unk> <unk> ?
-Die <unk> , sowohl als auch seine <unk> <unk> als auch für seine <unk> <unk> <unk> <unk> .
-<unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die Tatsache <unk> <unk> , dass ein <unk> <unk> <unk> <unk> und die <unk> , die <unk> wurden .
-<unk>
-Zum <unk> , nach <unk> der <unk> &quot; <unk> &quot; <unk> &quot; <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> werden , dass die größte <unk> in <unk> ist der Strand .
-<unk> Dinge , für seine <unk> <unk> .
-<unk> ist <unk> , &quot; <unk> &quot; <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> , wie <unk> und <unk> mit Erfahrung in den <unk> Welt <unk> .
-<unk> <unk> von der öffentlichen <unk> &quot; , die nach dem <unk> &quot; <unk> &quot; in den <unk> <unk> hat .
-Der erste <unk> ist der <unk> <unk> , wo sich <unk> <unk> .
-&quot; <unk> <unk> ist <unk> der nächsten Schritt , &quot; <unk> , <unk> <unk> .
-&quot; Wir müssen uns der neuen <unk> <unk> , weil die aktuellen &#91; <unk> in <unk> <unk> <unk> <unk> <unk> , um ein <unk> <unk> zu <unk> .
-<unk> der Frage , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> , es ist schon eine gute Arbeit der <unk> , die von der <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
-Und <unk> , <unk> der <unk> der <unk> mit der Stadt ist die <unk> , die <unk> <unk> <unk> , ob diese <unk> <unk> ist , ob er &quot; <unk> &quot; , ob diese <unk> <unk> werden kann .
-<unk> <unk> <unk> , dass die Frage , die <unk> dieses <unk> <unk> ist , weil der <unk> eine <unk> <unk> der <unk> <unk> <unk> <unk> , aber es gibt keine <unk> , <unk> als <unk> <unk> .
-Dieses <unk> <unk> sich in diesem Fall , um <unk> in diesem Fall haben .
-<unk> , ein Projekt für eine der <unk> <unk> in den <unk> und <unk> mit den <unk> des <unk> <unk> .
-Die <unk> sollte der <unk> <unk> , dass die <unk> der <unk> <unk> , eine <unk> der <unk> zwischen <unk> und den <unk> zu <unk> .
-<unk>
-<unk> <unk> , die <unk> <unk> der <unk> <unk> <unk> des <unk> gegen ihn gegen <unk> <unk> <unk>
-Nach der <unk> <unk> Tage <unk> <unk> wird nach dem <unk> <unk> der <unk> <unk> <unk> <unk> <unk> , die eine <unk> <unk> des <unk> der <unk> <unk> <unk> .
-Nach dem <unk> der <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Nach der öffentlichen <unk> , der <unk> <unk> <unk> eine <unk> <unk> gegen die <unk> und <unk> <unk> , <unk> er <unk> und <unk> für 30 Tage .
-<unk> der vier <unk> der <unk> für <unk> <unk> , <unk> er <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-In diesem Sinne <unk> er die <unk> eines <unk> <unk> nach dem <unk> der <unk> und <unk> <unk> .
-Auf der <unk> <unk> <unk> er zu <unk> <unk> für <unk> mit einer <unk> von <unk> <unk> der <unk> <unk> , aber er hat <unk> <unk> gegen <unk> <unk> .
-Die Behörden <unk> ihm , die <unk> in den <unk> <unk> <unk> <unk> <unk> <unk> .
-Auf der <unk> <unk> <unk> er sich um die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Am <unk> , die <unk> <unk> der <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Während der <unk> <unk> <unk> die öffentlichen <unk> <unk> , <unk> <unk> <unk> , ob er <unk> die <unk> und die <unk> der <unk> <unk> <unk> <unk> <unk> , <unk> die <unk> <unk> .
-<unk> der <unk> / <unk> <unk> <unk> ist <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Nach dem <unk> der <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> der <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> er er über die <unk> <unk> <unk> , um die <unk> <unk> zu <unk> .
-Die <unk> <unk> <unk> <unk> <unk> von der <unk> , wo der <unk> <unk> und andere <unk> <unk> .
-Die <unk> der <unk> und <unk> <unk> <unk> , dass die Ergebnisse der <unk> <unk> <unk> <unk> , und <unk> andere <unk> , die <unk> <unk> <unk> <unk> , ohne die <unk> <unk> <unk> <unk> .
-In einer <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> von <unk> und <unk> , dass der <unk> <unk> <unk> , dass die <unk> <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> <unk>
-&quot; Der <unk> , die <unk> <unk> <unk> , die <unk> <unk> <unk> mit <unk> <unk> , wo die <unk> <unk> mit <unk> im <unk> <unk> , wo die <unk> <unk> .
-Er <unk> auch , dass die <unk> der <unk> für <unk> Menschen <unk> , so <unk> sie die <unk> <unk> .
-Er sagte , dass die <unk> <unk> <unk> in der Bereich der <unk> nicht <unk> haben .
-&quot; Im <unk> ist es <unk> , dass es keine <unk> <unk> oder <unk> der <unk> in einem anderen Land <unk> , die <unk> ist , <unk> in einem <unk> Weg .
-&quot; Der <unk> der <unk> für <unk> , <unk> die <unk> <unk> für <unk> <unk> .
-Die <unk> hat von <unk> bis <unk> 30 <unk> .
-<unk> , die <unk> hat es ein <unk> , die Ergebnisse als <unk> <unk> , die Ergebnisse <unk> <unk> , <unk> <unk> <unk> <unk> oder sogar <unk> <unk> .
-<unk> , <unk> <unk> , <unk> <unk> der <unk> und <unk> <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Informationen <unk> <unk> die <unk> eines <unk> <unk> <unk> , <unk> er <unk> .
-<unk> <unk> , <unk> der <unk> , <unk> <unk> <unk> .
-<unk>
-<unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk>
-<unk> <unk> <unk> die <unk> <unk> <unk> für die <unk> des <unk> zwischen <unk> und <unk> <unk> <unk> <unk> <unk> .
-<unk>
-Es ist <unk> , dass sich die <unk> der <unk> eine <unk> <unk> <unk> und <unk> <unk> <unk> werden .
-<unk> der <unk> .
-Die <unk> der <unk> und der letzten <unk> der <unk> <unk> <unk> <unk> <unk> die <unk> <unk> des <unk> <unk> <unk> .
-<unk>
-Die Informationen <unk> <unk> , dass die <unk> in einem <unk> und <unk> <unk> .
-Die <unk> der <unk> <unk> , dass die <unk> <unk> in <unk> <unk> <unk> .
-Es gab nicht <unk> von <unk> oder <unk> .
-Im Bereich des <unk> gibt es auch <unk> <unk> im <unk> der <unk> , einige <unk> oder <unk> .
-<unk> Ergebnisse <unk> <unk> die <unk> <unk> <unk> mit der <unk> .
-Während der <unk> gibt es im <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> die <unk> , in dem es <unk> <unk> sind .
-Die Informationen zu <unk> , dass die <unk> <unk> <unk> mit dem <unk> <unk> haben .
-Nach einer <unk> <unk> in einem <unk> Gebiet als die <unk> <unk> , die <unk> <unk> sind , gibt es keine <unk> <unk> der <unk> , die die <unk> der <unk> <unk> ist .
-<unk>
-<unk>
-Die <unk> <unk> <unk> <unk> hat <unk> , dass ein <unk> für die <unk> Kinder und <unk> Menschen <unk> , <unk> und <unk> , die <unk> der <unk> von <unk> in <unk> und <unk> &quot; <unk> <unk> &quot; , <unk> &quot; <unk>
-In einer <unk> , die <unk> der <unk> <unk> in <unk> der <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> <unk> .
-Die <unk> ist durch <unk> und <unk> <unk> von der <unk> <unk> <unk> <unk> und der <unk> für <unk> und <unk> .
-Die <unk> <unk> die Bevölkerung oder nicht <unk> , durch die <unk> <unk> der <unk> in der <unk> <unk> , wo es <unk> wird , dass die <unk> Kinder , alle <unk> von <unk> <unk> <unk> .
-Er <unk> <unk> , dass die <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> und seit <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Er <unk> , dass die <unk> dieses <unk> für die <unk> und die Bedeutung von <unk> in <unk> und <unk> <unk> die <unk> für <unk> <unk> <unk> <unk> .
-Auf der <unk> <unk> <unk> wird die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> für die <unk> Kinder und <unk> für die <unk> und <unk> .
-Sie werden auch über <unk> <unk> <unk> und <unk> <unk> <unk> , um <unk> , die <unk> , die <unk> , <unk> oder <unk> zu <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> sagte , dass dieses <unk> die <unk> der <unk> für die <unk> <unk> in Kinder <unk> .
-<unk> <unk> <unk> zwischen <unk> und 2006 <unk> , dass ein <unk> der <unk> <unk> <unk> , und <unk> <unk> in den Fall der <unk> in <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> .
-Er sagte , die <unk> der <unk> auf anderen <unk> <unk> .
-Er <unk> <unk> , dass auf der <unk> ein <unk> <unk> der <unk> <unk> <unk> und fünf <unk> <unk> und <unk> <unk> ist .
-Er <unk> , dass die <unk> der <unk> <unk> in der <unk> <unk> <unk> die <unk> <unk> , die <unk> und <unk> <unk> ist .
-Die <unk> , die die <unk> <unk> für die <unk> <unk> ist , ist eine <unk> <unk> der Kinder , die <unk> <unk> oder <unk> <unk> .
-<unk> <unk> er sagte , <unk> der <unk> <unk> auf die <unk> und <unk> <unk> der <unk> von <unk> und <unk> .
-Die Informationen <unk> mit <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
-<unk> <unk> <unk> , es gibt drei <unk> , die <unk> , <unk> und andere <unk> <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
-<unk> ist es , dass die <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-<unk> wäre <unk> <unk> .
-<unk> <unk> , ein <unk> im <unk> von <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk>
-Wenn das <unk> von den <unk> <unk> <unk> wurden , würde sie über <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-In seiner <unk> <unk> <unk> der <unk> , <unk> <unk> , dass die <unk> <unk> ist , dass er eine <unk> <unk> <unk> ist .
-<unk> <unk> sagte , dass dieses <unk> <unk> in <unk> <unk> werden , wo die <unk> <unk> <unk> werden kann , wo der <unk> <unk> ist , <unk> und <unk> <unk> <unk> .
-Er <unk> , dass die <unk> <unk> Teil einer <unk> von <unk> <unk> <unk> <unk> , <unk> <unk> und andere von <unk> <unk> <unk> <unk> .
-Die <unk> <unk> der <unk> in der <unk> , dass <unk> <unk> in der <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Dies bedeutet , dass die <unk> der <unk> <unk> nicht <unk> ist , aber ist die <unk> in <unk> <unk> <unk> und <unk> , <unk> die <unk> in <unk> <unk> .
-<unk> <unk> <unk> , dass die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> der letzten drei <unk> .
-<unk> Sie die <unk> <unk> <unk> , <unk> der <unk> , <unk> und <unk> .
-<unk> der <unk> , die diese <unk> <unk> , <unk> er sagte , ist <unk> mit <unk> .
-Wenn die <unk> und <unk> <unk> <unk> , wird es die <unk> , sehr gut zu <unk> .
-Wenn die <unk> <unk> <unk> würde , <unk> die <unk> <unk> .
-Auf dem <unk> <unk> er <unk> , ist er <unk> ein <unk> <unk> <unk> , die <unk> von <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Seit diesem ist die <unk> , die mit der <unk> des <unk> <unk> , muss eine <unk> <unk> als die <unk> <unk> und <unk> <unk> .
-<unk> der <unk> <unk> , <unk> und <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> werden werden .
-Die <unk> , besonders <unk> , <unk> und <unk> sind auch eine sehr <unk> <unk> , besonders <unk> , <unk> , weil er <unk> die <unk> der <unk> <unk> .
-Wenn der <unk> <unk> ist , <unk> die <unk> und die <unk> <unk> und <unk> <unk> , <unk> , <unk> , <unk> <unk> .
-In der <unk> eines <unk> <unk> er bereits <unk> , ist der erste , die <unk> <unk> und nur nach dem <unk> <unk> <unk> , dass die <unk> <unk> , aber die <unk> ist ein <unk> , der <unk> <unk> <unk> <unk> .
-<unk> ein Mitglied des <unk> <unk> , die in der <unk> eines <unk> <unk> ist , ist es <unk> , die <unk> von <unk> und <unk> <unk> , um die <unk> <unk> zu <unk> .
-<unk> <unk> sagte , dass es noch immer immer viel <unk> und Arbeit <unk> ist , für die <unk> mit <unk> und <unk> <unk> mit <unk> und <unk> zu <unk> .
-<unk> <unk> ich die neuen <unk> <unk> ?
-<unk> der <unk> , die <unk> <unk> für die <unk> des <unk> <unk> .
-Die <unk> <unk> ihre <unk> <unk> von <unk> .
-<unk> wieder <unk> <unk> mit der <unk> des <unk> <unk> <unk> .
-Dies ist <unk> <unk> <unk> <unk> mit <unk> <unk> , <unk> die <unk> <unk> und die <unk> , die die neuen <unk> der neuen <unk> <unk> .
-<unk> <unk> <unk> in <unk> , wo <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> Sie den <unk> Frage .
-<unk> war <unk> ?
-Die erste <unk> <unk> im <unk> des <unk> , ihre <unk> <unk> , die <unk> ist , dass sie <unk> und <unk> <unk> ist ?
-Um die <unk> <unk> <unk> <unk>
-&quot; Ich kann noch eine <unk> <unk> , ich glaube , es ist eine <unk> , und ich denke , dass die <unk> , die meine <unk> <unk> &quot; <unk> ist .
-<unk> <unk> <unk> ich &quot; <unk> und <unk> &quot; <unk> ist es ein <unk> der <unk> <unk> , ein <unk> , eine <unk> <unk> , ein <unk> <unk> , eine <unk> <unk> , eine <unk> , ein <unk> <unk> , ein <unk> <unk> <unk> .
-Eine Antwort , dass die <unk> nicht <unk> , &quot; <unk> und <unk> <unk> für die <unk> <unk> haben .
-Aber nach dem <unk> <unk> <unk> er <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> Und Sie bitte eine <unk> <unk> &quot; <unk> &quot; <unk> ist es ein <unk> <unk> &quot; .
-<unk> die <unk> <unk> , dass <unk> <unk> von <unk> <unk> .
-Die <unk> , die für die <unk> , die <unk> , die <unk> , die <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> .
-Und die <unk> in ihrer beiden <unk> in <unk> <unk> , die in den beiden <unk> <unk> wurde und während ihr zwei <unk> <unk> .
-<unk> ist es <unk> , dass sie die <unk> und die <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> , ein <unk> der <unk> &quot; <unk> <unk> &quot; , dass die Tatsache , dass die Tatsache <unk> , dass die <unk> <unk> , <unk> &quot; <unk> ist , <unk> &quot; <unk> <unk> ist , <unk> &quot; <unk> .
-<unk> , <unk> <unk> , die <unk> <unk> und <unk> <unk> .
-<unk> <unk> ist <unk> , dass <unk> die <unk> über ihre <unk> <unk> <unk> , die die <unk> der <unk> <unk> <unk> .
-Daher ist es zwei Tagen vor der internationalen <unk> der internationalen <unk> <unk> <unk> , <unk> sie <unk> ein <unk> <unk> , die soziale <unk> zu <unk> .
-&quot; <unk> <unk> ist nicht <unk> für eine <unk> <unk> , müssen wir uns nicht mehr <unk> und <unk> <unk> <unk> , um die <unk> <unk> zu <unk> .
-Es gibt auch auch eine <unk> , die für ihre <unk> <unk> , die <unk> <unk> <unk> , <unk> und <unk> <unk> , weil die <unk> <unk> <unk> , weil die <unk> <unk> ist , weil sie <unk> <unk> , weil die <unk> <unk> sind , weil die <unk> <unk> <unk> <unk> .
-Die <unk> der <unk> <unk> <unk> <unk> , dass <unk> <unk> nicht die <unk> <unk> , <unk> , <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> .
-<unk> , die <unk> <unk> , der <unk> <unk> , <unk> <unk> <unk> , dass die <unk> der <unk> <unk> <unk> <unk> wurde .
-&quot; Die <unk> sind <unk> , aber <unk> <unk> nicht wissen , wie sie <unk> .
-<unk> <unk> war es nicht <unk> und hier ist es <unk> .
-<unk> <unk> , die von der <unk> <unk> <unk> ist , wurde <unk> <unk> <unk> , dass dieses <unk> die <unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> oder nicht , die <unk> ist , dass heute eine Jahr von <unk> , nicht als <unk> , sondern <unk> , sondern <unk> , dass die Möglichkeit , die <unk> in einer Reihe von <unk> <unk> hat .
-<unk> <unk> sie sich in <unk> als eine der <unk> , die durch <unk> <unk> <unk> , die durch <unk> , <unk> <unk> in <unk> <unk> .
-<unk> wurde <unk> der <unk> Person , die die <unk> <unk> <unk> .
-Ein <unk> <unk> <unk> in <unk> wie die <unk> der <unk> <unk> <unk> .
-Die Arbeit dieser <unk> ist ein <unk> <unk> .
-Auf <unk> <unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> in der Woche war die <unk> der &quot; <unk> für <unk> <unk> <unk> <unk> , die <unk> Jahre <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Im Anfang des <unk> <unk> <unk> <unk> in <unk> <unk> , wo er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Im Herzen des <unk> und nach dem <unk> <unk> <unk> er in <unk> , die <unk> der <unk> und <unk> <unk> <unk> , <unk> die <unk> der <unk> und <unk> .
-Die Woche der <unk> gegen <unk> <unk> <unk> er gegen drei Tage zu <unk> .
-<unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> er mit einem <unk> , <unk> .
-<unk> <unk> er zwei <unk> und war <unk> , zwei <unk> zu <unk> , die die <unk> <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Aber wenn er mit der <unk> <unk> <unk> , ist es sehr <unk> , dass er seine <unk> nicht <unk> wurde , war es sehr <unk> , dass er <unk> <unk> .
-Er war <unk> <unk> , <unk> , <unk> und <unk> <unk> .
-Aber die <unk> <unk> nicht .
-<unk> eines <unk> <unk> , <unk> , ein <unk> , ein <unk> , <unk> und eine <unk> , <unk> der <unk> mit <unk> der <unk> .
-<unk> <unk> hat nicht <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> , die <unk> von <unk> wurde <unk> <unk> , die <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-<unk>
-Zum <unk> <unk> von <unk> aus <unk> der <unk> <unk> <unk> <unk> <unk> von Präsident <unk> <unk> <unk> <unk> <unk> .
-Die Leute sind nicht <unk> .
-Die <unk> <unk> ist ein <unk> <unk> , ohne <unk> , <unk> und <unk> <unk> können .
-<unk> von der <unk> <unk> , die <unk> <unk> , <unk> und <unk> und <unk> der <unk> dieser <unk> .
-Wann haben die <unk> <unk> oder <unk> nicht <unk> .
-Wir werden ihre <unk> und <unk> sie in den <unk> <unk> .
-Die <unk> <unk> <unk> , dass <unk> eine <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> und Geld zu <unk> .
-&quot; Der <unk> sind <unk> , weil sie <unk> nicht <unk> sind , aber in diesem Fall ist es <unk> , dass die <unk> des <unk> in <unk> <unk> <unk> <unk> , <unk> er <unk> <unk> .
-Die <unk> können auch <unk> oder <unk> <unk> werden .
-Sie haben <unk> einen <unk> <unk> mit <unk> <unk> .
-<unk> war es <unk> , dass ein <unk> <unk> der <unk> und <unk> <unk> werden kann .
-<unk> <unk> dies nicht , dass es die <unk> <unk> wird .
-Ein <unk> <unk> von <unk> <unk> , die in <unk> oder <unk> <unk> <unk> sind .
-Wenn sie sich <unk> ist , ist eine <unk> oder <unk> <unk> .
-Nach der <unk> sind <unk> , die <unk> <unk> , die <unk> <unk> , <unk> oder <unk> .
-&quot; Das Problem ist , dass es viele <unk> noch viele <unk> gibt , &quot; sagte <unk> <unk> .
-Er <unk> <unk> , dass alles <unk> <unk> <unk> ist .
-<unk> <unk> als <unk> <unk> , nicht alles <unk> , sondern <unk> <unk> in einer <unk> .
-Doch wenn es <unk> kann , ist das <unk> <unk> .
-<unk> Der <unk> <unk> &quot; <unk> in <unk>
-<unk> von <unk> wurden in <unk> <unk> <unk> .
-Im <unk> <unk> die <unk> und <unk> zu einem <unk> <unk> .
-Die Mitglieder des <unk> <unk> <unk> <unk> <unk> <unk> die Behörden einer <unk> <unk> <unk> , wenn sie unter dem Schutz eines <unk> <unk> <unk> , <unk> unter den Schutz eines <unk> <unk> .
-<unk> von <unk> <unk> <unk> die <unk> <unk> , wo sie sich in <unk> <unk> haben , um die <unk> zu <unk> , während der <unk> <unk> <unk> <unk> <unk> .
-&quot; Unser <unk> ist , wenn der <unk> nicht <unk> , dass es uns nicht <unk> , dass die <unk> nicht <unk> , dass es <unk> <unk> und <unk> <unk> , <unk> &quot; <unk> <unk> <unk> <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> , dass die Antwort der &quot; <unk> <unk> &quot; <unk> <unk> &quot; , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Bei einem <unk> <unk> wurden die <unk> <unk> , aber dann ist die <unk> <unk> und <unk> <unk> , die auch <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> <unk> , die mehrere <unk> sind <unk> , <unk> , wo ein <unk> von <unk> <unk> bereits <unk> hat , ihre Unterstützung der <unk> <unk> zu <unk> .
-<unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> der <unk> gibt es aber <unk> und <unk> <unk> , dass <unk> die <unk> <unk> und <unk> <unk> <unk> , die die <unk> <unk> .
-Die <unk> <unk> <unk> die Mitglieder des <unk> <unk> und <unk> &quot; <unk> <unk> , die nach dem <unk> <unk> des <unk> oder <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> , weil der <unk> , die <unk> , die <unk> <unk> , die <unk> der öffentlichen <unk> und <unk> waren , die <unk> <unk> <unk> , <unk> <unk> <unk> nicht <unk> .
-Die <unk> <unk> die <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> er <unk> die <unk> der <unk> , weil es &quot; <unk> &quot; <unk> &quot; <unk> und <unk> &quot; <unk> &quot; <unk> <unk> &quot; <unk> und <unk> &quot; <unk> &quot; <unk> <unk> &quot; <unk> und <unk> <unk> &quot; <unk> <unk> &quot; für die Qualität der <unk> .
-&quot; Die <unk> dieses <unk> wurde <unk> , dass <unk> <unk> die <unk> der <unk> für <unk> <unk> <unk> , <unk> &quot; <unk> der <unk> <unk> .
-Die <unk> der &quot; <unk> <unk> &quot; auch die <unk> <unk> , dass sie <unk> <unk> <unk> &quot; <unk> <unk> , <unk> <unk> und <unk> <unk> , um die <unk> in den letzten zwei Monate <unk> zu <unk> .
-<unk> <unk> wird in einer <unk> <unk> <unk> <unk> <unk>
-<unk> mit <unk> <unk> und andere <unk> <unk> , wird sie <unk> auf die <unk> <unk> " <unk> " <unk> " <unk> <unk> <unk> <unk>
-Die <unk> <unk> <unk> hat in &quot; <unk> &quot; <unk> in &quot; <unk> &quot; in &quot; <unk> &quot; , &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> <unk> <unk> die <unk> , die <unk> mit &quot; <unk> &quot; <unk> <unk> und andere <unk> <unk> , werden <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> heute <unk> der <unk> in <unk> , in der <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Im <unk> , <unk> ein gut <unk> .
-<unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk>
-<unk> <unk> durch <unk> <unk> und <unk> <unk> , die in <unk> <unk> in <unk> <unk> <unk> .
-Seit Anfang der letzten <unk> wurde die Wirtschaft <unk> <unk> <unk> , noch <unk> von der <unk> <unk> , <unk> in einem <unk> <unk> , <unk> , <unk> in einer <unk> <unk> <unk> .
-Die erste <unk> von <unk> über die <unk> <unk> <unk> <unk> <unk> von <unk> Millionen Euro <unk> <unk> <unk> <unk> <unk> .
-Nach drei <unk> <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> im zweiten <unk> , für die <unk> der <unk> <unk> in <unk> - <unk> auch die <unk> <unk> von <unk> bis <unk> <unk> .
-Die <unk> kann in der <unk> im <unk> von <unk> <unk> <unk> , die von der <unk> und der <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> , die von <unk> bis <unk> <unk> wurde , die ersten <unk> nach <unk> <unk> .
-Die <unk> der <unk> ist jedoch nicht <unk> , dass die <unk> auf die Krise <unk> , <unk> von <unk> zu <unk> , <unk> von <unk> zu <unk> .
-<unk> hat die <unk> der <unk> <unk> , die jetzt <unk> <unk> der <unk> <unk> .
-Diese <unk> <unk> <unk> , <unk> von der <unk> für <unk> , <unk> und <unk> Aktivitäten .
+<unk> die <unk> der <unk> <unk> in <unk> 5 , die <unk> , die ich <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Aber was <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist ein <unk> , <unk> und <unk> <unk> , aber er war auch ein <unk> <unk> und <unk> <unk> .
+<unk> in <unk> , <unk> <unk> <unk> die <unk> <unk> der <unk> <unk> , und er <unk> die <unk> <unk> der <unk> <unk> , und er <unk> <unk> für eine <unk> , <unk> , <unk> .
+<unk> <unk> hat es <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ein <unk> <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Es war <unk> <unk> <unk> &quot; <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+Diese <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> dieses <unk> und <unk> .
+Die <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Und <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Es gibt auch auch <unk> <unk> , wo er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> von <unk> , die <unk> oder die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Es ist eine <unk> , die <unk> <unk> <unk> <unk> &quot; <unk> <unk> , aber es gibt der <unk> und <unk> über die <unk> <unk> .
+Er hat eine <unk> für die <unk> <unk> <unk> werden .
+<unk> gibt es in <unk> <unk> , es <unk> <unk> und <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> er ein <unk> <unk> , ein <unk> <unk> zu <unk> .
+Die <unk> in <unk> in <unk> , <unk> ich <unk> &quot; <unk> &quot; <unk> und <unk> <unk> <unk> <unk> , dass die <unk> der <unk> <unk> ist .
+<unk> <unk> sie <unk> , wie sie <unk> , <unk> <unk> <unk> in <unk> .
+Das <unk> ich mich .
+<unk> <unk> auf <unk> seine <unk> zu <unk> .
+<unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
 <unk> der <unk>
-<unk> <unk> ist der &quot; <unk> &quot; <unk> &quot; <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Mit einem <unk> <unk> , die Produkte sind <unk> <unk> , ein <unk> für eine Land , deren <unk> <unk> <unk> ist .
-<unk> oder <unk> , <unk> die <unk> für ihre <unk> zwischen <unk> und <unk> .
-Als <unk> <unk> der <unk> Länder der EU , der <unk> Regierung <unk> nicht die <unk> <unk> .
-&quot; Wir müssen das <unk> <unk> , dass <unk> <unk> werden bleiben , dass die <unk> von <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> sind nicht <unk> .
-Die <unk> für <unk> und <unk> <unk> <unk> <unk> , dass die <unk> in <unk> <unk> <unk> <unk> <unk> .
-Die <unk> , die die <unk> in der Wirtschaft Wirtschaft <unk> , dass die <unk> <unk> <unk> .
-Da es vier <unk> vier <unk> <unk> , <unk> zu <unk> .
-Die <unk> <unk> sogar <unk> die <unk> , die in der <unk> der <unk> <unk> ist , da sie <unk> <unk> <unk> .
+<unk> <unk> die &quot; <unk> &quot; <unk> &quot; , die er mit <unk> <unk> <unk> <unk> , dass er mit <unk> <unk> <unk> <unk> und <unk> <unk> <unk> für <unk> .
+Die <unk> wurde <unk> <unk> über die <unk> , aber <unk> &quot; <unk> hier in <unk> <unk> .
+Er <unk> , wie er <unk> und <unk> <unk> , würde er die <unk> von <unk> ein <unk> <unk> , die eine <unk> <unk> und <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> , was wir <unk> haben , dass wir uns <unk> <unk> , dass <unk> <unk> , dass die <unk> von <unk> <unk> <unk> werden .
+<unk> <unk> , <unk> wir nicht mehr , aber wir wissen , aber wir wissen , dass eine <unk> <unk> , die eine <unk> <unk> - und ich <unk> nicht <unk> .
+Die <unk> von <unk> <unk> , dass er <unk> und <unk> <unk> <unk> , <unk> die <unk> über die <unk> der <unk> in der <unk> und <unk> zu <unk> .
+Als <unk> der <unk> <unk> <unk> wurde in der <unk> der <unk> <unk> <unk> , um die <unk> <unk> in <unk> zu <unk> .
+<unk> in <unk> mit <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+In der <unk> des <unk> <unk> die <unk> für die <unk> <unk> , die eine <unk> <unk> <unk> , <unk> er <unk> <unk> in der <unk> und <unk> <unk> .
+<unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist ein <unk> <unk> auf , es war es in der <unk> und <unk> <unk> <unk> , wie sie <unk> <unk> und <unk> <unk> .
+<unk> hat eine der <unk> <unk> , die die <unk> <unk> <unk> , die <unk> <unk> <unk> , wo er <unk> &quot; <unk> &quot; <unk> &quot; <unk> .
+Es war <unk> als <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , und ich in <unk> mit dem <unk> .
+Ich möchte ein <unk> <unk> <unk> , wie ein <unk> und <unk> <unk> für die <unk> <unk> .
+<unk> <unk>
+<unk> in der <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> in seiner <unk> , wie er <unk> werden , eine <unk> von <unk> <unk> , <unk> er <unk> <unk> , <unk> er <unk> <unk> , <unk> <unk> <unk> , <unk> er <unk> <unk> .
+<unk> auf nur 4 Tage <unk> , <unk> er <unk> , <unk> <unk> und <unk> der <unk> <unk> .
+<unk> <unk> , <unk> er die <unk> <unk> , <unk> er in <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> Tage <unk> wir eine <unk> , die <unk> , die <unk> <unk> , die <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk>
+<unk> <unk> er die <unk> von <unk> , <unk> <unk> <unk> die <unk> in der <unk> , die viele <unk> <unk> , <unk> <unk> <unk> <unk> .
+&quot; <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Sie haben eine <unk> der <unk> <unk> , so die <unk> nicht <unk> .
+<unk> <unk> und <unk> <unk> ist es <unk> der <unk> , die <unk> <unk> , die <unk> <unk> und die <unk> <unk> <unk> .
+Die <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+Das <unk> <unk> ...
+<unk> wäre die gesamte <unk> .
+Es ist <unk> <unk> , die <unk> , die <unk> <unk> der <unk> ...
+Sie <unk> <unk> von <unk> .
+<unk> <unk> und <unk> <unk>
+<unk> ist ein <unk> <unk> von <unk> zwischen einem <unk> und einem <unk> , <unk> , <unk> , <unk> und <unk> .
+Sie <unk> eine <unk> über die <unk> der <unk> .
+Es gibt <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+Sie haben <unk> <unk> <unk> - diese <unk> - diese <unk> - <unk> .
+<unk> ist es in <unk> , um <unk> zu <unk> , um die <unk> <unk> zu <unk> , <unk> und <unk> zu <unk> .
+<unk> <unk> , dass <unk> <unk> <unk> , <unk> <unk> <unk> .
+Wir <unk> eine <unk> <unk> über <unk> <unk> .
+Es ist <unk> <unk> , dass die Menschen , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Wenn nicht für <unk> <unk> , würde sie in anderen <unk> <unk> .
+<unk> und <unk> <unk> mit <unk> <unk> wie <unk> <unk> <unk> <unk> <unk>
+Die <unk> <unk> die <unk> der <unk> <unk> auf <unk> <unk> <unk> die <unk> <unk> , wenn es eine <unk> <unk> , <unk> <unk> , <unk> und <unk> <unk> <unk> .
+Die <unk> war <unk> , wenn alle <unk> <unk> <unk> für eine <unk> <unk> <unk> .
+<unk> des <unk> ist ein <unk> <unk> von <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> , die <unk> , eine <unk> <unk> <unk> , ist eine <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , dass die <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> <unk> wurde <unk> <unk> <unk> , die <unk> <unk> in den <unk> der <unk> .
+Die <unk> wurde in einer <unk> <unk> <unk> <unk> <unk> .
+In <unk> wurde die <unk> der <unk> <unk> und eine <unk> <unk> der <unk> <unk> .
+Die <unk> <unk> im <unk> <unk> und <unk> .
+Die <unk> <unk> haben <unk> <unk> <unk> <unk> <unk> für <unk> .
+Und das <unk> <unk> <unk> <unk> .
+<unk> sind <unk> von der <unk> <unk> , dass die <unk> der <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> , die <unk> <unk> der <unk> <unk> und <unk> auf <unk> der <unk> <unk> in den <unk> <unk> <unk> <unk> .
+Die <unk> <unk> der <unk> und <unk> auf die <unk> <unk> von <unk> und <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> .
+Die <unk> <unk> <unk> und <unk> auf eine <unk> <unk> mit <unk> , <unk> , <unk> , <unk> .
+<unk> <unk> und <unk> in <unk> für diese <unk> <unk> <unk> und ist <unk> .
+<unk> und <unk> haben sich <unk> <unk> , die <unk> <unk> <unk> die <unk> mit <unk> <unk> wie die <unk> <unk> .
+Und <unk> &quot; <unk> , <unk> , <unk> , <unk> , <unk> ist ein <unk> <unk> .
+<unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
+<unk> <unk> als <unk> <unk> in der <unk> <unk> , wenn die erste <unk> <unk> , die <unk> <unk> <unk> <unk> .
+<unk> haben die <unk> für die <unk> <unk> von <unk> von <unk> <unk> , <unk> , dass sie sich in <unk> <unk> <unk> .
+<unk> hat keine <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Es ist <unk> <unk> , wenn ein <unk> <unk> für 2 <unk> <unk> <unk> .
+Doch es ist der <unk> <unk> , wenn die <unk> <unk> <unk> und die <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> wie <unk> ist , <unk> <unk> die <unk> des <unk> <unk> <unk> <unk> .
+In einer <unk> <unk> <unk> die <unk> <unk> <unk> , dass die <unk> in der <unk> drei Jahre <unk> <unk> <unk> .
+<unk> über die <unk> <unk> seine <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> von <unk> <unk> in <unk> .
+Die <unk> <unk> auch eine <unk> <unk> , <unk> <unk> , <unk> die <unk> der <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> ist wichtig , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> &quot; <unk> &quot; <unk> <unk> &quot; .
+<unk> <unk> sind <unk> von den <unk> <unk> .
+<unk> nicht nur nicht nur <unk> , sondern eine <unk> in <unk> <unk> , sondern eine <unk> in <unk> <unk> , weil es die <unk> der <unk> <unk> , die <unk> <unk> <unk> .
+Das ist <unk> wichtig , weil sie <unk> werden , die <unk> zu <unk> oder <unk> <unk> zu <unk> , wenn <unk> <unk> , <unk> <unk> .
+<unk> ist ein <unk> <unk> , &quot; er <unk> <unk> .
+Die <unk> <unk> <unk> <unk> <unk> <unk> in der <unk> für <unk> und <unk> auf <unk> <unk> <unk> " <unk> " <unk> " <unk> " <unk> " <unk> <unk> <unk> " <unk> <unk> " <unk> " <unk> <unk> " <unk> <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> <unk>
+<unk> der <unk> in der <unk> befindet sich im <unk> <unk> in vier <unk> <unk> , <unk> <unk> , <unk> mit dem <unk> .
+Die <unk> , <unk> <unk> , <unk> <unk> und <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> der <unk> <unk> in <unk> <unk> .
+<unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Herr Präsident , <unk> <unk> <unk> , die <unk> für <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> die <unk> in der <unk> für <unk> des <unk> <unk> <unk> , oder <unk> .
+&quot; Die <unk> von <unk> <unk> <unk> die gesamte <unk> und besonders <unk> ist <unk> , nicht nur für die <unk> , aber die <unk> , nicht nur für die <unk> , sondern in einer <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+&quot; Sie <unk> unsere <unk> , unsere <unk> , <unk> <unk> , <unk> , <unk> und <unk> , <unk> , <unk> und <unk> , <unk> , <unk> und <unk> , <unk> , <unk> und <unk> <unk> .
+<unk> <unk> <unk> für <unk> <unk> , <unk> die <unk> in 2000 .
+Doch es ist eine <unk> , und <unk> in <unk> ist ein wichtiger Schritt in der <unk> .
+Die <unk> ist die <unk> <unk> in <unk> .
+<unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> .
+<unk> , ein <unk> für die <unk> der <unk> <unk> <unk> , oder <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
+<unk> <unk> , die <unk> für die <unk> <unk> <unk> <unk> , oder <unk> , die die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> auch die <unk> <unk> <unk> .
+<unk> <unk> <unk> der <unk> <unk> der <unk> <unk> , <unk> <unk> und <unk> die anderen <unk> , um die Ergebnisse zu <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> , <unk> und <unk> .
+Es ist <unk> der <unk> <unk> , und er <unk> <unk> , eine <unk> gegen <unk> in <unk> zu <unk> .
+<unk> hat <unk> <unk> .
+Ein <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Für die <unk> ist jedoch die <unk> <unk> <unk> , eine <unk> der <unk> <unk> .
+Die <unk> <unk> , die <unk> in den <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> <unk> auf <unk> <unk>
+Die <unk> <unk> <unk> hat <unk> <unk> , China zu <unk> und China zu <unk> , um die <unk> der <unk> <unk> zu <unk> .
+<unk> <unk> , die <unk> <unk> der <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Ich <unk> gegen <unk> &#91; <unk> &#93; , <unk> , China , China , China , <unk> , China , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> in diesem Bereich .
+&quot; <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+&quot; <unk> <unk> werden auf einige <unk> <unk> , sondern es nicht <unk> .
+&quot; <unk> <unk> wenn China <unk> und <unk> <unk> werden .
+Europa ist der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Im <unk> Tagen <unk> die <unk> <unk> <unk> <unk> <unk> und die <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> die <unk> <unk> in Europa hat <unk> , dass es die <unk> der <unk> in Europa <unk> , die <unk> <unk> , die <unk> <unk> zu <unk> , um <unk> zu <unk> .
+Herr <unk> <unk> , dass ein <unk> <unk> <unk> werden , um die <unk> von <unk> zu <unk> , sondern auch <unk> <unk> <unk> , die Europäische <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> <unk> die <unk> , die <unk> und <unk> , <unk> er <unk> .
+&quot; <unk> <unk> und <unk> haben wir eine <unk> <unk> .
+<unk> ist nicht eine <unk> , weil sie <unk> , weil wir die <unk> für <unk> <unk> <unk> und Frauen <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , eine <unk> auf <unk> <unk> in den USA <unk> , <unk> er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> &quot; <unk> &quot; <unk> <unk> werden , dass die <unk> von 50 und <unk> auf <unk> und <unk> <unk> <unk> .
+<unk> <unk> , die <unk> <unk> des <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Herr <unk> , <unk> <unk> <unk> , dass die <unk> <unk> <unk> <unk> &quot; <unk> &quot; <unk> &quot; <unk> .
+Die <unk> der <unk> von <unk> pro <unk> in <unk> und <unk> <unk> <unk> <unk> <unk> <unk> .
+Ich <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> .
+<unk> <unk> von <unk> über <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> hat <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> &quot; <unk> <unk> <unk> <unk> für die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+Er <unk> ich , dass <unk> <unk> und die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> <unk> , <unk> in diesem <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> wäre <unk> mit <unk> , die unsere <unk> und <unk> <unk> <unk> .
+Die <unk> wäre <unk> <unk> , <unk> <unk> <unk> .
+&quot; <unk> <unk> <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+&quot; <unk> <unk> wäre <unk> , <unk> in der <unk> und der <unk> <unk> , dass die <unk> der <unk> <unk> .
+&quot; <unk> <unk> wäre <unk> , <unk> in <unk> <unk> , um <unk> <unk> und <unk> zu <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> eines <unk> auf die <unk> <unk> würde eine <unk> <unk> des <unk> <unk> .
+Die <unk> sind <unk> , &quot; die <unk> <unk> in einer <unk> <unk> <unk> <unk> , wenn sie die <unk> <unk> .
+&quot; <unk> ist keine <unk> , dass wir mit , und es ist <unk> nicht <unk> , dass wir die <unk> nicht <unk> .
+&quot; <unk> ist eine <unk> , die nationalen <unk> der nationalen <unk> , und es sollte nicht <unk> werden .
+Die <unk> <unk> und die <unk> von <unk> und die <unk> von <unk> wird <unk> <unk> , um die <unk> von <unk> zu <unk> .
+<unk> hat die <unk> <unk> <unk> <unk> , <unk> er <unk> <unk> , <unk> er die <unk> <unk> und <unk> <unk> , die er <unk> wurde .
+Im <unk> Woche <unk> die <unk> <unk> ein <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist ein <unk> ohne <unk> .
+<unk> ist ein <unk> ohne <unk> .
+<unk> ist ein <unk> <unk> ohne <unk> <unk> .
+Die <unk> ist ein <unk> <unk> , ein <unk> <unk> , <unk> und <unk> ohne <unk> <unk> <unk> .
+<unk> ist ein <unk> , die <unk> <unk> , <unk> , <unk> und <unk> <unk> zu <unk> .
+<unk> ist es <unk> <unk> .
+Im <unk> und <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Und <unk> Kolleginnen und Kollegen <unk> , dass einige der <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+Das Liste der <unk> <unk> <unk> , eine <unk> <unk> <unk> , eine neue <unk> , die <unk> <unk> , die neue <unk> <unk> und die neue <unk> <unk> .
+<unk> <unk> und <unk> die <unk> , die einige <unk> <unk> <unk> <unk> in <unk> <unk> in <unk> <unk> , aber seine <unk> ist ein <unk> <unk> .
 <unk>
-<unk> sagte , dass <unk> <unk> werden , aber <unk> werden nicht <unk> <unk> <unk> .
-Mit <unk> <unk> <unk> <unk> und <unk> <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> , die der neuen <unk> Regierung von <unk> <unk> ist , mehr von der <unk> von politischen <unk> zu <unk> .
-<unk> die neuen <unk> <unk> , <unk> <unk> <unk> <unk> , dass keine <unk> <unk> und <unk> <unk> , dass er seine <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
-&quot; Der <unk> dieser Regierung ist <unk> die <unk> des <unk> <unk> <unk> , <unk> &quot; <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Ein <unk> von <unk> <unk> , die <unk> der <unk> <unk> , die <unk> der <unk> <unk> und neue <unk> gegen den <unk> <unk> werden .
-<unk> der <unk> <unk> jedoch nicht der <unk> über seine <unk> &quot; , <unk> &quot; <unk> <unk> <unk> , aber es ist nicht <unk> .
-Die <unk> wurde in seiner <unk> <unk> <unk> und die <unk> , die die <unk> <unk> <unk> , die die <unk> <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> , und <unk> <unk> <unk> er <unk> er <unk> er nicht <unk> .
-Doch die Europäische Kommission , noch <unk> eine <unk> von den <unk> <unk> <unk> , <unk> <unk> , die <unk> , die <unk> , die <unk> <unk> und dieses <unk> <unk> .
-Die <unk> <unk> , <unk> <unk> , sagte der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Das <unk> <unk> noch noch eine <unk> für die <unk> .
+Ein <unk> im <unk> <unk> <unk> , wie <unk> und <unk> sind in <unk> und <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> Woche <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> hat <unk> und <unk> Länder .
+<unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Und dann werden nicht einer <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> von <unk> und <unk> sind <unk> <unk> .
+Es gibt <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> in <unk> zu <unk> .
+<unk> , die die <unk> <unk> <unk> werden , sind eine <unk> , die <unk> und <unk> <unk> .
+Wie <unk> <unk> <unk> wir <unk> ?
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , viele <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> .
+<unk> <unk> oder &quot; <unk> <unk> , &quot; <unk> ist ein <unk> <unk> für alle <unk> , <unk> und <unk> .
+<unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
+<unk> der <unk> ist , dass die <unk> <unk> über <unk> <unk> haben .
+<unk> <unk> <unk> Sie in <unk> .
+Sie sind nicht als <unk> , <unk> , <unk> oder <unk> .
+<unk> <unk> nicht , dass die <unk> <unk> <unk> und <unk> <unk> werden .
+Ein <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Ich <unk> <unk> <unk> und <unk> die <unk> <unk> in der <unk> und <unk> <unk> von <unk> , <unk> , <unk> oder <unk> .
+<unk> sind <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Wir wissen , dass die <unk> mehr als <unk> <unk> , die <unk> <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Wir wissen , dass Sie auch <unk> , dass Sie eine <unk> als <unk> <unk> , die Sie <unk> haben , um <unk> zu <unk> .
+Wie Sie <unk> , wenn <unk> <unk> ist ?
+<unk> <unk> Sie Ihre <unk> <unk> .
+Das ist <unk> <unk> .
+Es ist ein <unk> <unk> für <unk> <unk> .
+<unk> Sie Ihre <unk> , <unk> , <unk> , <unk> .
+Sie <unk> wissen , wenn die <unk> alle <unk> die <unk> alle <unk> <unk> , so dass Sie nicht <unk> <unk> <unk> , wenn Sie <unk> <unk> in der <unk> <unk> .
+<unk> <unk> <unk> für <unk> <unk> und <unk> .
+<unk> diese <unk> <unk> <unk> , nicht <unk> .
+<unk> <unk> , die <unk> <unk> , wenn die <unk> <unk> , wenn die <unk> ihre <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> oft <unk> <unk> , dass eine <unk> in <unk> <unk> ist .
+<unk> , die <unk> auf Ihre <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> sind <unk> .
+<unk> <unk> <unk> <unk> &quot; , wenn <unk> eine <unk> <unk> <unk> &quot; <unk> &quot; , wenn es <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+Dies <unk> die Antwort <unk> , wenn <unk> und <unk> oft eine <unk> <unk> .
+Es <unk> keine <unk> <unk> für <unk> <unk> , sondern <unk> <unk> <unk> <unk> <unk> .
+Diese <unk> wird die <unk> der <unk> von <unk> <unk> <unk> in ihrer <unk> und <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> , die <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> er <unk> <unk> , wird die <unk> <unk> der <unk> <unk> <unk> <unk> , und ist das <unk> <unk> <unk> <unk> .
+Die <unk> <unk> die <unk> des <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Das <unk> der <unk> <unk> in <unk> Woche würde es eine Entscheidung , die <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> und die <unk> <unk> <unk> .
+&quot; <unk> ist ein <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> .
+Die neue <unk> <unk> der <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> , in einem <unk> <unk> <unk> wurde , <unk> die Entscheidung , die <unk> , und <unk> unterstützen .
+Die <unk> würde von <unk> auf die <unk> <unk> .
+Es wäre <unk> <unk> pro Tag von der <unk> in <unk> .
+Für <unk> wäre es <unk> <unk> <unk> .
+Es ist <unk> von <unk> , aber <unk> von <unk> <unk> <unk> , die auf der <unk> <unk> <unk> <unk> .
+Doch <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> die <unk> der <unk> <unk> <unk> <unk> <unk> die <unk> nur nur <unk> <unk> <unk> , sondern die <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist ob eine <unk> von <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Die anderen ist , ob eine <unk> <unk> , die die <unk> <unk> hat , die <unk> <unk> <unk> , weil er <unk> <unk> ist .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Ein <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> in einer <unk> in der <unk> der <unk> , wo sie die <unk> in <unk> <unk> .
+<unk> &quot; <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Es war <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> <unk> <unk> die <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> de <unk> <unk> de <unk> de <unk> de <unk> de <unk> de <unk> de <unk> de <unk> .
+&quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> die <unk> <unk> .
+&quot; <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+&quot; <unk> &quot; <unk> &quot; <unk> Ich habe nicht <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> hat eine <unk> von <unk> und <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> <unk> in der <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+Die <unk> war <unk> <unk> , dass sie <unk> , <unk> <unk> .
+<unk> , die <unk> <unk> ein <unk> <unk> für eine <unk> von <unk> , aber <unk> nicht <unk> .
+<unk> <unk> und <unk> ist nicht <unk> für <unk> .
+Die <unk> <unk> <unk> , aber die <unk> <unk> , <unk> er <unk> <unk> , <unk> er <unk> <unk> , <unk> er <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> ist die <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> ist <unk> <unk> , besonders wenn die <unk> eines <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> <unk>
+Im ersten Jahr der <unk> <unk> <unk> <unk> , die <unk> <unk> die <unk> und die <unk> , <unk> <unk> und <unk> <unk> .
+<unk> ist ein Land , die in der <unk> <unk> <unk> <unk> , <unk> mit dem ersten Jahr der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> <unk> <unk> , nicht nur <unk> <unk> von <unk> für die <unk> <unk> , aber sie <unk> die <unk> des <unk> <unk> in <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> Sie die Bericht der <unk> von <unk> , <unk> von den <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> in der <unk> <unk> hat <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
 <unk>
-Die <unk> <unk> der &quot; <unk> &quot; <unk> in <unk> <unk> , in <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> der <unk>
-<unk> &quot; <unk> hat sich in der Rolle einer <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> , dass die <unk> in <unk> auf die <unk> der <unk> <unk> , die den vergangenen <unk> in der <unk> von <unk> <unk> .
-Die <unk> <unk> der <unk> <unk> <unk> in <unk> mit dem &quot; <unk> &quot; , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> ist &quot; <unk> &quot; noch &quot; <unk> &quot; , <unk> und <unk> mit &quot; <unk> <unk> <unk> , der die <unk> der neuen <unk> und <unk> für Frauen , &quot; und <unk> für Frauen , &quot; <unk> <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk>
-Es gibt &quot; <unk> &quot; und &quot; <unk> <unk> <unk> wir <unk> .
-Die <unk> <unk> <unk> nicht nur als <unk> für Debatte , sondern auch als <unk> , das <unk> &quot; <unk> <unk> .
-<unk> , <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> für die <unk> <unk> in <unk> und in der <unk> der Welt ist <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> &quot; .
-<unk> die <unk> dieses <unk> als &quot; <unk> <unk> der <unk> der <unk> <unk> &quot; <unk> <unk> &quot; für 15 Jahre <unk> .
-<unk> <unk> <unk> ein <unk> <unk> von den ersten <unk> in <unk> und anderen <unk> wie auch in <unk> , <unk> , <unk> , deren <unk> mit diesem <unk> <unk> <unk> .
-<unk> <unk> <unk> die <unk> <unk> <unk> , die in der Aussprache und der <unk> der <unk> gegen <unk> .
-&quot; <unk> <unk>
-<unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> &quot; ist ein <unk> <unk> &quot; .
-<unk> <unk> sie ein <unk> , die Zusammenarbeit mit den <unk> in <unk> <unk> <unk> , so ist es ein &quot; <unk> <unk> .
-<unk> <unk> <unk> ein <unk> und <unk> <unk> <unk> , die Regierungen der <unk> und nicht <unk> <unk> , &quot; Regierungen der <unk> der <unk> und nicht <unk> .
-<unk> <unk> ist der <unk> <unk> in der Zusammenarbeit .
-Die <unk> für <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> in <unk> in der <unk> ist <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> <unk> wir heute eine <unk> der <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
 <unk>
-Die erste Tag der <unk> <unk> der Union <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk>
-Die Zukunft Europas nicht <unk> , dass die <unk> der <unk> über die <unk> der <unk> <unk> und die <unk> <unk> <unk> , die die Regierung über <unk> <unk> wird , die die Regierung über <unk> <unk> wird .
-Die <unk> <unk> der Europäischen Kommission , der von der <unk> , wurde <unk> <unk> <unk> .
-<unk> von <unk> <unk> , nur <unk> <unk> gegen <unk> und <unk> aus <unk> .
-Die <unk> <unk> <unk> , die sie <unk> und dann ein <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> der <unk> und der <unk> ist <unk> <unk> , ist <unk> <unk> , aber mehr Europa <unk> .
-<unk> nur weil Europa <unk> <unk> , sondern <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Für die <unk> ist die Zeit der <unk> für eine <unk> in Europa .
-Diese <unk> <unk> der Vertrag von Lissabon , ist es auch möglich , die <unk> der Europäischen Union zu <unk> , sondern auch die <unk> der Europäischen Union <unk> , um einen <unk> zu <unk> .
-Dies ist <unk> , <unk> , <unk> der Vorschläge der Vorschläge des <unk> , deren <unk> <unk> ist .
-<unk> , es ist nicht <unk> , dass die <unk> <unk> dieser <unk> <unk> ist , <unk> es <unk> und die <unk> der <unk> <unk> , die auch <unk> <unk> ist .
-Doch die <unk> ist .
-<unk> , die <unk> von <unk> Mehrheit der <unk> der Europäischen <unk> <unk> <unk> <unk> <unk> die Abstimmung über <unk> <unk> des <unk> der Europäischen <unk> , die <unk> <unk> <unk> .
-<unk> Sie den <unk> in ihren <unk> <unk> , um <unk> <unk> zu <unk> , aber sie ist nicht <unk> , die <unk> <unk> zu <unk> , aber sie <unk> nicht <unk> .
-Die <unk> auf Europa <unk> eine <unk> auf den Bedeutung der &quot; <unk> <unk> , &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> , dass in der <unk> der <unk> <unk> ist , ist auch ein <unk> <unk> .
+&quot; <unk> Teil der Menschen , die die <unk> in einem <unk> <unk> , in der <unk> der <unk> in den Vereinigten Staaten hat <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk>
+Die <unk> <unk> von <unk> <unk> , wenn die <unk> <unk> <unk> <unk> <unk> , wenn <unk> die <unk> <unk> , die <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+<unk> <unk> und <unk> <unk> eine <unk> <unk> <unk> , ist der <unk> der <unk> <unk> <unk> <unk> der <unk> <unk> und <unk> <unk> .
+Die <unk> <unk> der <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk>
+<unk> der <unk> in der <unk> <unk> und <unk> <unk> , in der <unk> in <unk> <unk> und <unk> <unk> in <unk> <unk> .
+Die <unk> der <unk> <unk> der <unk> <unk> der <unk> <unk> der <unk> <unk> der <unk> der <unk> <unk> der <unk> <unk> <unk> .
+<unk>
+<unk> die <unk> der <unk> <unk> , der <unk> <unk> , in der <unk> der <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk>
+<unk> <unk> , die erste Jahr der <unk> <unk> <unk> <unk> , <unk> eine <unk> der Regierung .
+<unk> <unk> <unk> , <unk> der <unk> <unk> der <unk> <unk> <unk> <unk> <unk> , dass eine <unk> <unk> der <unk> <unk> <unk> , <unk> die <unk> <unk> <unk> .
+<unk> <unk> die <unk> der Wirtschaft in <unk> dieses Jahr <unk> , um die <unk> <unk> dieses Jahr in <unk> zu <unk> , dass wir unsere <unk> <unk> , die <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk>
+<unk> <unk> <unk> <unk> , dass die <unk> so <unk> <unk> <unk> der <unk> der <unk> <unk> und <unk> <unk> .
+&quot; <unk> <unk> <unk> ist die <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk>
+<unk> <unk> <unk> , <unk> der <unk> &quot; <unk> " <unk> " <unk> in <unk> , <unk> , dass die <unk> eine <unk> <unk> <unk> .
+Die <unk> , <unk> wir <unk> , dass es <unk> ist , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk>
+<unk> Herr Präsident , die Bedeutung der <unk> von <unk> zu <unk> <unk> die <unk> der Regierung .
+&quot; <unk> möchte ich die Regierung <unk> , um <unk> <unk> in verschiedenen <unk> zu <unk> , <unk> er <unk> <unk> .
+Er <unk> , dass die <unk> <unk> <unk> in seiner eigenen <unk> der <unk> <unk> <unk> .
+&quot; <unk> gibt es <unk> , dass die Regierung <unk> <unk> <unk> <unk> , und was ich <unk> <unk> , dass es <unk> ist .
+<unk> <unk> <unk>
+<unk> Jahren <unk> in <unk> und ein <unk> von <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> , dass die <unk> <unk> <unk> ist , ist <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , für die <unk> gegen <unk> <unk> <unk> .
+<unk> <unk> <unk> / <unk> / <unk> / <unk> / <unk> / <unk> / <unk> / <unk> / <unk> / <unk> / <unk> / <unk> / <unk> / <unk> <unk> wurde der <unk> <unk> .
+<unk> <unk> wurde ein <unk> <unk> <unk> , wo er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Für diesen <unk> wurde die <unk> der <unk> <unk> <unk> und die <unk> zwischen den <unk> der <unk> <unk> und der <unk> <unk> <unk> .
+Es muss <unk> <unk> werden .
+Die <unk> <unk> , in der <unk> <unk> wie <unk> , <unk> der <unk> und <unk> für <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> .
+Die <unk> der <unk> <unk> <unk> <unk> , die <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Er <unk> , dass die <unk> in diese drei drei <unk> <unk> ist , ist der <unk> von <unk> 2007 <unk> <unk> , die <unk> <unk> in der <unk> <unk> .
+Sie haben <unk> mit einem <unk> <unk> und viele <unk> <unk> , da sie sich nicht eine <unk> <unk> haben , weil es <unk> <unk> , die uns <unk> und sie sind <unk> .
+Ich <unk> , dass in der <unk> der <unk> <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , <unk> <unk> , dass die <unk> der <unk> nicht <unk> .
+<unk> <unk> , dass die <unk> nicht die <unk> <unk> , weil die <unk> <unk> nicht die <unk> <unk> und die <unk> <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> <unk> ,
+<unk> gibt es eine <unk> der <unk> <unk> , mit der <unk> dieser <unk> <unk> , <unk> <unk> , dass die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> muss die <unk> mit <unk> <unk> und viele <unk> <unk> .
+<unk> <unk> <unk> &quot; <unk> in <unk> in <unk> in <unk> .
+Die <unk> von <unk> mit <unk> ist eine der <unk> wichtige <unk> , die die <unk> in den letzten Jahren <unk> <unk> hat .
+Die <unk> <unk> der <unk> <unk> der <unk> <unk> der <unk> und <unk> des <unk> gegen die <unk> der <unk> und <unk> des <unk> gegen die <unk> <unk> <unk> <unk> .
+Ein <unk> <unk> , <unk> die <unk> der <unk> , <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Mit diesem <unk> <unk> die <unk> <unk> von der <unk> <unk> für die <unk> von <unk> <unk> für die <unk> von <unk> <unk> für die <unk> , <unk> und <unk> .
+Die <unk> <unk> von der <unk> <unk> <unk> <unk> , <unk> die <unk> der <unk> , weil die <unk> der <unk> und <unk> <unk> ist .
+<unk> <unk> , <unk> <unk> , <unk> <unk> und <unk> <unk> <unk> für die <unk> .
+Mit diesem <unk> , die die <unk> und die <unk> der <unk> zwei <unk> <unk> , um die <unk> , die <unk> , die <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> .
+In der <unk> &quot; <unk> &quot; war auch die <unk> <unk> <unk> , ohne die <unk> der <unk> <unk> , ohne <unk> in den <unk> der <unk> <unk> .
+In seiner <unk> , die <unk> <unk> er nicht mit der <unk> des <unk> in der <unk> , dass die <unk> keine <unk> nicht <unk> werden kann .
+<unk> <unk> ich , dass die <unk> der <unk> <unk> , &quot; und <unk> , dass die <unk> der <unk> <unk> , <unk> und <unk> , dass die <unk> der <unk> <unk> .
+Die <unk> von <unk> , <unk> ist eine der <unk> wichtige <unk> , die die <unk> in den letzten Jahren <unk> <unk> , <unk> und <unk> <unk> .
+<unk> die <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> Fragen .
+Diese Probleme , die <unk> <unk> , <unk> <unk> die <unk> der <unk> <unk> " " " " " " <unk> " <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> , dass ein <unk> Zahl der Länder über die <unk> <unk> hat , und hat jetzt die <unk> , die <unk> <unk> <unk> <unk> <unk> .
+Es kann nicht <unk> , dass die Regierung von <unk> <unk> <unk> , dass die <unk> <unk> , dass die <unk> der <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> die Möglichkeit eines &quot; <unk> in <unk> .
+<unk> Sie die Daten von <unk> , die <unk> zwischen den ersten und <unk> <unk> zu <unk> .
+Die Möglichkeit von <unk> <unk> &quot; <unk> &quot; ist eine <unk> wie die <unk> <unk> dieses Jahr in <unk> , wo man die <unk> von <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+In diesem Fall hat die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Wie wird es <unk> werden , <unk> nicht die <unk> oder die <unk> <unk> der <unk> oder die <unk> <unk> <unk> , weil er <unk> <unk> <unk> .
+Die <unk> <unk> <unk> , die <unk> , die <unk> <unk> , die <unk> <unk> der <unk> <unk> und <unk> &quot; <unk> und <unk> &quot; <unk> &quot; .
+<unk> über die Möglichkeit der &quot; <unk> &quot; &quot; <unk> &quot; , die mit der <unk> der <unk> <unk> <unk> <unk> , die mit dem <unk> der <unk> <unk> <unk> wird .
+<unk> , die <unk> <unk> von einer oder <unk> <unk> <unk> <unk> <unk> die Ergebnisse des <unk> <unk> nicht <unk> <unk> .
+<unk> <unk> die <unk> in allen <unk> des <unk> <unk> <unk> <unk> , wenn es eine <unk> der <unk> zwischen der <unk> und / / oder der <unk> der <unk> der <unk> <unk> ist , die <unk> der <unk> <unk> ist .
+<unk> <unk> wird die <unk> <unk> , wenn die <unk> zwischen den <unk> und der <unk> <unk> <unk> , <unk> <unk> , dass die <unk> zwischen den <unk> und die <unk> der <unk> <unk> <unk> <unk> .
+Es sollte <unk> <unk> , dass in diesem Situation die <unk> <unk> , wo man die <unk> zwischen den ersten und der ersten <unk> <unk> <unk> .
+<unk>
+<unk> <unk> werden in der <unk> von <unk> , <unk> die <unk> .
+Die <unk> der <unk> <unk> <unk> <unk> in <unk> , seine <unk> , <unk> , <unk> und <unk> <unk> .
+<unk> Sie die <unk> der <unk> <unk> <unk> <unk> in der <unk> des <unk> .
+<unk> ein <unk> <unk> mit der anderen <unk> , die <unk> in der <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Im <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Im <unk> <unk> <unk> <unk> die <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> <unk> sollte <unk> , und seine <unk> zu <unk> , um <unk> zu <unk> und seine <unk> zu <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> <unk> <unk> <unk> alle seine <unk> <unk> , <unk> <unk> , dass er in <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> hat nicht nicht <unk> , dass er <unk> <unk> <unk> in der <unk> <unk> , aber immer <unk> , dass eine <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> , dass er <unk> wurde , <unk> er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk>
+<unk> <unk> hat die <unk> <unk> der <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk>
+<unk> <unk> die <unk> Tage <unk> <unk> , wenn er <unk> <unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> sind <unk> in der <unk> <unk> <unk> <unk>
+Die <unk> <unk> die <unk> <unk> in <unk> <unk> , die <unk> <unk> in <unk> <unk> <unk> , die <unk> in <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> auf <unk> <unk> des <unk> <unk> , um die <unk> des <unk> <unk> <unk> .
+<unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> der <unk> <unk> eine <unk> <unk> mit <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> ist ein <unk> <unk> mit <unk> <unk> und <unk> <unk> .
+Die gesamte <unk> sind <unk> .
+<unk> Sie die <unk> <unk> <unk> <unk> <unk> in einer anderen <unk> , da es sich nicht auf die <unk> <unk> .
+In einer <unk> der <unk> <unk> sind <unk> von einer <unk> <unk> <unk> <unk> und <unk> <unk> <unk> in <unk> und <unk> .
+<unk>
+Die <unk> <unk> <unk> <unk> <unk> die <unk> der <unk> <unk> <unk> , <unk> eine <unk> , die <unk> <unk> , die <unk> <unk> <unk> , <unk> <unk> und <unk> <unk> .
+<unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Sie haben drei <unk> <unk> und ein <unk> <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+Die <unk> <unk> auf <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> sie <unk> und <unk> die <unk> , eine <unk> und <unk> <unk> .
+<unk> , in diesen <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Es ist <unk> der <unk> <unk> in der <unk> , China und <unk> .
+<unk> sind die neue <unk> Regierung <unk> <unk> .
+Die <unk> <unk> <unk> , <unk> <unk> , wird morgen mit der <unk> der <unk> in <unk> <unk> , um die neue Regierung , die die <unk> <unk> , die <unk> <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die
+Die <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> und <unk> mit dem Präsident <unk> in <unk> <unk> , um die <unk> der <unk> <unk> , die <unk> <unk> zu <unk> .
+Ein <unk> von der <unk> <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Es ist <unk> <unk> , eine <unk> <unk> von <unk> , <unk> es ist <unk> , wenn die neue <unk> wird .
+<unk> <unk> ich die <unk> <unk> , die <unk> , die <unk> mit den politischen <unk> in seiner <unk> <unk> zu <unk> .
+<unk> möchte ich meine <unk> <unk> in der <unk> der <unk> <unk> , <unk> , <unk> , <unk> , die <unk> europäische <unk> zu <unk> .
+<unk> hat nicht <unk> , dass er eine Regierung <unk> <unk> , aber die <unk> der <unk> <unk> <unk> , dass die <unk> der <unk> <unk> <unk> .
+<unk> ist nun <unk> , <unk> er sehr <unk> .
+<unk> hat die <unk> ein <unk> <unk> <unk> <unk> , <unk> <unk> als die <unk> , während der <unk> eine politischen und <unk> <unk> <unk> <unk> .
+Die neue <unk> der <unk> von <unk> <unk> müssen <unk> <unk> , muss die <unk> eine <unk> <unk> <unk> , um die <unk> in <unk> zu <unk> .
+<unk> der EU auf <unk> , die <unk> <unk> , <unk> die <unk> der <unk> <unk> <unk> <unk> <unk> , die <unk> , die <unk> und <unk> <unk> <unk> .
+<unk> <unk> , <unk> der <unk> <unk> " <unk> <unk> " , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Wir <unk> , dass dieses Vorschlag der <unk> für die <unk> dieses <unk> <unk> .
+<unk> der <unk> von <unk> <unk> <unk> <unk> <unk> der <unk> <unk> <unk> <unk> , die <unk> , die <unk> , die <unk> zu <unk> .
+&quot; <unk> ist , dass die <unk> der <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+Die Unterstützung der <unk> , die <unk> in <unk> , ist <unk> <unk> , weil jetzt <unk> , weil jetzt viele <unk> <unk> <unk> hat .
+<unk>
+<unk> der Regierung muss die neue Regierung <unk> <unk> , die die <unk> <unk> , die <unk> <unk> <unk> werden .
+<unk> <unk> oder <unk> in den <unk> , um ein <unk> und <unk> zu <unk> .
+Die <unk> <unk> der <unk> <unk> <unk> <unk> , dass eine <unk> von <unk> <unk> <unk> wird .
+<unk> <unk> auf <unk> seine <unk> mit dem <unk> <unk> , <unk> und <unk> , als auch mit <unk> und <unk> <unk> .
+<unk> <unk> wird seine <unk> <unk> .
+<unk> <unk> wurde <unk> von <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> ein <unk> <unk> in der vergangenen Woche wurde <unk> , dass die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> mit einer <unk> von <unk> <unk> <unk> <unk> <unk> <unk> werden .
+<unk> hat <unk> , dass er die <unk> <unk> , die <unk> <unk> <unk> , <unk> die <unk> <unk> , die <unk> <unk> , die mir <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> er er <unk> , <unk> er in seiner <unk> <unk> , aber die <unk> <unk> <unk> , dass es nur von <unk> <unk> <unk> , <unk> <unk> .
+<unk> <unk> <unk> <unk> , dass die <unk> <unk> und <unk> zwischen den <unk> <unk> <unk> <unk> .
+Die <unk> der <unk> ist <unk> als das <unk> der <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Im <unk> <unk> <unk> nur ein <unk> <unk> <unk> <unk> <unk> <unk> .
+Ein <unk> <unk> , <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> die <unk> und Europa <unk> <unk> , ist eine <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die Reihe von <unk> wurde <unk> <unk> in <unk> <unk> .
+<unk> <unk> <unk> in der <unk> und in <unk> <unk> der <unk> <unk> und in <unk> <unk> <unk> und <unk> <unk> .
+<unk> <unk> die <unk> <unk> <unk> <unk> in <unk> <unk> für <unk> und <unk> .
+Die <unk> <unk> , die eine <unk> internationalen <unk> in einem Bereich <unk> , <unk> , die die <unk> <unk> in <unk> <unk> ist .
+Wir <unk> , dass die <unk> der <unk> <unk> ist , ist die <unk> <unk> , die <unk> <unk> <unk> mit <unk> in <unk> <unk> <unk> .
+<unk> wird heute gegen die <unk> und <unk> ein <unk> <unk> für <unk> <unk> .
+<unk> <unk> , die <unk> <unk> , hat <unk> <unk> .
+<unk> und <unk> wurde <unk> <unk> mit den anderen <unk> der <unk> <unk> , <unk> mit <unk> und <unk> <unk> .
+<unk> im <unk> <unk> <unk> <unk> , <unk> <unk> .
+<unk> <unk> <unk> sie mit <unk> , <unk> , <unk> , <unk> und <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+Im <unk> <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> nur 10 <unk> <unk> <unk> <unk> <unk> , <unk> <unk> mit <unk> , <unk> mit <unk> , <unk> mit <unk> und <unk> <unk> mit <unk> .
+<unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> nicht <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> von <unk> ist <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> mit <unk> .
+Die <unk> <unk> , <unk> <unk> ist die <unk> , zwei mehr als <unk> <unk> und drei <unk> .
+<unk> <unk> der <unk> für <unk> <unk>
+<unk> <unk> ist ein <unk> <unk> .
+In einer <unk> mit <unk> <unk> die <unk> <unk> <unk> , <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Es gibt noch mehr als 20 Jahren <unk> , aber die <unk> <unk> , dass die <unk> für die <unk> in den Land <unk> .
+Das war <unk> der <unk> und <unk> <unk> , die <unk> mit <unk> , die <unk> mit <unk> , <unk> .
+Die <unk> ist der <unk> <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Das Hotel <unk> <unk> wird in der <unk> <unk> <unk> <unk> <unk> mit dem <unk> der <unk> <unk> <unk> <unk> .
+Dies ist eine <unk> der <unk> , deren <unk> <unk> <unk> <unk> <unk> in <unk> <unk> .
+<unk> Sie die <unk> von <unk> <unk> , ist ein <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> werden ?
+<unk> <unk> ist ein <unk> <unk> für uns <unk> .
+Dies ist nur unsere zweiten <unk> in <unk> und <unk> <unk> .
+Ich habe mich <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> sind wir <unk> , unsere <unk> zu <unk> .
+<unk> ist es , dass es ein <unk> <unk> , um die <unk> der <unk> mit <unk> <unk> zu <unk> .
+<unk> Sie <unk> <unk> <unk> <unk> ?
+<unk> mit uns mit <unk> <unk> .
+Es ist uns <unk> <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> und <unk> <unk> , dass wir uns <unk> <unk> .
+<unk> <unk> , wie Sie Ihre <unk> <unk> , wie die <unk> des <unk> <unk> .
+<unk> dieses <unk> eine <unk> der <unk> ?
+<unk> der <unk> <unk> wir über die <unk> <unk> in der letzten <unk> .
+Wir haben ein <unk> <unk> <unk> in <unk> und <unk> , dass wir uns in <unk> <unk> <unk> <unk> .
+<unk> sind wir sehr <unk> <unk> .
+Wir <unk> dieses Land , die <unk> , <unk> <unk> , <unk> <unk> ist eine der <unk> Länder in der Welt .
+Wie <unk> Sie <unk> <unk> und seine <unk> für <unk> ?
+Wir haben einige <unk> , die <unk> und <unk> <unk> , die in <unk> und die <unk> <unk> .
+<unk> <unk> sind ein <unk> <unk> und <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> der <unk> , eine <unk> , <unk> , <unk> mit <unk> <unk> .
+<unk> haben Sie die <unk> in <unk> <unk> ?
+Als wir haben nicht <unk> , wenn wir keine <unk> nicht <unk> können .
+Wir werden die <unk> <unk> <unk> <unk> mit einem <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Sie <unk> die <unk> .
+Wie <unk> <unk> ?
+Ich glaube , die <unk> , weil wir mehr als <unk> <unk> und <unk> <unk> können .
+Wenn wir zwei zwei oder drei <unk> <unk> haben , <unk> wir <unk> , dass wir keine <unk> und <unk> <unk> haben , weil wir uns die <unk> <unk> , die uns <unk> haben , die <unk> , die wir <unk> haben , die uns <unk> haben , die <unk> , die wir <unk> haben , die <unk> <unk> , die wir <unk> haben , die <unk> <unk> , die wir <unk> haben , die uns <unk> haben , die <unk> , die wir <unk> haben , die uns <unk> haben , die <unk> , die wir <unk> haben ,
+Das ist <unk> <unk> für uns , und ich glaube , dass es mehr <unk> für die Menschen .
+Mit diesem <unk> werden Sie 20 Jahren <unk> <unk> .
+<unk> alle <unk> haben wir <unk> ?
+<unk> .
+<unk> <unk> ich <unk> , dass wir in einer <unk> <unk> und <unk> dieses <unk> <unk> werden .
+Wir <unk> unseren <unk> und wir sind sehr <unk> , dass wir <unk> <unk> können .
+Wir <unk> alle <unk> und <unk> <unk> <unk> .
+Wir <unk> uns auf die <unk> in der Welt , wo wir eine <unk> <unk> <unk> .
+<unk> würde uns nicht <unk> .
+<unk> ist es für Ihre <unk> Teil der <unk> <unk> ?
+<unk> ist eine <unk> , die <unk> <unk> <unk> .
+Wir sind sehr <unk> , <unk> und <unk> in <unk> .
+Die <unk> , wenn eine <unk> <unk> von <unk> und es ist <unk> .
+<unk> <unk> , <unk> eine <unk> von <unk> , aber es ist <unk> <unk> , wenn <unk> oder <unk> <unk> .
+Wir haben <unk> und <unk> für <unk> Teil der <unk> .
+Ich <unk> mich mit einigen <unk> <unk> .
+<unk> <unk> wir in einer <unk> mit <unk> in <unk> und haben wir in <unk> mit <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Es ist auch <unk> , dass eine <unk> und <unk> <unk> mit dem <unk> <unk> <unk> <unk> .
+<unk> , vier <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> <unk> ich , dass wir alle <unk> <unk> und <unk> <unk> , <unk> wir den anderen <unk> .
+Wir möchten alle sehr <unk> und <unk> <unk> , <unk> <unk> , dass die <unk> <unk> <unk> <unk> .
+Wir <unk> die <unk> mit der <unk> , die <unk> <unk> .
+<unk> Sie die <unk> <unk> <unk> <unk> <unk> , aber <unk> <unk> <unk> <unk> <unk> .
+Wie <unk> Sie eine <unk> ?
+Wie wir <unk> haben , hat es eine <unk> <unk> .
+Wir haben <unk> , dass es <unk> ist , weil es <unk> ist , in diesem Bereich <unk> und Menschen , die Ihre <unk> <unk> .
+<unk> einer <unk> , dass Sie die <unk> , dass Sie die <unk> und die <unk> <unk> , dass Sie die <unk> und die <unk> <unk> , ohne die <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Wie können Sie Ihre <unk> <unk> <unk> <unk> ?
+Ich glaube , dass wir sehr sehr <unk> und <unk> <unk> <unk> .
+Wir haben eine <unk> für eine drei Jahren <unk> <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Es gibt viele <unk> <unk> , weil die <unk> <unk> <unk> <unk> und die <unk> <unk> , dass wir uns noch eine <unk> oder <unk> <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+Es war ein <unk> <unk> und wir <unk> <unk> .
+Die nationalen <unk> <unk> <unk> wird für <unk> die <unk> in <unk> <unk> .
+<unk> es <unk> , dass Sie die <unk> , besonders <unk> , <unk> , <unk> und <unk> , die Ihnen für die <unk> ?
+<unk> , die <unk> <unk> uns <unk> <unk> und <unk> <unk> <unk> , dass wir die <unk> <unk> , <unk> wir <unk> <unk> , was wir <unk> <unk> und <unk> <unk> werden .
+<unk> Sie eine <unk> <unk> <unk> der <unk> <unk> <unk> ?
+Das ist eine Frage für die <unk> <unk> <unk> <unk> ich nicht .
+Er <unk> es , und ich glaube , er ist es , dass es <unk> hat .
+Wie Sie ein <unk> , was Sie Ihre <unk> ?
+Es gibt es viele <unk> .
+<unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Es gibt es viele <unk> , alle <unk> , die ich <unk> <unk> .
+Wie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Ich glaube , dass alle <unk> eine <unk> von der <unk> <unk> .
+Wenn ich der <unk> , dass es <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> und alle <unk> , dass es jetzt <unk> ist , <unk> <unk> und alle <unk> <unk> .
+Im ersten <unk> <unk> die <unk> <unk> eine <unk> <unk> , und nun hat mehr <unk> <unk> .
+Wie können Sie diese <unk> <unk> ?
+Es ist <unk> <unk> , weil ich es eine <unk> von <unk> über die <unk> <unk> , aber es sind <unk> , die <unk> oder <unk> <unk> <unk> , <unk> sie <unk> <unk> .
+Mit dem <unk> <unk> <unk> sie <unk> , wenn ich sie <unk> , und diese <unk> sind <unk> .
+Ich glaube , dass Sie sich , wenn Sie einige <unk> und <unk> <unk> <unk> , die <unk> <unk> , die <unk> <unk> und <unk> <unk> .
+<unk> , ich glaube , dass Sie eine <unk> ® und <unk> <unk> werden , dass <unk> <unk> ist .
+<unk>
+<unk> <unk> wurde <unk> <unk> .
+Die <unk> Herr Präsident , <unk> war <unk> im <unk> <unk> , um die <unk> von <unk> zu <unk> , um die <unk> von <unk> zu <unk> .
+<unk> <unk> , <unk> Jahre , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Die <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> <unk> , dass in seiner Fällen <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> ist in <unk> als <unk> 2007 in der <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> auf <unk> politischen <unk>
+Ein <unk> <unk> <unk> der <unk> <unk> <unk> , <unk> und <unk> <unk> und <unk> , wird diese <unk> ein <unk> <unk> , um <unk> zu <unk> , um <unk> zu <unk> und politischen <unk> zu <unk> .
+Als <unk> wird seine <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Die <unk> zwischen <unk> , in der <unk> <unk> , wird der <unk> &quot; <unk> für die <unk> <unk> , wird die <unk> <unk> und die <unk> der <unk> <unk> <unk> <unk> .
+<unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+In seiner <unk> <unk> <unk> <unk> die internationale Gemeinschaft , die <unk> <unk> , die <unk> <unk> , eine <unk> , die die <unk> der <unk> und der <unk> der <unk> in der Europäischen Union <unk> .
+<unk> <unk> hat die <unk> eine <unk> <unk> des <unk> der <unk> <unk> <unk> und <unk> <unk> .
+Die <unk> Regierung <unk> <unk> in <unk> Jahren auf die <unk> der <unk> <unk> <unk> , um die &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+In der <unk> <unk> , <unk> und <unk> haben die <unk> ein <unk> <unk> <unk> <unk> , dass die <unk> zwischen <unk> <unk> , <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> , die in der <unk> in der Welt befinden , hat sich die <unk> <unk> , die <unk> der <unk> <unk> <unk> <unk> , die <unk> in drei <unk> ohne die Notwendigkeit <unk> .
+&quot; <unk> ist die <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , in der <unk> in <unk> .
+<unk> <unk> <unk> , dass <unk> <unk> <unk> <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist die <unk> <unk> in der <unk> <unk> &quot; oder eine <unk> <unk> <unk> <unk> &quot; <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> <unk> <unk>
+Diese <unk> <unk> <unk> in drei <unk> <unk> auch die <unk> des <unk> , <unk> , <unk> , <unk> , <unk> nicht als <unk> .
+In diesem Bereich <unk> <unk> die <unk> der <unk> und <unk> die <unk> <unk> der <unk> , die mit <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk>
+Herr Präsident , <unk> <unk> <unk> <unk> <unk> , dass die <unk> <unk> der <unk> <unk> <unk> <unk> hat , um die <unk> in der <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> die <unk> für die <unk> , um die <unk> zu <unk> , die <unk> <unk> zu <unk> , <unk> er <unk> .
+In einem <unk> <unk> , <unk> <unk> , dass seine Entscheidung <unk> ist , <unk> <unk> und <unk> <unk> , die in der <unk> <unk> <unk> hat .
+Er <unk> , dass die <unk> er nicht &quot; <unk> &quot; in <unk> <unk> und <unk> alle <unk> <unk> hat .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> eine <unk> <unk> , <unk> alle <unk> und <unk> <unk> zu <unk> .
+In <unk> mit der <unk> der <unk> <unk> und der <unk> <unk> <unk> <unk> werden seine <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> wurde <unk> von <unk> Millionen <unk> in der <unk> <unk> , wenn er ein <unk> <unk> , die <unk> , die <unk> , die <unk> , <unk> und <unk> <unk> .
+<unk> hat <unk> <unk> <unk> <unk> <unk>
+Die <unk> war <unk> , dass die <unk> auf die <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> des <unk> <unk> des <unk> ist <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> gibt es <unk> über eine <unk> und <unk> <unk> <unk> .
+Die <unk> <unk> auf eine <unk> <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> wurde in der <unk> von <unk> <unk> <unk> in <unk> mit dem <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> auf <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> .
+Die politische <unk> , in den <unk> <unk> , in den <unk> <unk> , <unk> die <unk> <unk> der <unk> <unk> .
+<unk> Sie die <unk> der <unk> , <unk> , <unk> und seine <unk> <unk> <unk> , <unk> die <unk> der <unk> und der <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> war <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> wie ein Beispiel für die <unk> <unk> und <unk> <unk> , dass die Menschen mit <unk> <unk> .
+Die Krise ist nicht <unk> , die <unk> <unk> und die Arbeit von <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> der <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk>
+Die neue <unk> <unk> die <unk> <unk> , ohne eine <unk> <unk> zu <unk> .
+Es scheint , dass die <unk> <unk> der <unk> in <unk> <unk> <unk> <unk> hat , hat sich ein <unk> <unk> .
+<unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Wenn die <unk> in <unk> <unk> die <unk> in <unk> <unk> , um eine <unk> von <unk> zu <unk> .
+&quot; <unk> <unk> wird eine neue <unk> , &quot; <unk> <unk> .
+Die <unk> , die <unk> <unk> der <unk> <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die erste drei <unk> haben die <unk> <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> und die <unk> .
+Die <unk> ist ein <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
+Die <unk> , <unk> <unk> , <unk> <unk> , dass die <unk> in den <unk> der <unk> <unk> <unk> <unk> .
+Die <unk> der <unk> <unk> , dass die <unk> der <unk> der <unk> <unk> <unk> , weil sie sich <unk> <unk> für drei <unk> <unk> , während sie sich in der <unk> <unk> <unk> .
+<unk> <unk> die <unk> der <unk> <unk> , um die <unk> <unk> von <unk> zu <unk> , während sie <unk> <unk> hat , nicht <unk> , die <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Die <unk> der <unk> <unk> <unk> , dass die <unk> <unk> <unk> , dass sie sich mit dem <unk> der <unk> und <unk> <unk> sind .
+Die <unk> <unk> auch die <unk> , die in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> , dass die <unk> nur eine <unk> der <unk> <unk> ist , aber in den letzten Jahren <unk> die <unk> <unk> .
+In diesem <unk> <unk> er <unk> <unk> , dass es <unk> ist , um die <unk> zu <unk> und <unk> zu <unk> , dass die <unk> der <unk> <unk> .
+<unk> <unk> , die <unk> der <unk> <unk> eine <unk> in <unk> <unk> .
+Im <unk> <unk> <unk> die <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die vier <unk> im <unk> <unk> .
+<unk> oder <unk> ?
+Die <unk> <unk> <unk> <unk> auf <unk> <unk> .
+Die <unk> <unk> auf den <unk> <unk> <unk> die Aussprache über die Aussprache in <unk> <unk> .
+In der <unk> des <unk> der <unk> <unk> der <unk> <unk> <unk> der <unk> <unk> dieses <unk> <unk> <unk> .
+Die <unk> <unk> die <unk> <unk> <unk> .
+<unk> ist es <unk> von einer <unk> , im <unk> mit dem <unk> <unk> <unk> .
+<unk> der <unk> der <unk> , in der <unk> , in der <unk> <unk> wurde , war der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> <unk> als <unk> <unk> in diesem <unk> .
+Die <unk> wurde nicht <unk> <unk> , aber <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+Das war alle <unk> , in <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> für <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Ein <unk> <unk> , <unk> <unk> , <unk> <unk> .
+<unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+Die Frage <unk> <unk> <unk> oder <unk> ?
+Die <unk> , wie für ihre <unk> <unk> <unk> ist , ist eine <unk> der <unk> der <unk> <unk> .
+Es ist eine <unk> <unk> , um die <unk> dieses <unk> zu <unk> , wenn die <unk> dieser <unk> <unk> <unk> <unk> wird .
+Die <unk> ist <unk> <unk> , die drei <unk> zwischen den drei <unk> <unk> <unk> <unk> und die <unk> , die <unk> <unk> .
+<unk> <unk> , <unk> <unk> und <unk> <unk> die <unk> ist <unk> <unk> <unk> <unk> <unk> .
+Für <unk> , <unk> die <unk> &quot; <unk> &quot; <unk> &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot;
+<unk> <unk> <unk> , dass die <unk> in <unk> <unk> ist .
+<unk> <unk> für die <unk> <unk> .
+<unk> ist <unk> <unk> , &quot; <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> , wie <unk> und <unk> mit <unk> in der <unk> des <unk> <unk> die Vorschlag &quot; <unk> &quot; .
+<unk> <unk> von der <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die erste <unk> ist die <unk> , wo man sich auf <unk> <unk> .
+&quot; <unk> <unk> ist <unk> , <unk> , <unk> , <unk> .
+Die <unk> ist der <unk> <unk> <unk> , weil die <unk> der <unk> in <unk> <unk> <unk> werden kann .
+Die Frage , <unk> <unk> , dass die <unk> der <unk> <unk> <unk> <unk> <unk> werden kann , als <unk> , <unk> , <unk> nicht <unk> <unk> .
+<unk> <unk> , dass ein <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> <unk> , dass die Antwort die Frage der Frage der <unk> <unk> <unk> , weil die <unk> der <unk> ein <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> , die in diesem Fall haben , <unk> sich in diesem Fall <unk> .
+<unk> , ein <unk> für einen der <unk> <unk> in den <unk> und <unk> mit dem <unk> des <unk> <unk> .
+Im <unk> sollten die <unk> <unk> <unk> , dass die <unk> der <unk> der <unk> <unk> <unk> <unk> <unk> <unk> in den <unk> und der <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk>
+<unk> <unk> <unk> der <unk> <unk> der <unk> <unk> der <unk> <unk> der <unk> des <unk> des <unk> des <unk> des <unk> des <unk> der <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> der <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> der <unk> <unk> , die <unk> <unk> <unk> eine <unk> Fall gegen die <unk> der <unk> und <unk> <unk> , er wurde <unk> <unk> .
+Die vier <unk> <unk> der <unk> <unk> für <unk> <unk> , <unk> er <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+In diesem Zusammenhang <unk> er die <unk> von <unk> <unk> , <unk> die <unk> der <unk> und <unk> <unk> .
+<unk> <unk> er <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die Richtlinie <unk> <unk> , die in der <unk> <unk> , die <unk> in der <unk> <unk> <unk> <unk> .
+Im <unk> <unk> <unk> er ein <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+In <unk> , die <unk> <unk> der <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+Während der <unk> <unk> , die <unk> <unk> , <unk> <unk> , ob er <unk> , ob er <unk> <unk> , ob er die <unk> und die <unk> der <unk> <unk> <unk> <unk> , <unk> die <unk> <unk> <unk> .
+<unk> auf die <unk> <unk> / <unk> <unk> <unk> ist die <unk> <unk> und <unk> <unk> nicht <unk> .
+Die <unk> der <unk> der <unk> <unk> der <unk> , der <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> der <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> hat er <unk> <unk> und <unk> <unk> .
+<unk> <unk> er <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> der <unk> und <unk> <unk> <unk> , dass die <unk> <unk> auf die <unk> in der <unk> <unk> <unk> <unk> , ohne die <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> und <unk> <unk> <unk> , dass die <unk> <unk> für die <unk> <unk> .
+Die <unk> , dass die <unk> <unk> <unk> , dass die <unk> in <unk> mit dem <unk> <unk> , die <unk> in <unk> mit dem <unk> <unk> <unk> .
+Er <unk> auch <unk> , dass die <unk> <unk> für <unk> <unk> , <unk> es die <unk> <unk> <unk> .
+Er <unk> auch <unk> , dass die <unk> <unk> in den <unk> der <unk> <unk> nicht der <unk> <unk> .
+&quot; <unk> ist es <unk> , dass es keine <unk> <unk> sind oder <unk> der <unk> in einer anderen <unk> <unk> , ist die <unk> <unk> <unk> .
+&quot; <unk> &quot; <unk> " für <unk> <unk> , <unk> die <unk> <unk> für <unk> <unk> .
+Die <unk> hat eine <unk> von <unk> <unk> <unk> .
+Für jetzt ist es eine <unk> <unk> , die sich die Notwendigkeit <unk> , die Ergebnisse als <unk> <unk> <unk> oder <unk> <unk> .
+<unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> und <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> Informationen <unk> die <unk> der <unk> eines <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , die <unk> der <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> in der <unk> .
+<unk>
+<unk> Sie die <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> , dass die <unk> in der <unk> und der <unk> <unk> .
+<unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk>
+Es ist <unk> , dass die <unk> <unk> die <unk> der <unk> <unk> und <unk> <unk> in der <unk> <unk> .
+<unk> der <unk> .
+Die <unk> der <unk> und der letzten <unk> der <unk> <unk> <unk> , weil sich die <unk> <unk> nicht <unk> , die <unk> <unk> ist .
+<unk> <unk> auf ein <unk> <unk>
+<unk> Informationen zu <unk> <unk> <unk> , dass die <unk> in einer <unk> und <unk> <unk> .
+Die <unk> der <unk> <unk> , dass die <unk> die <unk> in <unk> <unk> <unk> .
+Es ist nicht <unk> <unk> von <unk> oder <unk> <unk> .
+In der Nähe des <unk> gibt es <unk> <unk> <unk> <unk> <unk> in der <unk> des <unk> <unk> <unk> .
+<unk> sind die <unk> <unk> <unk> <unk> <unk> mit dem <unk> .
+In der <unk> befinden sich die <unk> in einer <unk> von <unk> <unk> <unk> <unk> .
+Die <unk> ist die <unk> in der <unk> , die <unk> .
+Die Informationen sind <unk> , dass die <unk> <unk> , dass die <unk> mit dem <unk> <unk> <unk> <unk> werden .
+Die <unk> eines <unk> <unk> in einer <unk> <unk> als die <unk> <unk> <unk> , <unk> die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> ist , die <unk> ist , die <unk> <unk> , die <unk> <unk> ist .
+<unk> <unk> ein <unk> für <unk> <unk>
+<unk> <unk> <unk> <unk> ein <unk> <unk> für <unk> in <unk> und <unk> .
+Die <unk> <unk> <unk> <unk> <unk> <unk> hat , dass die <unk> ein <unk> <unk> für <unk> und <unk> <unk> , die die <unk> der <unk> in <unk> und <unk> &quot; <unk> &quot; <unk> wird .
+In einer <unk> , die <unk> der <unk> <unk> in <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> ist von <unk> und <unk> <unk> von der <unk> <unk> <unk> und der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> der <unk> oder nicht , die durch die <unk> von <unk> oder nicht <unk> werden , durch die <unk> der <unk> in den <unk> <unk> , wo es <unk> werden , <unk> <unk> <unk> .
+<unk> <unk> , dass die <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> der <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> , dass die <unk> dieses <unk> <unk> , die die <unk> und die Bedeutung der <unk> in <unk> und <unk> <unk> der <unk> für <unk> <unk> <unk> .
+In <unk> <unk> werden die <unk> <unk> <unk> , und die <unk> ist die <unk> <unk> <unk> <unk> und <unk> <unk> und <unk> <unk> und <unk> <unk> .
+Sie werden auch <unk> <unk> , <unk> <unk> und <unk> <unk> <unk> <unk> , die <unk> <unk> , die <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+<unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> <unk> , dass dieses <unk> des <unk> für die <unk> <unk> in Kinder <unk> .
+<unk> <unk> <unk> <unk> zwischen <unk> und 2006 , dass die in nur <unk> Jahren <unk> <unk> ist , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Ich <unk> die <unk> für <unk> die <unk> <unk> <unk> , ist die <unk> <unk> der <unk> <unk> .
+Er <unk> , dass die <unk> eine <unk> <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Er <unk> , dass die <unk> <unk> , dass die <unk> der <unk> <unk> in der <unk> der <unk> <unk> <unk> , die wir <unk> <unk> und <unk> ist .
+Die <unk> <unk> , dass die <unk> <unk> für die <unk> der <unk> <unk> <unk> , ist eine <unk> <unk> der Kinder , die <unk> <unk> oder <unk> .
+<unk> <unk> er <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die Informationen ist <unk> <unk> mit <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> ist es , die <unk> <unk> , <unk> , <unk> und die <unk> <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> mit <unk> und <unk> und <unk> in diesem <unk> .
+<unk> würde <unk> <unk> <unk> <unk>
+<unk> <unk> , eine <unk> auf die <unk> der <unk> von <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> , <unk> , <unk> und <unk> <unk> .
+Wenn die <unk> von der <unk> <unk> <unk> <unk> , würde es <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+In seiner <unk> <unk> <unk> der <unk> <unk> der <unk> , die die <unk> <unk> <unk> , <unk> <unk> , dass die <unk> er <unk> ist , <unk> und <unk> <unk> .
+<unk> <unk> <unk> , dass dieses Vorschlag der <unk> in <unk> , wo die <unk> in <unk> , wo die <unk> <unk> ist , als <unk> in der <unk> und <unk> <unk> .
+<unk> <unk> , dass die <unk> , die <unk> <unk> <unk> ist , ist ein <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> der <unk> der <unk> in der <unk> , dass die <unk> von <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Dies bedeutet , dass die <unk> der <unk> <unk> nicht <unk> , aber ist der <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> <unk> , dass die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> der <unk> <unk> ist die <unk> , die <unk> <unk> <unk> in der <unk> und <unk> <unk> .
+<unk> der <unk> , die diese <unk> <unk> <unk> , ist es <unk> mit <unk> .
+Wenn die <unk> und <unk> <unk> <unk> , ist es die <unk> <unk> sehr gut <unk> .
+Wenn es sich <unk> <unk> <unk> , wäre es <unk> <unk> .
+Im <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Diese <unk> ist die <unk> , die in <unk> mit dem <unk> der <unk> <unk> , muss es eine <unk> <unk> als die <unk> <unk> <unk> .
+Als <unk> der <unk> , dass die <unk> und die <unk> , die <unk> , die <unk> <unk> und die <unk> , die <unk> <unk> und die <unk> <unk> ist .
+Die <unk> , besonders <unk> und <unk> sind auch eine sehr <unk> <unk> , besonders <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Die <unk> ist <unk> <unk> , <unk> <unk> die <unk> und <unk> <unk> , die eine <unk> der <unk> und <unk> <unk> .
+In einer <unk> eines <unk> , er habe ich <unk> , dass die ersten <unk> und nur nur in <unk> <unk> , ist es <unk> , dass die <unk> <unk> nicht <unk> wird .
+<unk> ein <unk> der <unk> <unk> der <unk> <unk> , dass die <unk> <unk> <unk> wichtig ist , dass die <unk> für die <unk> und die <unk> der <unk> <unk> <unk> <unk> <unk> werden .
+<unk> <unk> <unk> <unk> , dass es keine <unk> und Arbeit <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
+Was die <unk> <unk> <unk> , um die neue <unk> <unk> <unk> ?
+<unk> der <unk> , die <unk> <unk> , <unk> <unk> <unk> für die <unk> des <unk> <unk> .
+Die <unk> <unk> seine <unk> <unk> von <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Dies ist <unk> <unk> <unk> , <unk> <unk> mit dem <unk> <unk> und die <unk> , dass die <unk> die neuen <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> die Frage <unk> <unk> <unk>
+<unk> <unk> hat die <unk> eines <unk> <unk> , die in <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die erste <unk> in den <unk> , die die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , dass sie nicht mit dem <unk> <unk> ist , ist die <unk> , die Sie <unk> , und <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk>
+<unk> <unk> ich eine <unk> in <unk> , glaube ich , dass die <unk> <unk> , und ich glaube , dass die <unk> mein <unk> <unk> ist .
+<unk> möchte ich &quot; <unk> und <unk> &quot; <unk> und <unk> &quot; ist eine <unk> <unk> <unk> , die wir <unk> <unk> , eine <unk> <unk> .
+Eine Frage , die die <unk> <unk> , nicht <unk> , dass die <unk> &quot; <unk> &quot; und eine <unk> für die <unk> der <unk> <unk> <unk> <unk> .
+Aber nach der <unk> <unk> <unk> <unk> er <unk> <unk> und <unk> mit der <unk> ist es <unk> .
+<unk> <unk> , <unk> <unk> , <unk> <unk>
+<unk> die <unk> <unk> , es ist sehr <unk> , dass die <unk> von <unk> <unk> .
+Ein <unk> von <unk> <unk> , die für die <unk> , die <unk> , und die <unk> , die alle <unk> <unk> <unk> , die <unk> <unk> <unk> , die <unk> <unk> <unk> , die <unk> <unk> <unk> <unk> .
+Und die <unk> <unk> in den ersten <unk> in der <unk> <unk> und der <unk> der <unk> <unk> .
+<unk> in seiner <unk> <unk> <unk> , war es <unk> , dass sie die <unk> und die <unk> <unk> <unk> <unk> .
+<unk> <unk> , eine <unk> der <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; , der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> .
+<unk> <unk> ist , dass <unk> <unk> die <unk> über die <unk> <unk> , die die <unk> der <unk> <unk> <unk> .
+Dies ist <unk> , <unk> <unk> die internationale <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> ist nicht für eine <unk> <unk> <unk> , müssen wir über die <unk> <unk> <unk> und die <unk> <unk> , um die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+Es ist auch eine <unk> , dass die <unk> für die <unk> und die <unk> der <unk> <unk> , dass die <unk> der <unk> <unk> <unk> werden kann , weil die <unk> der <unk> <unk> , <unk> und <unk> <unk> .
+Die <unk> der <unk> <unk> <unk> <unk> <unk> , dass die <unk> <unk> nicht die <unk> <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> , die <unk> <unk> , <unk> <unk> , <unk> <unk> , dass die <unk> der <unk> der <unk> <unk> <unk> <unk> .
+Die <unk> sind <unk> , aber <unk> <unk> nicht , wie sie nicht <unk> , wie sie nicht <unk> .
+Die <unk> <unk> wurde nicht nur <unk> <unk> und hier ist , wo sie <unk> <unk> .
+Die <unk> , die für die erste Zeit ist , <unk> die <unk> <unk> <unk> <unk> , in der die <unk> der <unk> <unk> <unk> wurde .
+<unk> oder nicht <unk> , ist die Tatsache , dass die Frage der <unk> <unk> , nicht als <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> werden sie in <unk> <unk> als eine der <unk> <unk> , die die <unk> <unk> , <unk> <unk> in <unk> <unk> .
+<unk> war der <unk> des <unk> <unk> <unk> .
+Ein <unk> <unk> in <unk> als <unk> , die die <unk> der <unk> <unk> <unk> .
+Die Arbeit dieser <unk> ist eine <unk> Arbeit .
+Im <unk> <unk> <unk> die <unk> der <unk> <unk> <unk> <unk> , die die <unk> der <unk> <unk> <unk> , <unk> <unk> , die <unk> der <unk> <unk> .
+Die <unk> <unk> in den <unk> <unk> , die in der <unk> des <unk> <unk> <unk> , ist es <unk> <unk> <unk> , die <unk> <unk> in der Region <unk> .
+<unk> der <unk> , <unk> <unk> in <unk> , <unk> er oft <unk> <unk> <unk> <unk> , <unk> er <unk> , dass die <unk> , die <unk> , die <unk> , die <unk> , die <unk> <unk> , die <unk> <unk> .
+Um die <unk> der <unk> und nach dem <unk> <unk> , <unk> er <unk> in <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
+Die Woche ist der <unk> der <unk> des <unk> gegen <unk> <unk> <unk> <unk> er <unk> <unk> .
+<unk> <unk> wurde <unk> <unk> .
+Im <unk> <unk> <unk> <unk> <unk> von <unk> mit einem <unk> , <unk> .
+<unk> er <unk> er zwei <unk> und eine <unk> <unk> , die die <unk> des <unk> <unk> , so <unk> sie <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> , wenn er mit dem <unk> <unk> , die <unk> war , <unk> er nicht <unk> , dass er nicht <unk> hat , dass es in <unk> <unk> ist .
+Er <unk> ohne <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+Aber die <unk> <unk> nicht <unk> .
+<unk> einer <unk> <unk> <unk> , <unk> , eine <unk> und eine <unk> , <unk> die <unk> der <unk> mit <unk> .
+<unk> <unk> hat nicht <unk> <unk> <unk> <unk> &quot; <unk> &quot; .
+<unk> <unk> , die <unk> von <unk> <unk> wurde , <unk> die <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> , die <unk> <unk> ist .
+<unk> der <unk>
+Für eine <unk> <unk> von <unk> von <unk> <unk> <unk> die <unk> der <unk> <unk> <unk> <unk> , ist sehr <unk> .
+<unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+Die <unk> <unk> ist ein <unk> <unk> , ohne <unk> , die in <unk> <unk> werden kann .
+<unk> von der <unk> <unk> <unk> die <unk> Unterstützung für <unk> und <unk> und <unk> die <unk> von <unk> .
+Wann haben viele <unk> <unk> oder <unk> nicht <unk> .
+Wir werden alle <unk> und <unk> sie in der <unk> .
+Die <unk> <unk> , die in einem Fall <unk> hat , hat er eine <unk> <unk> der <unk> <unk> , weil die <unk> der <unk> <unk> <unk> <unk> <unk> und <unk> <unk> .
+&quot; <unk> sind <unk> <unk> , weil sie nicht <unk> , eine <unk> <unk> zu <unk> , sondern in diesem Fall können wir die <unk> des <unk> <unk> und die <unk> der <unk> <unk> , die in <unk> <unk> <unk> <unk> wird .
+Die <unk> kann auch <unk> <unk> oder <unk> <unk> <unk> .
+Sie haben eine <unk> <unk> <unk> mit <unk> <unk> <unk> .
+<unk> der <unk> ist es <unk> , dass eine <unk> <unk> der <unk> und der <unk> der <unk> <unk> <unk> .
+<unk> dieses <unk> ist nicht , dass es sich die <unk> <unk> ist , es ist es im <unk> <unk> .
+Ein <unk> <unk> des <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Wenn sie sich <unk> <unk> oder <unk> <unk> werden .
+Die <unk> sind <unk> , die <unk> <unk> , die <unk> <unk> oder in der <unk> .
+&quot; <unk> Problem ist , dass es viele <unk> <unk> , <unk> <unk> <unk> .
+Er <unk> , dass nicht mehr als <unk> <unk> ist .
+<unk> wie nicht nicht <unk> , dass <unk> <unk> , nicht mehr <unk> <unk> .
+<unk> kann es <unk> werden .
+<unk> <unk> &quot; <unk> " <unk> " <unk> " <unk> " " <unk> " <unk> " " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> .
+Ein Teil der <unk> <unk> , die <unk> <unk> und <unk> zu einer <unk> <unk> .
+Die <unk> der <unk> <unk> <unk> <unk> <unk> auf der <unk> der <unk> <unk> <unk> <unk> , wenn sie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> die <unk> <unk> , wo sie die <unk> in <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> ist , dass die <unk> nicht <unk> , die uns in den <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> , <unk> <unk> und <unk> , <unk> , <unk> , <unk> und <unk> , <unk> , <unk> , <unk> und <unk> , <unk> , <unk> , <unk> und <unk> , <unk> , <unk> , <unk> und <unk> , <unk> , <unk> , <unk> und <unk> , <unk> , <unk> , <unk> und <unk> , <unk> , <unk> , <unk> und <unk> , <unk> , <unk> , <unk> und <unk> , <unk>
+<unk> <unk> , dass die Frage der &quot; <unk> &quot; <unk> &quot; , um die <unk> der <unk> <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> , die &quot; <unk> <unk> &quot; <unk> &quot; , um die <unk> der <unk> <unk> <unk> und <unk> <unk> , <unk> <unk> , <unk> <unk> und <unk> <unk> .
+<unk> <unk> sie sich für eine <unk> <unk> , sondern die <unk> <unk> , aber die <unk> <unk> und <unk> zu <unk> , dass er die <unk> <unk> <unk> , während er sich <unk> <unk> .
+<unk> <unk> , die <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> der <unk> <unk> sind <unk> und <unk> in der Zeit <unk> und <unk> in der Zeit , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Die <unk> <unk> <unk> die Richtlinie auf <unk> <unk> <unk> und <unk> &quot; <unk> , dass die <unk> in der <unk> und anderen <unk> <unk> <unk> .
+<unk> <unk> <unk> die <unk> , weil der <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> , die <unk> <unk> , nicht <unk> , <unk> und <unk> <unk> .
+Die <unk> <unk> <unk> die <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> er die <unk> , die <unk> , weil es <unk> <unk> ist , um die <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Die <unk> dieser <unk> wurde <unk> und <unk> , dass <unk> <unk> <unk> ist , ist <unk> <unk> in <unk> der <unk> , die die <unk> der <unk> <unk> <unk> <unk> .
+Die <unk> der <unk> <unk> <unk> &quot; auch die <unk> , dass sie <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> werden in einer <unk> <unk> <unk> <unk> .
+<unk> mit <unk> <unk> und <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> hat die <unk> der <unk> <unk> in <unk> &quot; <unk> &quot; in &quot; <unk> &quot; in <unk> <unk> &quot; <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> , dass <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> <unk> <unk> der <unk> <unk> in der <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Im <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> und <unk> , die <unk> <unk> <unk> <unk> <unk> die <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> &quot; <unk> &quot; <unk> &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; &quot; <unk> &quot;
+<unk>
+<unk> <unk> von <unk> , <unk> , <unk> , <unk> und <unk> <unk> , dass <unk> in <unk> <unk> <unk> <unk> <unk> <unk>
+Die letzte <unk> wurde <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Die erste <unk> der <unk> Regierung über die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> die <unk> <unk> <unk> <unk> .
+<unk> drei <unk> <unk> der <unk> <unk> <unk> <unk> <unk> <unk> zwischen <unk> und <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> in <unk> <unk> .
+Die <unk> in <unk> <unk> , <unk> die <unk> der <unk> <unk> in <unk> - <unk> auch die <unk> der <unk> von <unk> , <unk> .
+Die <unk> können im <unk> des <unk> in <unk> <unk> <unk> , um die <unk> der <unk> und der <unk> <unk> .
+<unk> <unk> die <unk> von <unk> <unk> in <unk> <unk> , die <unk> von <unk> <unk> in <unk> <unk> .
+Die <unk> <unk> der <unk> Wirtschaft ist nicht <unk> , dass die <unk> nicht die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+<unk> hat <unk> <unk> , besonders <unk> <unk> der <unk> <unk> .
+Diese <unk> <unk> <unk> , <unk> , <unk> und <unk> <unk> .
+<unk> der <unk>
+<unk> hat die <unk> <unk> , wenn die <unk> <unk> <unk> <unk> <unk> <unk> werden , die <unk> <unk> , die <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Mit einem <unk> <unk> , die <unk> <unk> <unk> , eine <unk> <unk> für eine <unk> <unk> <unk> <unk> .
+<unk> oder <unk> , <unk> die <unk> für ihre <unk> Ergebnisse zwischen <unk> und <unk> .
+Als <unk> <unk> der <unk> Länder in der EU , die <unk> <unk> , <unk> nicht die <unk> .
+<unk> müssen wir die <unk> <unk> , daß die <unk> einige <unk> <unk> , die <unk> <unk> , die <unk> <unk> in <unk> und die <unk> <unk> der <unk> , <unk> <unk> <unk> .
+Und die <unk> sind nicht <unk> .
+Die <unk> für <unk> und <unk> <unk> <unk> <unk> <unk> , dass die <unk> Länder in <unk> <unk> <unk> <unk> .
+Die <unk> , die die <unk> in der <unk> Wirtschaft <unk> , die <unk> der <unk> <unk> .
+Die <unk> <unk> auf <unk> <unk> , um <unk> in <unk> .
+Die <unk> <unk> <unk> <unk> <unk> die <unk> , weil er sich <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk>
+<unk> <unk> , dass <unk> <unk> werden , aber <unk> wird nicht <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Mit der <unk> <unk> <unk> <unk> <unk> und <unk> <unk> in den <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Die <unk> , dass die <unk> &quot; <unk> &quot; " " " <unk> " <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> die neue <unk> <unk> , <unk> <unk> <unk> , dass es keine <unk> <unk> <unk> , ist <unk> <unk> , dass die <unk> der <unk> <unk> nicht <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Die <unk> dieser Regierung ist <unk> der <unk> der <unk> <unk> <unk> , &quot; <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+Ein <unk> von <unk> <unk> , die <unk> der <unk> <unk> , die <unk> <unk> <unk> <unk> und neue Maßnahmen gegen <unk> <unk> werden .
+Die <unk> der <unk> ist nicht der <unk> <unk> , das <unk> <unk> <unk> , aber wir sind nicht <unk> .
+Die <unk> <unk> war ein Teil der <unk> und der EU , die die <unk> <unk> , die <unk> <unk> , die die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Aber die Europäische Kommission noch noch eine <unk> <unk> der <unk> <unk> oder <unk> der <unk> <unk> , <unk> <unk> , dass die <unk> nicht die <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+Die <unk> <unk> noch eine <unk> für die <unk> .
+<unk> <unk> &quot; <unk> <unk>
+Die <unk> <unk> die &quot; <unk> &quot; in <unk> in <unk> , um diese <unk> von <unk> zu <unk> .
+<unk> &quot; <unk> ist eine <unk> <unk> in den <unk> .
+<unk> <unk> <unk> , dass die <unk> in den letzten zwei beiden <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> .
+Die <unk> <unk> <unk> die <unk> <unk> in <unk> mit dem <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> ist <unk> <unk> , um die <unk> <unk> zu <unk> , <unk> und <unk> die <unk> mit &quot; <unk> &quot; <unk> , der <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Es gibt <unk> &quot; <unk> und &quot; <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> nicht nur als <unk> <unk> , sondern auch <unk> , dass <unk> &quot; <unk> &quot; <unk> <unk> .
+<unk> , <unk> <unk> , die <unk> <unk> , dass sie <unk> , dass <unk> <unk> , dass sie in der <unk> <unk> , <unk> <unk> <unk> <unk> werden .
+Die <unk> für die <unk> <unk> in <unk> und in der <unk> der Welt <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Und <unk> <unk> dieses <unk> als &quot; <unk> <unk> der <unk> <unk> der <unk> <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> zu <unk> .
+&quot; <unk> &quot; <unk>
+<unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> ist ein <unk> <unk> <unk> .
+In diesem Punkt <unk> sie sehr <unk> , dass es in der <unk> Zusammenarbeit mit der <unk> der <unk> <unk> , wie es eine <unk> <unk> ist .
+<unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist eine der <unk> <unk> der Entwicklung der Zusammenarbeit .
+Die <unk> der <unk> für <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> <unk> der Europäischen Präsident <unk>
+Die erste Tag der <unk> der <unk> <unk> der Europäischen Union über <unk> <unk> <unk> , ohne <unk> <unk> zu <unk> , ohne <unk> <unk> zu <unk> , die auch der <unk> <unk> <unk> .
+Die Zukunft der Zukunft ist nicht <unk> , um die <unk> , aber auch in den <unk> , in dem <unk> , die <unk> , die <unk> , die <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> der <unk> <unk> zu <unk> und die <unk> der <unk> <unk> .
+Die <unk> auf die <unk> der Europäischen Kommission , die von der <unk> <unk> <unk> <unk> hat .
+<unk> <unk> <unk> , nur <unk> <unk> gegen <unk> <unk> .
+<unk> <unk> <unk> , <unk> sie <unk> , <unk> , <unk> und <unk> <unk> .
+Die <unk> <unk> der <unk> und der <unk> ist in der <unk> <unk> <unk> <unk> <unk> .
+<unk> nur weil Europa <unk> , weil der <unk> <unk> <unk> <unk> <unk> <unk> <unk> , weil er &quot; <unk> " <unk> " <unk> .
+Für die <unk> , &quot; die <unk> <unk> für eine <unk> in Europa .
+Diese <unk> ist <unk> der Vertrag von Lissabon , die <unk> zu <unk> , die <unk> der Europäischen Union zu <unk> , sondern auch die <unk> der Europäischen Union <unk> .
+Dies ist <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> , es ist nicht <unk> , dass die <unk> <unk> <unk> werden , dass die <unk> <unk> <unk> werden , und die <unk> der <unk> , die <unk> <unk> ist .
+Aber die <unk> in <unk> .
+<unk> , die <unk> der <unk> von einer <unk> von <unk> von <unk> <unk> , <unk> die Abstimmung der <unk> , die die <unk> der <unk> der <unk> <unk> .
+<unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> und <unk> <unk> <unk> <unk> .
+Die <unk> auf Europa <unk> eine <unk> , um die Bedeutung des <unk> <unk> , &quot; <unk> <unk> <unk> nicht <unk> .
 <unk> , wenn in einer <unk> <unk> .
-<unk> , zwei <unk> war <unk> die <unk> eines <unk> <unk> .
-<unk> war es einer der <unk> <unk> der <unk> <unk> .
-Was ist <unk> <unk> ?
-<unk> <unk> , die <unk> und die Regierung <unk> eine <unk> gegen <unk> <unk> .
-Auf 15 <unk> , <unk> <unk> wird in <unk> ein <unk> <unk> <unk> und auf die <unk> <unk> <unk> .
-Die <unk> <unk> <unk> aus einem <unk> <unk> in der <unk> der <unk> , aber auch die <unk> <unk> der <unk> <unk> , die Mehrheit zu <unk> <unk> .
-<unk> und <unk> mit einem <unk> <unk> , die Regierung auf <unk> <unk> <unk> , um die <unk> <unk> zu <unk> .
-Und ohne <unk> <unk> der <unk> , ein <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> , die <unk> <unk> , aber die <unk> <unk> <unk> <unk> <unk> <unk> eine <unk> von <unk> Millionen <unk> <unk> .
-Und die <unk> <unk> mit einem <unk> <unk> , <unk> die <unk> auf die <unk> der <unk> für <unk> im Falle der <unk> <unk> <unk> <unk> .
-<unk> , diese Fragen sind <unk> , die <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Das <unk> wird <unk> und in <unk> <unk> , wenn Sie <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Wie in anderen Fällen , die <unk> der <unk> <unk> ein wenig <unk> , um die <unk> von <unk> <unk> <unk> <unk> .
-Diese hat <unk> <unk> seit <unk> über politische <unk> , die <unk> <unk> <unk> .
-Die <unk> sind <unk> als Menschen in Europa .
-<unk> Sie dem <unk> <unk> .
-Die <unk> <unk> <unk> <unk> <unk> <unk> über <unk> Millionen Euro <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> .
-<unk> <unk> <unk> de la <unk> <unk> <unk> de la <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Diese <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Und <unk> <unk> <unk> <unk> .
-Die <unk> <unk> eine <unk> von <unk> Tagen in <unk> , <unk> mit <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> in <unk> <unk> .
-Ein <unk> , der <unk> <unk> ein <unk> <unk> in 2007 von der <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> , dass sie <unk> der <unk> <unk> nicht <unk> hatte .
-<unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
-<unk> diese <unk> mit dieser <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> in den USA <unk> .
+Die <unk> , die zwei <unk> war , war <unk> <unk> <unk> .
+<unk> war es in der <unk> <unk> der <unk> <unk> .
+Was <unk> <unk> <unk> ?
+<unk> <unk> , die <unk> und die Regierung <unk> <unk> eine <unk> gegen <unk> <unk> .
+<unk> <unk> , <unk> <unk> wird in <unk> ein <unk> <unk> <unk> <unk> <unk> und <unk> <unk> <unk> .
+Und diese <unk> <unk> von einer <unk> <unk> in der <unk> der <unk> , aber auch die <unk> <unk> der <unk> <unk> , aber auch <unk> <unk> <unk> .
+<unk> <unk> und <unk> , mit einem <unk> <unk> , die <unk> <unk> , um <unk> zu <unk> , um <unk> <unk> zu <unk> .
+<unk> ohne <unk> , ohne die <unk> <unk> des <unk> , <unk> <unk> <unk> <unk> <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk>
+Ein <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Und die <unk> <unk> <unk> mit einem <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk>
+<unk> <unk> werden diese <unk> <unk> , die von <unk> <unk> , <unk> <unk> , <unk> <unk> zu <unk> .
+Die <unk> werden <unk> und in <unk> , wenn Sie <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Wie in anderen Fällen , <unk> die <unk> der <unk> <unk> eine <unk> <unk> <unk> <unk> .
+Dies ist <unk> <unk> <unk> seit <unk> über die politische <unk> , die <unk> <unk> .
+Die <unk> sind keine <unk> als Menschen in Europa .
+<unk> uns <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> .
+<unk> <unk> de <unk> <unk> de <unk> <unk> de <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Und meine <unk> <unk> <unk> <unk> .
+Die <unk> <unk> eine <unk> <unk> von <unk> Tage in <unk> <unk> , <unk> mit <unk> <unk> in <unk> <unk> .
+Ein <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> in 2007 der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> , <unk> , <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> diese <unk> mit den europäischen <unk> , <unk> <unk> sind <unk> <unk> , die in <unk> anderen Land <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
 <unk> <unk> <unk> ist sehr <unk> , <unk> mit &quot; <unk> &quot; .
-Als <unk> <unk> ist es sehr <unk> .
-Die <unk> von <unk> wurde <unk> <unk> , um <unk> von <unk> zu <unk> und <unk> zu <unk> .
-In 2008 hat sich <unk> Millionen <unk> , die <unk> <unk> , dass die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> &quot; <unk> , <unk> &quot; <unk> <unk> <unk> <unk> .
-Im Falle <unk> <unk> <unk> <unk> für mehr als <unk> Tage <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> , <unk> <unk>
-Deshalb ist es <unk> <unk> <unk> <unk> , &quot; <unk> von <unk> Millionen <unk> mit <unk> <unk> .
-Ein <unk> , die sehr <unk> <unk> , <unk> , <unk> mit &quot; <unk> &quot; <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> müssen eine neue <unk> <unk> <unk>
-<unk> <unk> eine neue Programm von <unk> <unk> .
-Das war <unk> auf <unk> <unk> <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> für dieses <unk> <unk> <unk> .
-<unk> die <unk> der <unk> , <unk> müssen wir die Unterstützung unserer europäischen <unk> <unk> und eine neue Programm der <unk> <unk> , die seinen ersten <unk> <unk> hat .
-Die <unk> des <unk> wurde im <unk> der <unk> <unk> <unk> <unk> &quot; <unk> &quot; <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> neue <unk> <unk> neue <unk> .
-Am <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Wir werden nicht neue <unk> <unk> , wenn er bereits gesagt <unk> mit der <unk> des <unk> <unk> <unk> <unk> .
-Er <unk> seine Ziele des <unk> und des <unk> gegen <unk> , aber auch <unk> <unk> , die <unk> <unk> <unk> <unk> .
-Um die <unk> und <unk> <unk> <unk> , die <unk> , die die <unk> und der EU nicht <unk> würde , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Es ist notwendig , <unk> und <unk> <unk> , <unk> ein <unk> von <unk> <unk> .
-<unk> sind <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> , die <unk> <unk> , die Regierungen , <unk> und <unk> , die <unk> und <unk> <unk> und <unk> <unk> .
-Die <unk> ist <unk> .
-<unk> von <unk> <unk> von <unk> <unk> sie zu <unk> , wenn sie zu <unk> und <unk> <unk> <unk> .
-Dies ist eine der <unk> eines <unk> Bericht von <unk> , in dem <unk> <unk> <unk> <unk> , <unk> , <unk> und <unk> .
-Dies <unk> sich auf die Regierung <unk> , um die <unk> <unk> zu <unk> , so dass es eine <unk> <unk> <unk> und <unk> <unk> , wenn sie eine <unk> <unk> <unk> .
-Bei der <unk> <unk> <unk> die <unk> eine <unk> von der <unk> <unk> <unk> , die die Qualität von <unk> in <unk> Ländern <unk> .
-<unk> <unk> ist <unk> <unk> , die <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> oder nicht <unk> , <unk> von den <unk> <unk> , <unk> <unk> von den <unk> <unk> von <unk> .
-Und <unk> von ihnen <unk>
-<unk> ist es in <unk> , dass der <unk> <unk> mit <unk> der <unk> <unk> ist .
-Am <unk> Frage der <unk> und <unk> <unk> , die <unk> des Berichts Regierung bereits gesagt hat , die <unk> des <unk> <unk> , die bereits gesagt hat , nicht zu <unk> .
-<unk> , die <unk> , die auch <unk> <unk> , <unk> die Haltung aller Länder <unk> , wo diese <unk> <unk> oder <unk> haben , gibt es keine <unk> , dass die <unk> der <unk> nicht <unk> sind oder nicht <unk> .
-Auf dem <unk> , <unk> während einer <unk> , die <unk> , die <unk> <unk> , die <unk> <unk> , die im <unk> <unk> , wo <unk> und <unk> <unk> haben .
-&quot; <unk> ist in <unk> <unk> , wo es <unk> &quot; <unk> ist .
-&quot; <unk> <unk> ist <unk> in <unk> , wo es <unk> ist , ist <unk> <unk> .
+Es ist sehr <unk> .
+Die <unk> des <unk> ist seit <unk> <unk> <unk> für <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> <unk> , die <unk> <unk> , dass <unk> der <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Im Falle <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Ein <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
+<unk> <unk> <unk> <unk> , <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> müssen ein <unk> <unk> <unk>
+<unk> ist eine neue <unk> des <unk> zu <unk> .
+Dies war <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> &quot; <unk> die <unk> <unk> der Wirtschaft , wir müssen die Unterstützung unserer Europäischen <unk> und eine neue <unk> der europäischen <unk> &quot; <unk> &quot; <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> <unk>
+Der <unk> der <unk> <unk> in der <unk> des <unk> <unk> <unk> werden die &quot; <unk> &quot; <unk> " <unk> " <unk> " " <unk> " " <unk> " " <unk> " " <unk> " " <unk> " " <unk> " " <unk> " " <unk> " " <unk> " " <unk> " " <unk> " " <unk> " " <unk> " " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk> " <unk>
+<unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , dass die <unk> der <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> in <unk> .
+Das <unk> <unk> <unk> <unk>
+<unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+&quot; Wir werden nicht der neuen Behörden <unk> , <unk> er in einer <unk> mit dem <unk> <unk> <unk> <unk> .
+Er <unk> seine <unk> <unk> mit der Ziele der <unk> und der <unk> und der <unk> der <unk> gegen <unk> , aber auch seine <unk> , die <unk> <unk> .
+<unk> <unk> , die Europäische <unk> für die <unk> und <unk> <unk> , die <unk> , dass die <unk> und die EU <unk> , die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> und <unk> <unk> , <unk> eine <unk> von <unk> <unk> .
+<unk> sind <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> <unk> , die <unk> , die <unk> , die <unk> , <unk> und <unk> <unk> , die <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> ist <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , wenn sie <unk> und <unk> <unk> werden .
+Dies ist eine der <unk> <unk> <unk> Bericht von der <unk> <unk> , in der <unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> und <unk> .
+Dies <unk> die Regierung zu <unk> , die die <unk> <unk> , <unk> <unk> und <unk> <unk> , wenn es <unk> ist , eine <unk> <unk> zu <unk> .
+Im <unk> , die <unk> <unk> ein <unk> <unk> , die <unk> <unk> , die die <unk> in <unk> Ländern <unk> .
+<unk> <unk> ist <unk> <unk> , die <unk> <unk> , die <unk> <unk> , dass die <unk> der <unk> in <unk> <unk> <unk> werden .
+<unk> oder nicht <unk> , <unk> von <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Und <unk>
+<unk> , es ist in <unk> , dass die <unk> <unk> ist , mit <unk> der <unk> <unk> in <unk> .
+Auf der <unk> Frage der <unk> <unk> und <unk> <unk> , die <unk> der <unk> der <unk> <unk> , die <unk> <unk> , die <unk> <unk> , <unk> <unk> <unk> <unk> .
+<unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Im <unk> , <unk> die <unk> in einem <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> , nicht <unk> .
+<unk> ist in <unk> , wo es <unk> ist .
+&quot; <unk> <unk> ist <unk> in <unk> , wo sie <unk> <unk> .
+<unk> in <unk> <unk>
+Es sollte <unk> <unk> , dass die <unk> in der <unk> <unk> , weil sie in einer <unk> <unk> <unk> <unk> , <unk> sie <unk> , die <unk> , die <unk> , die <unk> , die <unk> , ihre <unk> zu <unk> .
+Und die <unk> <unk> würde nicht <unk> , dass die <unk> von <unk> oder <unk> <unk> <unk> <unk> .
+<unk> <unk> , die <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> oder die <unk> der <unk> oder der <unk> der <unk> ist eine <unk> <unk> , die die <unk> der Bericht <unk> .
+Sie <unk> die <unk> zwischen anderen <unk> , die die <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> , ist nicht <unk> .
+Die <unk> der <unk> <unk> auch die Gesundheit , die in der <unk> der <unk> und <unk> <unk> werden werden .
+<unk> <unk> <unk> , die <unk> <unk> , <unk> <unk> , <unk> und <unk> , um die <unk> <unk> <unk> und nicht nur in <unk> <unk> .
+<unk> , <unk> <unk> bereits <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
 <unk>
-Es sollte <unk> , dass <unk> <unk> werden , dass die <unk> von <unk> für die <unk> in <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> ihre <unk> <unk> .
-Und die <unk> <unk> würde nicht <unk> , dass die <unk> der <unk> oder <unk> <unk> <unk> <unk> <unk> .
-Die <unk> , die <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> die <unk> oder die <unk> der <unk> <unk> eines <unk> <unk> , ist das <unk> der Bericht .
-Sie <unk> auch unter anderen <unk> , dass die <unk> <unk> <unk> , dass <unk> <unk> <unk> <unk> ist .
-Die <unk> <unk> auch <unk> , dass der <unk> eine <unk> des <unk> <unk> werden , ohne <unk> <unk> zu <unk> .
-<unk> <unk> <unk> , die <unk> <unk> auf Regierungen , <unk> und <unk> , die <unk> , die <unk> , <unk> und <unk> zu <unk> .
-<unk> sollte die <unk> <unk> bereits <unk> <unk> in <unk> Gesundheit , die <unk> <unk> , dass es nur <unk> <unk> werden sollte , um die <unk> <unk> zu <unk> und dass sie <unk> werden sollten .
-<unk> von anderen <unk> <unk>
-<unk> im Bereich der <unk> Rechtsvorschriften bereits <unk> über die <unk> des <unk> <unk> <unk> .
-<unk> <unk> , ein <unk> im Bereich der Rechtsvorschriften , <unk> als &quot; <unk> &quot; , weil der <unk> der <unk> der <unk> , weil die <unk> andere <unk> nicht <unk> .
-&quot; Das <unk> ist das <unk> auf eine Situation , wo sich die <unk> der <unk> und der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk>
-<unk> <unk> auch <unk> , dass die <unk> der <unk> Person <unk> , die den <unk> der <unk> <unk> <unk> <unk> .
-Er <unk> , dass &quot; in der Gesellschaft <unk> und <unk> <unk> sind .
-Die <unk> im Bereich der Rechtsvorschriften <unk> , <unk> auch <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> , der Mitglied des <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> haben .
-Die <unk> von <unk> <unk> auf <unk> <unk>
-<unk> <unk> eine &quot; <unk> &quot;
-<unk> ist <unk> <unk> <unk>
-Die <unk> von <unk> <unk> <unk> in <unk> der <unk> des <unk> des <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> auf der <unk> der <unk> <unk> , der mit Unterstützung der <unk> <unk> , der mit Unterstützung der Russland <unk> ist , ist <unk> eine &quot; <unk> &quot; .
-<unk> Tage nach der <unk> von <unk> von <unk> der <unk> , der Europäischen Union hat ihre <unk> gegen <unk> , <unk> <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> der ersten <unk> auf <unk> <unk> in <unk> , wo einige <unk> und Mitglieder des <unk> <unk> wurden .
-Wenn <unk> des <unk> <unk> <unk> , würde er auch <unk> , aber er würde auch für eine neue <unk> der politischen <unk> <unk> , <unk> die <unk> der politischen <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
-In seiner <unk> <unk> <unk> die <unk> <unk> <unk> , dass <unk> <unk> die <unk> <unk> <unk> , <unk> nicht mit <unk> .
-&quot; in der <unk> Osten ist die <unk> im <unk> Osten , aber nicht <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-Für die <unk> <unk> sich die Vereinigten Staaten von <unk> gegen <unk> und die <unk> der <unk> <unk> <unk> und der Europäischen Union .
-&quot; Die internationale Gemeinschaft , die <unk> , der Europäischen Union , der Europäischen Union , der Europäischen Union , der Europäischen Union , der Europäischen Union <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-In dieser Zeit , <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> <unk> <unk> de <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> anderen <unk> <unk> während des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-In einer <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> , dass die <unk> des <unk> <unk> .
-Er <unk> <unk> <unk> gegen den <unk> der <unk> <unk> , die nach dem <unk> <unk> <unk> .
-<unk> wird er <unk> nicht <unk> , dass <unk> gegen <unk> <unk> <unk> &quot; <unk> .
-Nach der Entscheidung , die <unk> <unk> ist <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Ein <unk> <unk> der <unk> ist der <unk> für die <unk> der <unk> von <unk> von <unk> von <unk> von <unk> , <unk> und <unk> , die <unk> von <unk> <unk> <unk> <unk> .
-Die <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> in der Region <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> , eine <unk> in <unk> und <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; &quot; <unk> &quot; &quot; <unk> &quot; &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> , der die <unk> der <unk> <unk> <unk> .
+&quot; <unk> <unk> die <unk> auf einer Situation , wo sie die <unk> <unk> , und die <unk> in <unk> Jahren <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> auch die <unk> , dass die <unk> der <unk> <unk> , die <unk> <unk> , die <unk> , die <unk> , die <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der <unk> der
+Er <unk> , dass <unk> <unk> in der EU sind und <unk> <unk> .
+Die <unk> in Gesundheit und Entwicklung , <unk> auch <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , die eine <unk> der <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> der <unk> <unk> auf <unk> <unk> , um <unk> zu <unk> .
+<unk>
+<unk> ist <unk> <unk>
+Die <unk> der <unk> <unk> <unk> <unk> in <unk> der <unk> des <unk> des <unk> <unk> .
+<unk> <unk> <unk> <unk> auf die <unk> von <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> hat eine &quot; <unk> &quot; .
+<unk> Tage mit der <unk> von <unk> von <unk> von <unk> <unk> , der Europäische Union hat seine <unk> gegen <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> <unk> von <unk> <unk> <unk> die ersten <unk> , um <unk> zu <unk> , <unk> <unk> und <unk> der <unk> <unk> der <unk> <unk> .
+&quot; <unk> <unk> <unk> die politische <unk> , <unk> er <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Im <unk> , die <unk> <unk> , <unk> <unk> die Tatsache , dass <unk> <unk> , dass <unk> , dass <unk> , die <unk> , die <unk> der <unk> <unk> , <unk> nicht <unk> .
+&quot; <unk> <unk> in der <unk> Osten , die in <unk> mit ihrem Menschen , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Für die <unk> sind die internationale Mitgliedstaaten <unk> , um <unk> und die <unk> des <unk> <unk> zu <unk> und der Europäischen Union <unk> .
+&quot; Die internationale Gemeinschaft , die die Europäische Union , die <unk> , <unk> und Länder als <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Im <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> <unk> in <unk> und <unk> <unk> in der <unk> von <unk> und <unk> .
+In einer <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> , dass die <unk> der Krise <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> wird nicht <unk> , <unk> er <unk> , dass <unk> gegen <unk> <unk> <unk> .
+Die Entscheidung , die <unk> , die <unk> <unk> ist , ist ein <unk> <unk> für die <unk> und <unk> die <unk> von <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Eine neue <unk> <unk> der <unk> ist <unk> für den <unk> des <unk> von <unk> <unk> und <unk> in <unk> , die <unk> der <unk> in <unk> und <unk> <unk> .
+Die <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
 <unk>
 <unk> <unk> <unk>
-Die <unk> <unk> der Regierung , <unk> <unk> hat die <unk> für eine <unk> Zeit , die <unk> <unk> und <unk> <unk> zu <unk> , ein Programm <unk> <unk> zu <unk> .
-Die <unk> Europäische <unk> wurde in <unk> mit den politischen <unk> <unk> <unk> .
-<unk> <unk> wird ein <unk> <unk> <unk> <unk> von <unk> <unk> <unk> .
-&quot; <unk> <unk> <unk> über eine wichtige Programm <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> der <unk> oder <unk> , <unk> <unk> , dass er <unk> würde , wenn <unk> <unk> <unk> würde , wenn die neuen Regierung <unk> <unk> , <unk> würde , ob die neue Regierung <unk> <unk> .
-Die <unk> wird im <unk> von <unk> <unk> ein <unk> oder so <unk> die <unk> <unk> , <unk> <unk> .
-<unk> <unk> <unk> auf der <unk> des <unk> hier <unk> .
-In einem &quot; Demokratie , der Regierung ist <unk> , dass die <unk> eines Regierung und eine Reihe von <unk> , <unk> <unk> , <unk> er <unk> , dass die <unk> <unk> und <unk> &quot; <unk> ist .
-<unk> <unk> wurde <unk> von der <unk> <unk> <unk> <unk> , aber <unk> <unk> , in <unk> nach einem <unk> <unk> in <unk> <unk> .
-Die <unk> <unk> <unk> ein <unk> , <unk> <unk> , <unk> er auch <unk> , wie er auch <unk> , wie auch <unk> <unk> .
-Die neue Regierung <unk> sich auf <unk> , die <unk> der nächsten <unk> , <unk> <unk> .
-<unk> die <unk> des <unk> der <unk> , <unk> , <unk> <unk> , die <unk> Regierung <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> , dass <unk> in <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Ein <unk> für die europäische Kommissar , Herr <unk> , <unk> <unk> , dass &quot; <unk> eines neuen Regierung <unk> , unseren <unk> <unk> nicht <unk> .
-Die Europäische Union wird <unk> , dass <unk> in <unk> <unk> die <unk> <unk> in <unk> <unk> die <unk> <unk> , die den <unk> <unk> <unk> hat .
-Die <unk> &quot; von <unk> &quot; <unk> <unk> , die ihm auf die <unk> des <unk> <unk> , ist auch eine <unk> , das nicht die <unk> der <unk> <unk> .
-<unk> <unk> , <unk> für seine <unk> und seine <unk> , wenn er <unk> europäische <unk> <unk> <unk> , <unk> &quot; <unk> <unk> , &quot; <unk> <unk> &quot; und &quot; <unk> &quot; <unk> <unk> &quot; <unk> <unk> &quot; <unk> <unk> &quot; für <unk> Jahre &quot; .
-<unk> ist die <unk> seiner <unk> .
-Herr Präsident , ein <unk> <unk> zu <unk> , weil die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> ein <unk> <unk> mit der <unk> der <unk> .
-Ein <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> von <unk> <unk> <unk> <unk> <unk> auf dem letzten Bericht des <unk> <unk> <unk> <unk> und andere <unk> von diesem <unk> <unk> <unk> .
-Die Woche <unk> <unk> seine <unk> auf einer " <unk> <unk> &quot; <unk> <unk> &quot; .
-<unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Im <unk> oder <unk> <unk> <unk> die <unk> ein <unk> <unk> &quot; in <unk> .
-Die <unk> <unk> seiner Unternehmen <unk> er zu <unk> , <unk> <unk> zu <unk> .
-Er <unk> <unk> auf ein <unk> Programm aus <unk> , <unk> <unk> <unk> <unk> .
-In den letzten Bericht <unk> <unk> &quot; <unk> <unk> <unk> <unk> , dass die <unk> von <unk> von <unk> <unk> <unk> <unk> <unk> <unk> <unk> wurde , sondern auch die <unk> , die auch <unk> <unk> <unk> <unk> .
-<unk> haben <unk> durch <unk> <unk> .
-<unk> <unk> 2009 <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> der <unk> von <unk> gegen <unk> <unk> in <unk> <unk> in <unk> <unk> in <unk> <unk> in <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> zu <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; <unk> <unk> in <unk> <unk> , ist es <unk> , diese <unk> immer wieder <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-&quot; <unk> <unk> <unk> <unk> hat lange <unk> , dass <unk> von <unk> gegen <unk> , als auch alle <unk> der <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Der <unk> Regierung und muss mehr tun werden , mit dem er <unk> , dass diese <unk> durch die <unk> <unk> <unk> werden .
-&quot; <unk> <unk> &quot; in <unk> <unk> ist eine <unk> von der <unk> für <unk> .
-Diese <unk> wurde nach dem <unk> von <unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-<unk> <unk> seine <unk> und <unk> <unk>
-Auf <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> in der <unk> des <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-Ein <unk> &quot; <unk> &quot; und eine andere &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Dies ist ein <unk> , wenn sie <unk> <unk> werden , wenn sie neue <unk> <unk> werden , wenn sie neue <unk> <unk> haben , wenn sie neue <unk> <unk> haben .
-Dieses neue <unk> <unk> <unk> &quot; auf einem kleinen <unk> von <unk> &quot; <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> , <unk> , <unk> und <unk> <unk> <unk> <unk> <unk> für <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Am <unk> , <unk> die <unk> dieses <unk> mit &quot; <unk> &quot; auf <unk> .
-&quot; Es ist <unk> , <unk> und <unk> <unk> .
-&quot; Der <unk> <unk> wird mir nach <unk> <unk> <unk> <unk> <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> .
-<unk>
-<unk> eines <unk> <unk>
-Die Regierung der Regierung der <unk> <unk> / <unk> <unk> in <unk> <unk> auf <unk> <unk> , um eine <unk> &quot; <unk> in die <unk> , um die <unk> <unk> von <unk> zu <unk> .
-Es war ein <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-&quot; Wenn das <unk> von <unk> nicht von einem <unk> <unk> <unk> , <unk> wir uns <unk> , dass die <unk> und <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Es ist also mit einem <unk> aus dem <unk> <unk> der <unk> <unk> und <unk> eine <unk> von <unk> und <unk> eine <unk> von den <unk> <unk> <unk> <unk> <unk> .
-Die von der Regierung Regierung <unk> <unk> der <unk> Regierung <unk> die erste europäische Landes auf das &quot; <unk> &quot; .
-<unk> , <unk> die öffentlichen <unk> muss von der <unk> und aus <unk> , die <unk> <unk> der <unk> <unk> und <unk> <unk> <unk> <unk> <unk> <unk> werden .
-Die <unk> ist , dass der <unk> <unk> die <unk> <unk> von <unk> / <unk> <unk> .
-<unk>
-<unk>
-Die <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , dass die <unk> Behörden in den <unk> Markt <unk> , wenn die <unk> der <unk> <unk> .
-<unk> <unk> wir als letzte Mal , wenn wir uns in der <unk> der <unk> <unk> <unk> , <unk> <unk> <unk> , die <unk> <unk> zu <unk> .
-Am <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Am <unk> , <unk> <unk> die <unk> gegen den <unk> in <unk> , um die <unk> der <unk> <unk> , die <unk> der <unk> <unk> , die neue <unk> <unk> wurde .
-Aber die <unk> <unk> <unk> seit der <unk> von <unk> , durch die es als &quot; <unk> &quot; <unk> <unk> und die <unk> Krise in Europa <unk> .
-Am <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> die <unk> über die <unk> <unk> und die <unk> über <unk> <unk> .
-Diese <unk> der <unk> <unk> <unk> <unk> , weil sie <unk> <unk> <unk> und <unk> die <unk> der <unk> von <unk> <unk> <unk> , wenn <unk> die nationalen <unk> <unk> .
-&quot; <unk> ist <unk> , dass die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , die <unk> , die dieses <unk> <unk> , <unk> nicht die <unk> <unk> .
-Die <unk> <unk> <unk> hat <unk> <unk> <unk> <unk> mit dem <unk> <unk> <unk> <unk> mit dem <unk> <unk> <unk> <unk> .
-Doch die <unk> <unk> <unk> , dass die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> von <unk> , <unk> <unk> , als <unk> auf dem <unk> der <unk> <unk> <unk> , die eine <unk> <unk> der <unk> <unk> , um die <unk> <unk> zu <unk> .
-<unk> die <unk> der <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Seit dem letzten <unk> im letzten <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> Millionen <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk>
-<unk> werden die <unk> <unk> <unk> .
-Die <unk> des <unk> <unk> sich <unk> <unk> .
-<unk> Sie die <unk> neuer <unk> in <unk> und <unk> <unk> <unk> in Frankreich , <unk> und <unk> <unk> .
-<unk> <unk> über die <unk> der <unk> , der europäischen <unk> <unk> eine <unk> <unk> in die 15 <unk> .
-Im <unk> <unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> im <unk> <unk> und <unk> <unk> .
-&quot; Mit dem neuen <unk> <unk> sich der <unk> von <unk> in <unk> , die <unk> <unk> <unk> , die <unk> <unk> zu <unk> .
-&quot; <unk> <unk> sind nur <unk> <unk> des <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> geschlossen werden mit einer <unk> von <unk> , <unk> <unk> <unk> <unk> .
-&quot; <unk> , wie die <unk> des <unk> <unk> hat und die <unk> eines anderen <unk> <unk> als die <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Dieses <unk> <unk> über die Zukunft der <unk> <unk> der <unk> , die auf <unk> <unk> <unk> hat .
-Die <unk> ist <unk> seine <unk> für eine <unk> und ein <unk> .
-<unk> <unk> der europäischen <unk> ist <unk> <unk> , <unk> von <unk> .
-<unk> <unk> es nach dem <unk> der <unk> <unk> <unk> <unk> , die <unk> <unk> auf <unk> <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> und <unk> <unk>
-Die <unk> <unk> von <unk> und <unk> auf sehr <unk> <unk> .
-Dieses <unk> <unk> das <unk> der <unk> <unk> <unk> <unk> <unk> , dass der <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> .
-Diese <unk> der <unk> <unk> der <unk> , <unk> auch <unk> die <unk> der <unk> .
-Die <unk> der <unk> Regierung , <unk> <unk> <unk> die <unk> für <unk> in einer <unk> von <unk> des <unk> .
-Die neue <unk> <unk> <unk> <unk> <unk> , dass die <unk> der <unk> auf <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> Sie sich in der Nähe von <unk> der <unk> <unk> <unk> .
-Die <unk> des <unk> zwischen <unk> und <unk> hat ein <unk> <unk> <unk> <unk> .
-<unk> der <unk> der <unk> <unk>
-Frankreich hat <unk> ein <unk> <unk> der <unk> in der <unk> <unk> , eine <unk> <unk> als die <unk> <unk> , von <unk> <unk> zu <unk> .
-Die <unk> <unk> <unk> die <unk> für die zweite <unk> , <unk> mit <unk> von <unk> <unk> <unk> <unk> .
-<unk> ist es wirklich der <unk> <unk> , die <unk> <unk> .
-<unk> <unk> eine <unk> für die <unk> <unk> <unk> <unk> .
-Die erste <unk> im <unk> ist <unk> in <unk> <unk> , die Europäische Kommission gegen die <unk> eines neuen <unk> <unk> .
-<unk>
-<unk> müssen über <unk> <unk> werden .
-Wenn es ein <unk> <unk> kann , oder unter dem <unk> der <unk> <unk> , ist der <unk> .
-Die <unk> und <unk> <unk> <unk> direkt an die <unk> und die <unk> Unternehmen .
-Es ist <unk> , dass ein <unk> <unk> für eine solche <unk> und die <unk> von <unk> <unk> werden .
-Die Aussprache wird nicht <unk> , wenn sie alle <unk> , <unk> und <unk> <unk> der <unk> <unk> .
-<unk> müssen die <unk> <unk> <unk> werden .
-<unk> , dass wir <unk> <unk> Millionen Euro <unk> werden , <unk> eine <unk> von <unk> für <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-In der gleichen <unk> werden es <unk> , die <unk> <unk> von <unk> in <unk> zu <unk> , um <unk> <unk> zu <unk> , ohne die <unk> <unk> zu <unk> , <unk> <unk> zu <unk> .
-Die <unk> <unk> <unk> keine <unk> dieser <unk> .
-<unk> <unk> ist <unk> in seiner Entscheidung , die <unk> <unk> .
-Das ist nicht die Fall , die <unk> , die <unk> , die <unk> <unk> , die <unk> <unk> zu <unk> oder die <unk> <unk> , die nur den <unk> <unk> <unk> .
-Am <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-Die Vereinigten Staaten , die von den <unk> <unk> <unk> , ein <unk> <unk> <unk> , die nach dem <unk> <unk> <unk> wurde .
-<unk> die <unk> <unk> auf <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> wird in einer Reihe von <unk> <unk> , ein <unk> der <unk> , der <unk> von Russland und <unk> <unk> <unk> zu <unk> .
-In einem <unk> <unk> alle <unk> wird bereits <unk> <unk> .
-Die <unk> sollte <unk> werden .
-Die <unk> Europas <unk> , ist es auch eines der größten <unk> , es ist auch eine der größten <unk> der größten und der <unk> von <unk> und der <unk> von <unk> von <unk> und <unk> .
-<unk> Sie sich auf die <unk> der <unk> , die <unk> <unk> mehr für ihre <unk> als <unk> <unk> .
-Seit Anfang der Wirtschaft <unk> die <unk> der <unk> in der <unk> der <unk> in der <unk> der <unk> <unk> <unk> <unk> <unk> , <unk> Unternehmen aus dem <unk> <unk> in Europa <unk> .
-<unk> <unk> in der <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> , die eine großen Mehrheit der <unk> <unk> , <unk> sie nicht <unk> .
-Es sollte <unk> werden , dass die <unk> unseres Landes <unk> <unk> <unk> <unk> <unk> <unk> Arbeitsplätze <unk> und <unk> <unk> <unk> <unk> .
-<unk> <unk> , es <unk> eine <unk> von <unk> <unk> in internationalen <unk> und <unk> viele Arbeitsplätze , die nicht <unk> kann .
-Wenn Frankreich <unk> <unk> , wäre sie <unk> eine große Reihe von <unk> und <unk> .
-Was <unk> ein <unk> <unk> für <unk> Jahre <unk> , wenn die <unk> ihrer <unk> <unk> wurde ?
-Um die <unk> , die <unk> , müssen sie <unk> , dass keine <unk> oder <unk> von <unk> <unk> werden kann .
-Die Entwicklung von <unk> <unk> <unk> Lösungen , <unk> und <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk>
-Für die <unk> des <unk> ist <unk> <unk> .
-In Frankreich haben wir eine <unk> <unk> , die eine <unk> und <unk> Kontrolle der <unk> <unk> <unk> wie <unk> <unk> .
-Unsere <unk> , deren <unk> ist <unk> , die <unk> <unk> <unk> .
-In einer <unk> Jahren <unk> die <unk> <unk> drei <unk> <unk> .
-<unk> einer , <unk> <unk> , <unk> <unk> unter <unk> <unk> <unk> , aber ohne <unk> <unk> oder <unk> .
-<unk> der <unk> und <unk> <unk> über die <unk> .
-Im <unk> , einige Menschen zu <unk> , dass die <unk> <unk> von zwei <unk> <unk> <unk> , <unk> die <unk> der <unk> von Menschen zu <unk> .
-Die <unk> <unk> <unk> aus diesem <unk> .
-Die <unk> dieser Schritt und der <unk> und <unk> <unk> , die <unk> und <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> .
-Seit <unk> ist es von allen <unk> <unk> <unk> , ein <unk> <unk> zu <unk> , es würde ein <unk> <unk> , um die <unk> der <unk> und <unk> ihrer <unk> <unk> zu <unk> .
-Es ist <unk> und <unk> , daß die <unk> <unk> für unsere Land <unk> , aber es wäre <unk> , <unk> und <unk> zu <unk> , die die <unk> <unk> , <unk> und <unk> der <unk> unserer Landes <unk> .
-<unk> eine <unk> oder eine <unk> für die Wirtschaft ?
-<unk> <unk> <unk> <unk> <unk> von verschiedenen <unk> <unk> <unk> , <unk> und <unk> <unk> für eine Politik von <unk> und der <unk> <unk> , die mit der <unk> der <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> ist es nur <unk> aus dem <unk> <unk> .
-Es gibt ein <unk> zwischen der <unk> und der <unk> auf diesem Thema .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> , die <unk> der <unk> <unk>
-Im <unk> , die <unk> des <unk> von <unk> wurde <unk> <unk> <unk> <unk> <unk> .
-<unk> sehen Sie <unk> als <unk> auf der <unk> und <unk> <unk> .
-Das nur <unk> <unk> im <unk> von <unk> , die <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Dies ist ein <unk> , ein <unk> , ein <unk> <unk> , aber es ist <unk> sehr sehr <unk> .
-Wie die <unk> <unk> und <unk> <unk> , <unk> uns in einer <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> <unk> , <unk> und <unk> <unk> .
-<unk> über die <unk> der <unk> sind auf der <unk> , die <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> auf <unk> <unk> .
-<unk> zeigt , dass der <unk> <unk> viel mehr <unk> , um als <unk> von <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-Die <unk> <unk> in <unk> , die nicht <unk> <unk> und die <unk> <unk> <unk> in <unk> <unk> , wo die <unk> <unk> nicht <unk> ist .
-<unk>
-<unk> wie <unk> <unk> würde es <unk> <unk> , dass die <unk> zwischen <unk> und <unk> <unk> <unk> , die <unk> zwischen <unk> und <unk> <unk> <unk> .
-<unk> <unk> hat <unk> , dass ein <unk> von <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Und die <unk> <unk> , dass die <unk> von <unk> und <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
-<unk> sind auch <unk> <unk> , <unk> <unk> der europäischen Länder .
-<unk> <unk> <unk> <unk> <unk> , dass für <unk> in Deutschland , ein <unk> Beitrag zur <unk> von <unk> <unk> <unk> .
-<unk> <unk> <unk> an der <unk> des <unk> <unk> , <unk> &quot; <unk> mit dem <unk> .
-Die <unk> in Frage <unk> sich <unk> , <unk> die <unk> <unk> .
-Europa , <unk> in der europäischen Demokratie , <unk> in der Europäischen Demokratie <unk> Demokratie , <unk>
-<unk> ist ein <unk> <unk> , <unk> man auch eine <unk> <unk> .
-Die Europäische <unk> sollte <unk> werden , dass es in <unk> zwei <unk> Jahre <unk> hat , <unk> die <unk> , aber auch <unk> in <unk> und <unk> in <unk> und <unk> in <unk> .
-<unk> <unk> <unk> , dass es <unk> war , dass die <unk> <unk> <unk> <unk> , um die Abstimmung , <unk> und <unk> <unk> .
-Es ist <unk> , dass seit der Zeit der <unk> <unk> war .
-<unk> <unk> , um die <unk> <unk> der Demokratie , der Demokratie zu <unk> , ist nicht <unk> , dass die <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> , Demokratie mehr , ein <unk> , ein <unk> , ein <unk> , ein <unk> , ein <unk> und Kontrolle der <unk> , Bildung , <unk> , <unk> , <unk> , <unk> , <unk> und sozialen <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und sozialen <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und sozialen <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und sozialen <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
-Die Europäische Union , die über <unk> <unk> sind , ist es eine politische <unk> und eine <unk> der Demokratie .
-In diesem Sinne <unk> die <unk> einer <unk> <unk> , eine <unk> <unk> der <unk> , die auch der <unk> <unk> <unk> , die <unk> der <unk> und ihrer <unk> <unk> .
-Diese <unk> muss durch <unk> <unk> werden , damit sie <unk> werden kann .
-Die <unk> ist , dass die <unk> der <unk> <unk> <unk> haben , und dass für viele , die <unk> sind nicht mehr <unk> sind .
-Wir haben nichts von <unk> <unk> <unk> , eine <unk> zu <unk> und in einer <unk> <unk> .
-Das &quot; <unk> &quot; <unk> &quot; oder eine <unk> mit <unk> in den <unk> <unk> , was eine <unk> für eine <unk> !
-<unk> , wir wollen nicht die <unk> eines <unk> , aber eine <unk> , <unk> , <unk> und <unk> von Demokratie und Demokratie , dieses <unk> und der Demokratie , dieses <unk> und der Demokratie , dieses <unk> <unk> zu <unk> .
-Es gibt keine <unk> in <unk> , <unk> , <unk> oder <unk> und einer <unk> wäre nicht nur eine <unk> <unk> , da es ist in Europa .
-Es ist die ganze Europas , die <unk> der <unk> und <unk> <unk> <unk> , die aus ihrem <unk> <unk> und eine <unk> von <unk> <unk> .
-<unk> ist die internationale <unk> <unk> .
-Es gibt <unk> über die <unk> der <unk> an Europa , aber es ist der gesamte <unk> , das <unk> seine <unk> <unk> und seine <unk> <unk> .
-Die <unk> <unk> die <unk> <unk> , die <unk> der europäischen <unk> .
-<unk> ist es von allen <unk> , die <unk> <unk> werden , die <unk> ihrer <unk> <unk> , <unk> , <unk> und <unk> für die Zukunft von <unk> zu <unk> .
-<unk> von <unk> <unk> auf europäischer Ebene können Sie ohne <unk> <unk> ohne <unk> <unk> werden .
-<unk> <unk> diese Vorschlag von <unk> und <unk> <unk> , die <unk> <unk> für eine europäische wirtschaftlichen Regierung .
-Lassen Sie sich <unk> .
-Doch das <unk> ohne <unk> <unk> , politische und <unk> <unk> und <unk> <unk> <unk> werden , <unk> eine neue <unk> und eine neue <unk> <unk> .
-Wir müssen eine neue <unk> der europäischen <unk> .
-Um die <unk> in Frankreich , war es um &quot; <unk> &quot; .
-Die <unk> wäre <unk> nicht <unk> .
-Diese <unk> ist <unk> .
-Wir müssen eine Europa <unk> <unk> <unk> .
-Dies kann nur durch eine <unk> <unk> Europa sein , denn eine <unk> <unk> europäischer <unk> <unk> .
-Um die <unk> zu <unk> , sollten wir uns <unk> .
-<unk> ohne <unk> sind <unk> <unk> .
-Das <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> sollte <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> <unk> ist , dass der <unk> <unk> , die <unk> <unk> oder <unk> für die <unk> von <unk> <unk> <unk> .
-Dieses Jahr <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk>
-Für eine lange Zeit in der Region , Europa ist nun <unk> in <unk> <unk> .
-<unk> <unk> Millionen <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Frankreich , die <unk> ist <unk> <unk> <unk> <unk> <unk> .
-Die großen <unk> sind <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Um die <unk> <unk> , <unk> es nun zu <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> sind <unk> von <unk> <unk> <unk>
-<unk> ist dies nur eine erste <unk> der <unk> , <unk> , <unk> , <unk> <unk> .
-<unk> <unk> sind mit <unk> <unk> <unk> mit <unk> <unk> <unk> , <unk> für <unk> <unk> .
-&quot; Sie sind <unk> .
-&quot; Aber sie sollte wirklich <unk> <unk> .
-&quot; Wir <unk> auf einer <unk> <unk> von <unk> <unk> <unk> in <unk> , <unk> <unk> , <unk> von <unk> .
-Aber die <unk> <unk> <unk> .
-<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> von <unk> <unk> und <unk> sind mit <unk> <unk> <unk> .
-Die <unk> hat in <unk> und in <unk> <unk> .
-Und die <unk> <unk> auch <unk> , dass es <unk> ist , dass es <unk> ist , die <unk> eines <unk> <unk> zu <unk> .
-<unk>
-<unk> ist <unk> von der <unk> <unk> und der <unk> <unk> .
-<unk> für eine lange Zeit , der <unk> zwischen den <unk> Gruppe in der <unk> <unk> und der <unk> <unk> <unk> <unk> <unk> <unk> .
-Auf <unk> , <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> ist nun .
-&quot; Der <unk> , in dem die beiden <unk> <unk> und die <unk> von <unk> Dienstleistungen <unk> , dass es <unk> , ohne <unk> <unk> .
-<unk> <unk> auf ein <unk> <unk> .
-Die <unk> in den <unk> zwei <unk> in <unk> <unk> zwei <unk> .
-Die <unk> <unk> in einem Restaurant von <unk> , <unk> de <unk> , <unk> de <unk> und <unk> <unk> <unk> auf die nächsten Tag des <unk> <unk> .
-<unk> Sie den <unk> <unk> , <unk> und <unk> <unk> <unk> <unk> <unk> .
-<unk>
-Der <unk> von <unk> <unk> <unk> in <unk> und in <unk> .
-<unk> , Frankreich <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-&quot; Dies ist ein <unk> , aber es ist <unk> , <unk> <unk> zu <unk> , die die Zusammenarbeit zwischen <unk> und <unk> <unk> <unk> .
-<unk> ist es möglich .
-&quot; Es ist <unk> worden , dass der <unk> von <unk> <unk> und <unk> <unk> und <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> , ein <unk> <unk> .
-In den letzten <unk> haben die Unterstützung mehr <unk> von der <unk> und der <unk> von <unk> und <unk> <unk> , die <unk> <unk> , die <unk> <unk> , die <unk> <unk> und <unk> <unk> zu <unk> .
-Die internationale Gemeinschaft , <unk> mit <unk> , ist nun <unk> Druck auf die <unk> , die Probleme von <unk> <unk> .
-<unk> Behörden haben <unk> <unk> <unk> , dass die Gruppe in <unk> <unk> <unk> nicht <unk> werden .
-<unk> <unk> <unk> <unk> <unk>
-<unk> in <unk> <unk> <unk> eine <unk> und ein <unk> <unk> <unk> <unk> , die die <unk> eines <unk> in der <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-In diesem <unk> <unk> die <unk> <unk> <unk> Erfolg .
-Es ist <unk> und <unk> <unk> von <unk> , <unk> ihre <unk> <unk> .
-Die <unk> <unk> <unk> , <unk> und <unk> .
-Im <unk> 2009 <unk> die <unk> von <unk> <unk> , <unk> , <unk> <unk> auf <unk> <unk> .
-Die <unk> der <unk> ist , <unk> , <unk> und <unk> .
-Das <unk> <unk> eine Stadt und <unk> <unk> auf .
-<unk> <unk> , <unk> <unk> , <unk> <unk> wurde <unk> in <unk> <unk> .
-Die <unk> werden <unk> und wird seine <unk> <unk> <unk> .
-<unk> <unk> es eine <unk> , die <unk> <unk> <unk> und dann mehr mehr <unk> .
-Im Juni im <unk> <unk> <unk> <unk> <unk> <unk> eine <unk> <unk> während einer <unk> <unk> .
-<unk> , die <unk> <unk> <unk> <unk> wird seine internationalen <unk> .
-Die <unk> eines <unk> in <unk> , die <unk> aus <unk> <unk> , die <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> und <unk> der <unk> <unk> in <unk> , <unk> , <unk> , <unk> <unk> , ein <unk> <unk> in der <unk> .
-<unk> Woche während ein <unk> in <unk> mit <unk> <unk> <unk> , <unk> <unk> <unk> gegen <unk> und <unk> .
-Die <unk> nach <unk> <unk> <unk> <unk>
-<unk> China , <unk> , <unk> , <unk> , <unk> und <unk> <unk> in <unk> und <unk> in <unk> und <unk> .
-<unk> ein <unk> von <unk> <unk> <unk> ein <unk> <unk> .
-Um die <unk> zu <unk> , die <unk> <unk> , die <unk> , die <unk> , die <unk> <unk> , der <unk> der <unk> <unk> .
-Für <unk> Tage <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> und anderen <unk> <unk> <unk> und <unk> <unk> <unk> <unk> .
-<unk> China , <unk> und <unk> <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> .
-<unk> <unk> , die besten <unk> für die <unk> der <unk> <unk> <unk> <unk> , &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-In diesem <unk> gibt es viel <unk> , wenn dieses <unk> <unk> , <unk> er <unk> .
-<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> für eine <unk> , ein <unk> , <unk> , <unk> mit <unk> <unk> <unk> <unk> <unk> .
-Aber <unk> , die im <unk> <unk> ist , bleibt <unk> .
-<unk>
-<unk> <unk> <unk> <unk> <unk> auf <unk> , wenn <unk> seine <unk> <unk> .
-<unk> ich <unk> , dass ich <unk> bin &quot; <unk> bin .
-<unk> <unk> <unk> werden sie <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> <unk> , die <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> , er hat er als <unk> <unk> <unk> , <unk> <unk> <unk> , weil <unk> <unk> ist , dass China <unk> seit <unk> <unk> <unk> hat .
-Die <unk> <unk> <unk> , die <unk> und <unk> <unk> <unk> gegen <unk> , <unk> , die er <unk> ist , die <unk> in <unk> gegen den <unk> <unk> .
-<unk> Sie die <unk> der <unk> <unk> <unk> <unk> in <unk> , ist auch von der <unk> <unk> <unk> .
-Das ist vom <unk> <unk> <unk> <unk> <unk> , ein <unk> <unk> .
-Die <unk> der <unk> <unk> , dass die <unk> auch <unk> <unk> und <unk> <unk> <unk> .
-Sie <unk> , dass die <unk> <unk> ein <unk> und <unk> er <unk> hat , den <unk> zu <unk> .
-Sie <unk> mit guten <unk> für seine <unk> des <unk> " <unk> &quot; von <unk> <unk> &quot; aus dem <unk> &quot; <unk> &quot; .
-Aber die <unk> ist nicht <unk> .
-Die Bevölkerung <unk> als <unk> <unk> der nationalen <unk> , die <unk> <unk> <unk> .
-<unk> ist es <unk> <unk> <unk> , die in <unk> <unk> .
-Und in <unk> <unk> wird es notwendig , um seine <unk> <unk> , <unk> <unk> zu <unk> .
-<unk> <unk> , ein <unk> <unk> für die <unk> von <unk> in Europa in Europa <unk> .
-Die <unk> <unk> <unk> <unk> <unk> und Russland einen <unk> der <unk> <unk> .
-Es ist <unk> , <unk> für die <unk> 30 30 <unk> .
-<unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-<unk> <unk> , die <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Mit diesem neuen <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Die <unk> ist durch <unk> der <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Und die Möglichkeit , ein <unk> <unk> von <unk> <unk> <unk> ist , ist bereits unter <unk> .
-<unk> , die <unk> auf diesem <unk> <unk> ist ein <unk> .
-<unk> wurde <unk> für <unk> und <unk> <unk> .
-Die <unk> <unk> wird <unk> <unk> direkt an Deutschland , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
-Diese beiden Länder werden einige von <unk> <unk> <unk> <unk> , wird es <unk> , Russland <unk> zu <unk> , Russland <unk> zu <unk> .
-<unk> <unk> der Aussprache , <unk> <unk> nicht <unk> neue &quot; <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-Das ist sagen , dass die <unk> <unk> <unk> .
-<unk> <unk> , <unk> <unk> , <unk> <unk> ist <unk> <unk> <unk> für seine <unk> .
-Aber auf der Zeit der <unk> Europas , da der <unk> eine <unk> zwischen <unk> und <unk> Europa <unk> .
-<unk> hat Russland <unk> ein <unk> zwischen Russland und dem <unk> <unk> , die eine <unk> zwischen Russland und den <unk> Ländern <unk> , die eine <unk> <unk> von <unk> <unk> und deren <unk> <unk> <unk> .
-&quot; Diese <unk> ist ein <unk> <unk> mit Russland , es ist eine neue <unk> , die uns <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Das <unk> die <unk> <unk> auf der <unk> der <unk> <unk> , <unk> in großen <unk> der <unk> .
-Die <unk> dieses <unk> ist auch eine <unk> <unk> .
-Die <unk> <unk> ist von <unk> <unk> in <unk> , um sie <unk> &quot; <unk> .
-<unk> <unk> auf der <unk> des <unk> .
-Um die zweite <unk> zu <unk> , war es notwendig , <unk> zu <unk> .
-&quot; Ein <unk> <unk> auf <unk> oder <unk> , <unk> &quot; <unk> <unk> <unk> <unk> <unk> .
-Es war auch notwendig , <unk> der <unk> und die <unk> .
-Die <unk> ist ein <unk> <unk> , der <unk> <unk> , der <unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> <unk> auf der <unk> der <unk> , aber die <unk> <unk> <unk> er sich seit <unk> <unk> <unk> <unk> .
-<unk> <unk> wir <unk> , dass die <unk> von <unk> für <unk> <unk> , &quot; <unk> <unk> <unk> <unk> .
-Im Falle einer <unk> , die <unk> in den <unk> <unk> wird daher in den <unk> <unk> .
-Diese ist <unk> durch die <unk> der <unk> , die nur alle <unk> <unk> <unk> .
-Die <unk> der <unk> ist der <unk> der <unk> der <unk> .
-<unk> <unk> , es ist <unk> der <unk> <unk> <unk> , und es ist <unk> von den <unk> .
-Auf <unk> Tage 3 Tagen , <unk> ein <unk> <unk> pro <unk> pro <unk> <unk> .
-<unk> wurde für <unk> 50 Jahre ohne <unk> <unk> .
-Die <unk> <unk> ist <unk> durch seine <unk> <unk> .
-Das ist <unk> <unk> auf <unk> und <unk> auf <unk> .
-<unk> Unternehmen und <unk> ihr <unk> <unk> dieses <unk> .
-Die <unk> ist <unk> , die <unk> der <unk> .
-Die anderen sind <unk> und <unk> <unk> <unk> und die <unk> <unk> und den <unk> <unk> <unk> <unk> <unk> <unk> .
-Diese <unk> <unk> eine <unk> <unk> als <unk> <unk> , <unk> , <unk> und <unk> zu <unk> .
-<unk> <unk> in <unk> , wo <unk> <unk> <unk> ist .
-Nach dem <unk> <unk> Jahren <unk> die gesamte <unk> <unk> .
-&quot; <unk> <unk> wird die <unk> der <unk> <unk> sein , kann der <unk> der <unk> nicht <unk> werden .
-Die <unk> der <unk> wurde der <unk> der <unk> <unk> und der <unk> von <unk> <unk> <unk> .
-Die <unk> Kosten des <unk> werden <unk> <unk> <unk> <unk> für die beiden <unk> .
-Die <unk> <unk> werden über <unk> <unk> <unk> .
-Aber die <unk> <unk> sind <unk> , da <unk> die gesamte <unk> <unk> .
-Die <unk> <unk> aus den <unk> und am <unk> <unk> <unk> mit <unk> .
-<unk> <unk> <unk> <unk> <unk> die <unk> <unk> .
-<unk> <unk> <unk> , <unk> und die <unk> <unk> der <unk> <unk> <unk> .
-Seit letzten letzten <unk> ist die <unk> eines <unk> <unk> <unk> <unk> <unk> für <unk> <unk> .
-In <unk> <unk> wird das <unk> 3 <unk> und in <unk> <unk> <unk> .
-<unk> , ein <unk> <unk> .
-Vor einigen Jahren <unk> die <unk> und <unk> <unk> <unk> .
-Es ist eine <unk> der <unk> .
-Die <unk> <unk> ist <unk> <unk> , die <unk> , die <unk> , die <unk> , die <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
-<unk> , die <unk> als heute <unk> , war der <unk> <unk> .
-Die <unk> <unk> <unk> , <unk> in <unk> eine <unk> <unk> .
-<unk> <unk> , <unk> ein <unk> des <unk> , hat sich <unk> für die <unk> der neuen <unk> <unk> .
-Die <unk> <unk> seine <unk> aus einer <unk> <unk> , die <unk> <unk> <unk> für <unk> <unk> <unk> .
-Diese <unk> ist <unk> <unk> von <unk> und <unk> .
-&quot; <unk> hat sich der <unk> für eine <unk> <unk> und <unk> <unk> , <unk> mit <unk> , die seit <unk> <unk> <unk> wurde .
-<unk> ist <unk> .
-<unk> 2006 <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> hat die <unk> des <unk> der ersten Jahre <unk> , als nur <unk> <unk> <unk> .
-<unk> ist <unk> der <unk> <unk> und ist <unk> , um den <unk> zu <unk> .
-Es ist <unk> , ein <unk> der <unk> <unk> , weil die <unk> <unk> eine <unk> <unk> , eine <unk> und eine <unk> <unk> .
-<unk> sind <unk> und <unk> .
-Das <unk> <unk> hat sich <unk> <unk> <unk> , die nur <unk> <unk> im <unk> und zwei <unk> <unk> .
-<unk> <unk> seine <unk> <unk> , <unk> <unk> in <unk> und <unk> <unk> <unk> .
-&quot; Wir <unk> das <unk> der <unk> und dieses <unk> benötigen für <unk> , <unk> , <unk> , <unk> , &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Diese <unk> <unk> die Entwicklung von <unk> <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> ihr <unk> <unk> .
-<unk> Sie auch eine <unk> <unk> auf der <unk> der <unk> in <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Ein Erfolg , die <unk> in der <unk> 2006 <unk> <unk> wurde , wurde <unk> von der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> ist der <unk> von <unk> <unk> <unk> <unk> ?
-<unk> <unk> <unk> sind für <unk> .
-Die Woche für die <unk> <unk> heute .
-Die <unk> eines öffentlichen <unk> in <unk> , der <unk> der <unk> ist noch <unk> <unk> wie die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
-<unk> ?
-<unk> , <unk> <unk> , <unk> von <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
-&quot; <unk> <unk> &quot; <unk> ist <unk> .
-&quot; Im <unk> war <unk> nicht <unk> , aber <unk> <unk> .
-&quot; Es gibt allerdings noch ein <unk> <unk> .
-Es muss <unk> sein , dass für die <unk> <unk> noch viele <unk> <unk> werden .
-<unk> sind nur 50 <unk> auf <unk> <unk> .
-Sie haben sich eine <unk> <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> , <unk> <unk> ist sehr <unk> , <unk> <unk> für die <unk> .
-<unk> , alle sind <unk> , die eine <unk> <unk> , die eine <unk> <unk> und die <unk> des <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Die <unk> sind einige der <unk> .
-Es ist <unk> notwendig , um <unk> zu <unk> , die <unk> <unk> , aber auch <unk> .
-Ein <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , dass die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> - <unk> Unternehmen über 20 <unk> <unk> die <unk> des <unk> <unk> , die von einer <unk> <unk> <unk> <unk> .
-Die <unk> <unk> <unk> auf 2008 haben eine <unk> von <unk> .
-&quot; Wir sind jetzt auf <unk> <unk> , &quot; <unk> <unk> , <unk> der <unk> , die <unk> der <unk> , die nicht <unk> .
-<unk> <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-&quot; Der <unk> der <unk> , die die <unk> , eine <unk> Druck auf Unternehmen , <unk> <unk> <unk> .
-<unk> <unk> auch eine <unk> von <unk> , in der <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> .
-<unk> &quot; <unk> <unk> &quot; <unk>
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-Wir haben nicht so weit wie <unk> , daß es zwischen ihnen <unk> <unk> , aber die <unk> ist <unk> .
-<unk> <unk> der <unk> des <unk> des <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> <unk> die <unk> der <unk> ihrer Türkei gegen die Türkei , die nur <unk> <unk> werden kann .
-&quot; Ich bin sehr <unk> mit <unk> , seine Fortschritt und <unk> <unk> .
-&quot; Ich möchte einige <unk> <unk> .
-<unk> <unk> <unk> und <unk> <unk> , &quot; es ist der <unk> , wenn es &quot; <unk> ist .
-<unk> &quot; <unk> <unk> ich mich alle <unk> , die nicht <unk> .
-&quot; Ich muss meine <unk> <unk> .
-<unk> <unk> auf <unk> <unk> in ihrer <unk> gegen <unk> <unk> .
-<unk>
-Er <unk> die <unk> der <unk> Jahre und 2000 <unk> .
-&quot; Ich bin ihnen <unk> , er <unk> .
-Diese <unk> <unk> in <unk> <unk> <unk> <unk> .
-<unk> <unk> da <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-&quot; Wir <unk> nur <unk> <unk> .
-&quot; <unk> &quot; , das <unk> <unk> ! &quot;
-<unk> <unk> <unk> <unk> &quot; <unk> .
-&quot;
-&quot; auch in der <unk> <unk> <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
-&quot; <unk> <unk> <unk> wurde er ein <unk> , er <unk> <unk> .
-<unk> , dass <unk> die nächsten <unk> , die <unk> <unk> , wird die <unk> <unk> mit <unk> <unk> ...
-<unk> &quot; <unk> <unk> , &quot; er <unk> .
-&quot; <unk> <unk> ist ein <unk> <unk> , <unk> sie <unk> .
-&quot; Sie <unk> diese während der <unk> <unk> .
-<unk> ist sehr <unk> <unk> .
-Der <unk> von <unk> <unk> <unk> seine <unk> gegen <unk> <unk> .
-<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die Zukunft <unk> der <unk> Regierung <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> , <unk>
+Die <unk> <unk> wurde in <unk> mit dem <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> .
+<unk> werden ein <unk> <unk> <unk> von <unk> <unk> <unk> .
+&quot; <unk> <unk> <unk> über eine wichtige <unk> , ein <unk> <unk> , <unk> <unk> <unk> , eine <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> oder <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , ob der neue Regierung <unk> <unk> .
+Die <unk> wird in der <unk> von <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> auf der <unk> <unk> <unk> <unk> .
+<unk> eines &quot; Demokratie ist <unk> <unk> und <unk> <unk> , dass er <unk> , dass die <unk> <unk> und <unk> <unk> wird .
+<unk> <unk> der <unk> war der <unk> <unk> , aber <unk> <unk> , in der <unk> in <unk> <unk> in <unk> <unk> .
+Die <unk> <unk> hat eine <unk> , die <unk> <unk> , <unk> er <unk> , dass er auch <unk> <unk> , <unk> <unk> .
+Die neue Regierung <unk> in <unk> , die <unk> der <unk> <unk> , <unk> ich <unk> .
+<unk> die <unk> der <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> <unk> <unk> <unk> , <unk> er <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Ein <unk> für die Europäische Kommissarin , <unk> <unk> <unk> , dass <unk> <unk> , dass die <unk> der <unk> nicht <unk> ist .
+Die Europäische Union ist <unk> , dass <unk> <unk> nicht die <unk> der <unk> in <unk> <unk> <unk> <unk> hat , <unk> , <unk> , <unk> und <unk> .
+Die <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk>
 <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
-<unk> <unk> bereits <unk> in <unk> und in der <unk> .
-Für ihn gibt es nicht um eine <unk> , die <unk> , die er im <unk> 2010 <unk> hat , wird <unk> für <unk> <unk> .
-Das <unk> ist nur wenige <unk> entfernt .
-Doch es gibt es <unk> , und eine <unk> , <unk> zu <unk> .
-<unk> der <unk> auf <unk> in <unk> ist klar , dass die <unk> nicht mehr .
-<unk> <unk> die <unk> für einen <unk> , war es nicht <unk> , dass es <unk> <unk> .
-&quot; Es ist eine gute <unk> , das <unk> eine <unk> <unk> <unk> &quot; <unk> wird .
-<unk> <unk> <unk> de la <unk> in <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
-<unk> &quot; Wir <unk> eine sehr <unk> <unk> , aber wir sind <unk> , dass wir die <unk> <unk> <unk> können , <unk> die <unk> <unk> <unk> .
-&quot; Wir haben uns eine <unk> <unk> von <unk> an <unk> <unk> , &quot; <unk> unter dem <unk> der <unk> <unk> .
-Die <unk> zur <unk> von <unk> aus <unk> <unk> .
-<unk> kann eine <unk> <unk> .
-&quot; Es ist eine gute <unk> , das <unk> einige <unk> <unk> , <unk> <unk> .
+Die <unk> ist der <unk> der <unk> .
+Herr Präsident , <unk> möchte ein <unk> <unk> , weil der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> werden .
+<unk> <unk> hat ein <unk> <unk> <unk> <unk> <unk> <unk>
+Ein <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Die <unk> der <unk> von <unk> <unk> <unk> sich auf die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> Woche ist <unk> , die <unk> <unk> zu <unk> <unk> <unk> &quot; <unk> " <unk> " <unk> <unk> " .
+<unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Im <unk> oder <unk> <unk> er die <unk> , ein <unk> <unk> <unk> &quot; in <unk> .
+Die größte <unk> der <unk> der <unk> <unk> ich <unk> , die <unk> in <unk> in <unk> .
+Er kann <unk> <unk> auf eine <unk> <unk> des <unk> <unk> , um <unk> zu <unk> .
+<unk> <unk> <unk> &quot; <unk> <unk> <unk> , dass die Entwicklung von <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> haben <unk> <unk> <unk>
+<unk> <unk> <unk> und 2010 , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> auf diese <unk> <unk> , <unk> die <unk> von <unk> gegen <unk> in <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> eine <unk> in <unk> <unk> , ist es <unk> , diese <unk> zu <unk> , die <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , die <unk> in einer <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> Regierung <unk> und müssen mehr mit seiner <unk> <unk> , <unk> <unk> , dass die <unk> der <unk> <unk> auf <unk> <unk> <unk> .
+&quot; <unk> &quot; <unk> &quot; in <unk> <unk> , ist eine <unk> von der <unk> für die <unk> .
+Das <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+<unk> <unk> seine <unk> und <unk> <unk>
+Im <unk> , die <unk> <unk> <unk> <unk> <unk> <unk> in der <unk> der <unk> <unk> <unk> <unk> <unk> , die <unk> der <unk> , die <unk> , die <unk> <unk> , die <unk> <unk> .
+Ein <unk> &quot; und eine <unk> &quot; <unk> &quot; und eine <unk> &quot; <unk> &quot; <unk> und <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Diese <unk> , wenn sie <unk> , <unk> <unk> , wenn sie neue <unk> <unk> , wenn sie neue <unk> <unk> , wenn sie <unk> werden , <unk> .
+Dies <unk> <unk> <unk> <unk> <unk> &quot; <unk> auf ein <unk> <unk> " in <unk> &quot; <unk> &quot; <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Am <unk> , <unk> Sie sich über die <unk> der <unk> <unk> &quot; <unk> &quot; .
+<unk> ist <unk> , <unk> und <unk> <unk> .
+&quot; <unk> &quot; <unk> &quot; &quot; <unk> &quot; <unk> &quot; , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk>
+<unk> einer <unk> &quot; <unk> &quot; in der <unk>
+Die Regierung Regierung <unk> <unk> / <unk> / <unk> <unk> in <unk> in <unk> in <unk> auf <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Es war die <unk> <unk> , seine <unk> <unk> , <unk> <unk> , die dieses <unk> in der <unk> der <unk> <unk> , <unk> , <unk> oder <unk> .
+<unk> &quot; <unk> <unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> mit einer <unk> von der <unk> <unk> der <unk> der <unk> und der <unk> von <unk> <unk> <unk> die <unk> der <unk> und einer <unk> von <unk> in der <unk> <unk> .
+Die Entschließung hat den <unk> Regierung der <unk> <unk> <unk> <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; .
+<unk> , die <unk> <unk> <unk> müssen , müssen die <unk> der <unk> und der <unk> der <unk> <unk> , die <unk> <unk> , die <unk> <unk> , <unk> <unk> <unk> .
+Die <unk> ist , dass der <unk> die <unk> <unk> der <unk> von <unk> / <unk> / <unk> <unk> .
+<unk>
+<unk> <unk> auf den <unk> <unk>
+Die <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> <unk> , <unk> wir <unk> , wenn wir <unk> in der <unk> der <unk> der <unk> <unk> , <unk> <unk> , <unk> <unk> , die <unk> <unk> .
+Am <unk> , die <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+Die <unk> , <unk> <unk> die <unk> der <unk> gegen den <unk> in <unk> , um die <unk> der <unk> <unk> , die <unk> <unk> <unk> <unk> .
+Doch die <unk> <unk> <unk> seit <unk> von <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> in Europa .
+Im <unk> , die <unk> <unk> <unk> <unk> <unk> und die <unk> <unk> des <unk> <unk> <unk> , <unk> die <unk> der <unk> .
+Die <unk> , die <unk> <unk> wurde <unk> und die <unk> über <unk> <unk> .
+Diese <unk> der <unk> <unk> <unk> <unk> , weil sie <unk> <unk> <unk> <unk> und <unk> die <unk> von <unk> <unk> <unk> , wenn <unk> in den nationalen <unk> <unk> .
+&quot; <unk> ist <unk> <unk> , um die <unk> und die <unk> <unk> <unk> , die die Region <unk> der <unk> <unk> <unk> .
+Die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Doch die <unk> <unk> <unk> , dass die <unk> <unk> der <unk> <unk> <unk> <unk> <unk> .
+Die <unk> von <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+Aber die <unk> <unk> der <unk> , <unk> <unk> , dass die <unk> der <unk> <unk> hat , <unk> <unk> , dass die <unk> der <unk> <unk> <unk> wurde , die keine <unk> <unk> wurde .
+<unk> seine <unk> in der <unk> des <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk>
+Die <unk> sind <unk> , die <unk> <unk> <unk> sind .
+Die <unk> <unk> der <unk> , die europäische <unk> ist <unk> <unk> .
+<unk> der <unk> <unk> des <unk> in <unk> und <unk> die <unk> <unk> in Frankreich und <unk> die <unk> in <unk> .
+<unk> <unk> über die <unk> von <unk> , europäischen <unk> haben eine <unk> <unk> in diesem <unk> <unk> .
+<unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+Die <unk> <unk> <unk> <unk> und <unk> <unk> .
+Die neue <unk> über die <unk> der <unk> in <unk> , die <unk> <unk> , die <unk> <unk> , eine <unk> <unk> zu <unk> .
+&quot; <unk> <unk> sind nur <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> sind mit einem <unk> von <unk> , <unk> <unk> <unk> der <unk> der <unk> Europas <unk> .
+&quot; <unk> , wie die <unk> der <unk> des <unk> <unk> <unk> <unk> auf Europa und die <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Diese <unk> <unk> über die Zukunft der Zukunft der Zukunft <unk> , die <unk> zu <unk> .
+Die <unk> ist die <unk> der <unk> <unk> für eine <unk> und <unk> .
+<unk> <unk> <unk> das Europäische <unk> ist <unk> <unk> , <unk> <unk> .
+Die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> und <unk> <unk> <unk> <unk>
+Die <unk> <unk> von <unk> und <unk> ist <unk> <unk> <unk> .
+Diese <unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> , dass der <unk> der <unk> <unk> <unk> <unk> <unk> , <unk> .
+Diese <unk> der <unk> der <unk> Länder , aber auch <unk> , <unk> die <unk> der <unk> .
+Die <unk> der <unk> Regierung <unk> Regierung , <unk> <unk> , die <unk> für die <unk> in einer <unk> <unk> von <unk> zu <unk> .
+Die neue <unk> <unk> <unk> <unk> <unk> <unk> , dass die <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; .
+<unk> <unk> <unk> sich in der Nähe des <unk> <unk> <unk> .
+Die <unk> der <unk> zwischen <unk> und <unk> hat <unk> <unk> <unk> <unk> .
+<unk> der <unk>
+Frankreich hat eine <unk> <unk> des <unk> in der <unk> <unk> , ein <unk> <unk> als die <unk> <unk> <unk> .
+Die <unk> <unk> <unk> die <unk> <unk> , mit einem <unk> von <unk> der <unk> <unk> .
+<unk> ist wirklich der <unk> <unk> , die die <unk> <unk> .
+<unk> <unk> ein <unk> <unk> für die <unk> <unk> <unk> .
+Ein <unk> <unk> in der <unk> der <unk> ist der <unk> in <unk> <unk> <unk> <unk> , die europäische <unk> <unk> .
+<unk>
+<unk> müssen <unk> <unk>
+<unk> ist ein <unk> , die mit dem <unk> <unk> , <unk> oder in der <unk> <unk> , ist es <unk> <unk> .
+Die <unk> und <unk> der <unk> <unk> zwischen den <unk> und der <unk> .
+Es ist <unk> , dass ein <unk> <unk> für <unk> <unk> und die <unk> von <unk> <unk> <unk> werden .
+Die Aussprache wird nicht <unk> werden , dass sie alle <unk> <unk> , die <unk> und die <unk> der <unk> <unk> .
+Die <unk> müssen ihre <unk> <unk> <unk> <unk> .
+<unk> , dass wir <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Während der <unk> <unk> , wird es die <unk> <unk> , die <unk> zu <unk> , um die <unk> <unk> zu <unk> , um die <unk> <unk> zu <unk> , um die <unk> der <unk> <unk> zu <unk> .
+Die <unk> <unk> ist nicht <unk> .
+Das ist <unk> <unk> im <unk> <unk> <unk> .
+Dies ist nicht der <unk> <unk> , die sich auf die Notwendigkeit <unk> , um eine <unk> <unk> zu <unk> , <unk> oder die <unk> , die nur die <unk> <unk> .
+<unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> mit <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> mit <unk>
+Der <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> in einer <unk> der <unk> <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+<unk> <unk> diese <unk> <unk> werden .
+Die Fall sollte <unk> werden .
+<unk> Europa in der <unk> der <unk> , der der <unk> <unk> <unk> , ist auch eine der <unk> <unk> der <unk> und der <unk> , die ihre <unk> <unk> und der <unk> <unk> .
+Auf den anderen Seite , <unk> Sie die <unk> , unsere <unk> zu <unk> , die <unk> <unk> <unk> <unk> .
+Seit der <unk> Wirtschaft der <unk> Wirtschaft der <unk> ist eine <unk> <unk> von <unk> und eine <unk> in der <unk> der <unk> in Europa .
+<unk> <unk> in diesem <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Ein <unk> <unk> , die eine <unk> Mehrheit der <unk> <unk> , die <unk> <unk> , weil sie sich nicht <unk> werden .
+Es sollte <unk> <unk> , dass die <unk> unserer Land <unk> , eine <unk> von <unk> zu <unk> und <unk> <unk> <unk> .
+<unk> <unk> , es <unk> eine <unk> von <unk> , <unk> und <unk> <unk> <unk> , die nicht <unk> .
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> würde ein <unk> <unk> für <unk> Jahren <unk> , wenn die <unk> ihrer <unk> war ?
+Um die <unk> <unk> , muss es nicht <unk> werden , dass es keine <unk> oder <unk> <unk> werden .
+Die Entwicklung von <unk> <unk> <unk> über <unk> <unk> , <unk> und <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Für die <unk> des <unk> ist <unk> <unk> <unk> .
+<unk> haben wir eine <unk> <unk> , die eine <unk> und <unk> der <unk> <unk> <unk> <unk> <unk> <unk> .
+Unsere <unk> , deren <unk> ist <unk> , sind <unk> , die <unk> <unk> <unk> .
+In einem <unk> Jahren <unk> die <unk> drei <unk> <unk> .
+<unk> einer <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
+Die <unk> und <unk> <unk> die <unk> und <unk> <unk> über die <unk> .
+Die <unk> , einige Menschen zu <unk> , dass die <unk> von zwei <unk> <unk> <unk> <unk> <unk> , die die <unk> der <unk> <unk> <unk> <unk> , die <unk> der <unk> <unk> .
+Die <unk> wird von diesem <unk> <unk> , wie es von zwei <unk> <unk> .
+Die <unk> dieser Schritt <unk> und der <unk> der <unk> und der <unk> , die <unk> und <unk> <unk> , die <unk> eine <unk> <unk> .
+<unk> <unk> die <unk> von allen <unk> , ein <unk> <unk> , ein <unk> <unk> , ein <unk> zu <unk> , ein <unk> zu <unk> und <unk> zu <unk> .
+Es wäre <unk> und <unk> , <unk> für die <unk> <unk> von <unk> für unsere <unk> , sondern es <unk> , <unk> , <unk> und <unk> .
+<unk> ein <unk> oder ein System für die Wirtschaft ?
+<unk> hat <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> , es ist <unk> <unk> , <unk> <unk> <unk> , die <unk> , <unk> , <unk> und <unk> .
+Doch es ist nur <unk> <unk> von der <unk> <unk> .
+Es ist ein <unk> <unk> zwischen der <unk> und der <unk> <unk> .
+Im <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Der <unk> , der <unk> <unk>
+In <unk> , die <unk> der <unk> der nationalen <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> in der <unk> <unk> , die eine <unk> , um <unk> zu <unk> .
+Im <unk> , <unk> <unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Diese <unk> <unk> eine <unk> und ein Problem <unk> , aber es ist <unk> sehr <unk> .
+Was die <unk> <unk> und <unk> <unk> , <unk> wir uns in einer <unk> <unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> die <unk> <unk> und <unk> <unk> .
+<unk> über die <unk> der <unk> sind <unk> , dass sie <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Aber <unk> <unk> , die in <unk> <unk> sind , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> <unk> , <unk> , <unk> , <unk> , <unk> nicht <unk> und die <unk> <unk> <unk> in <unk> , <unk> , <unk> ist nicht <unk> .
+<unk> <unk> <unk> auf <unk> <unk> .
+In einer <unk> wäre wie eine <unk> <unk> <unk> , die <unk> zwischen <unk> und <unk> <unk> , die <unk> zwischen <unk> und <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> hat sich <unk> , dass eine <unk> von <unk> und <unk> in <unk> <unk> <unk> <unk> .
+<unk> ohne <unk> <unk> die Tatsache , dass die <unk> der <unk> von <unk> und <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> und <unk> .
+<unk> sind auch die <unk> <unk> , <unk> <unk> der <unk> <unk> der Europäischen Union .
+<unk> <unk> <unk> <unk> <unk> , dass die <unk> in Deutschland <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> im <unk> des <unk> <unk> <unk> <unk> <unk> <unk> &quot; <unk> &quot; <unk> &quot; <unk> .
+Die <unk> in Frage , um <unk> zu <unk> , <unk> die <unk> <unk> .
+Europa <unk> Demokratie , <unk> in <unk> .
+<unk> ist ein <unk> <unk> .
+Die Europäische <unk> sollte <unk> zu <unk> <unk> <unk> <unk> , dass es in <unk> über zwei <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> , dass es <unk> war , war es <unk> für die <unk> <unk> über ihre <unk> , um die Abstimmung , die <unk> und <unk> zu <unk> .
+Es ist <unk> , dass die Zeit der <unk> es <unk> ist , <unk> <unk> .
+<unk> <unk> , in <unk> , um die <unk> <unk> <unk> <unk> , ist nicht <unk> und kann nicht <unk> <unk> <unk> .
+<unk> , Demokratie <unk> , ein <unk> , ein <unk> , ein <unk> , ein <unk> , ein <unk> und <unk> <unk> , <unk> , <unk> und <unk> .
+Die Europäische Krise , die wir über <unk> sind , ist ein <unk> <unk> , aber es ist <unk> eine politische Krise und die Demokratie .
+In diesem <unk> ist die <unk> einer <unk> <unk> <unk> <unk> , die eine <unk> <unk> von <unk> und <unk> <unk> .
+Diese <unk> muss über <unk> , dass es <unk> werden kann .
+Die <unk> ist , dass die <unk> der <unk> <unk> <unk> <unk> <unk> , und die <unk> <unk> sind nicht mehr <unk> .
+Wir haben eine <unk> von <unk> ein <unk> <unk> <unk> und in einer <unk> <unk> .
+<unk> &quot; <unk> &quot; <unk> &quot; <unk> " <unk> " eine <unk> <unk> und eine <unk> mit <unk> <unk> in den <unk> <unk> .
+<unk> wollen wir nicht die <unk> einer <unk> , aber eine <unk> , <unk> und <unk> , der <unk> und Demokratie , der <unk> und Demokratie , der <unk> und Demokratie , <unk> .
+Es gibt keine <unk> in <unk> , <unk> , <unk> oder <unk> , weil es nur eine <unk> Krise <unk> , weil es nur eine <unk> Krise und <unk> ist , weil es nur eine <unk> Krise und <unk> ist .
+Es ist <unk> der <unk> Europas , die <unk> und <unk> <unk> , die von ihrer <unk> und eine <unk> der <unk> <unk> .
+Es ist <unk> , die internationale <unk> <unk> .
+Es ist <unk> <unk> , die <unk> zu Europa , aber es ist die gesamte <unk> , die die <unk> , die die <unk> <unk> , und mit ihrem <unk> .
+Die <unk> hat die <unk> <unk> <unk> , die <unk> des Europäischen <unk> .
+Es ist von allen <unk> , die <unk> <unk> , die die <unk> der <unk> <unk> , die <unk> , die <unk> und <unk> für die Zukunft der Zukunft <unk> .
+<unk> von der Krise <unk> <unk> auf der <unk> , die nicht <unk> werden , ohne <unk> <unk> zu <unk> .
+Die <unk> <unk> dieser Vorschlag von <unk> und <unk> <unk> , die <unk> <unk> des <unk> für eine europäische <unk> <unk> .
+<unk> ist <unk> .
+Doch die <unk> ohne <unk> <unk> <unk> <unk> und <unk> <unk> und <unk> in diesem <unk> werden ein <unk> <unk> und eine neue <unk> <unk> .
+Wir müssen eine neue <unk> europäischen <unk> .
+Um die <unk> in Frankreich <unk> , ist es <unk> <unk> <unk> .
+Der <unk> wäre nicht <unk> .
+Diese <unk> ist <unk> .
+Wir müssen ein <unk> <unk> über die <unk> <unk> .
+Dies kann nur durch <unk> <unk> <unk> werden , um eine <unk> <unk> europäische <unk> .
+Für Europa <unk> uns <unk> <unk> .
+<unk> <unk> ohne <unk> werden .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> in <unk> <unk> .
+Die <unk> sollte eine <unk> <unk> von <unk> <unk> <unk> <unk> , <unk> mit einem <unk> <unk> mit <unk> <unk> <unk> , <unk> , <unk> .
+Die <unk> ist , dass die <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> oder <unk> für die <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Für eine <unk> Zeit <unk> die <unk> <unk> in <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Doch die gesamte <unk> sind <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Um <unk> zu <unk> , ist es jetzt zu <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> sind <unk> von <unk> <unk>
+Doch die <unk> nur ein <unk> <unk> , <unk> , <unk> , <unk> .
+<unk> <unk> sind mit <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Sie haben <unk> .
+&quot; <unk> <unk> sollte sie <unk> werden .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Doch die <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> von <unk> <unk> und <unk> sind <unk> , um <unk> zu <unk> .
+Die <unk> hat in <unk> <unk> und in <unk> <unk> .
+Und die <unk> <unk> auch auch <unk> <unk> , dass es die <unk> <unk> eines <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk>
+<unk> ist <unk> von <unk> zwischen der <unk> und der <unk> <unk> .
+<unk> für eine <unk> Zeit <unk> die <unk> zwischen der <unk> in der <unk> und der <unk> <unk> <unk> <unk> .
+<unk> , die <unk> <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Die <unk> in der beiden <unk> , die zwei <unk> <unk> und die <unk> von <unk> <unk> <unk> , ist es eine <unk> der Zusammenarbeit , die er nicht <unk> .
+<unk> <unk> sich ein <unk> <unk> .
+Die <unk> in der <unk> zwei <unk> in <unk> <unk> zwei <unk> <unk> .
+Die <unk> <unk> in einer <unk> von <unk> von <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> <unk> .
+<unk> der <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk>
+Die <unk> von <unk> <unk> <unk> <unk> in <unk> und in <unk> .
+<unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> ist ein <unk> , aber es ist <unk> <unk> , um <unk> Zusammenarbeit zu <unk> und <unk> zu <unk> .
+<unk> ist es möglich .
+Die <unk> ist sehr <unk> , dass die <unk> von <unk> <unk> und <unk> <unk> und <unk> <unk> ist , <unk> <unk> <unk> .
+In der Unterstützung der <unk> <unk> <unk> der <unk> und der <unk> von <unk> und der <unk> von <unk> und der <unk> <unk> <unk> , die <unk> , die <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+Die internationale Gemeinschaft , <unk> mit <unk> , ist jetzt die internationale <unk> , um die Probleme von <unk> zu <unk> .
+<unk> Behörden haben eine <unk> <unk> , die <unk> <unk> <unk> , nicht <unk> .
+<unk> ?
+Die <unk> in <unk> auf <unk> <unk> <unk> , ein <unk> und eine <unk> <unk> <unk> <unk> , <unk> <unk> , die die <unk> einer <unk> <unk> <unk> .
+In diesem <unk> ist die <unk> <unk> <unk> <unk> .
+Es ist <unk> und <unk> <unk> <unk> , die ihre <unk> in einer <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> , <unk> und <unk> .
+Im <unk> 2009 die <unk> von <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> <unk> <unk> .
+Die <unk> der <unk> ist als <unk> , ohne <unk> und <unk> .
+Die <unk> <unk> eine <unk> von <unk> und <unk> .
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> wird die <unk> <unk> und werden ihre <unk> <unk> <unk> .
+<unk> <unk> es <unk> ein <unk> , die <unk> <unk> und <unk> <unk> .
+Im Juni <unk> <unk> <unk> die <unk> ein <unk> <unk> in <unk> <unk> .
+In <unk> wird die <unk> internationale internationalen <unk> <unk> .
+Die <unk> eines <unk> in <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+Die <unk> hat <unk> <unk> und <unk> und die <unk> von <unk> in <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> Woche in einer <unk> mit <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> des <unk> <unk>
+<unk> <unk> <unk> <unk> , <unk> <unk> , <unk> , <unk> und <unk> <unk> in <unk> und <unk> <unk> .
+<unk> eine <unk> von <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ?
+Um die <unk> von <unk> <unk> , die <unk> <unk> ist , ist es <unk> .
+Die <unk> Tage <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und anderen <unk> und <unk> <unk> <unk> <unk> , die eine <unk> <unk> <unk> .
+<unk> <unk> China , <unk> und <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> .
+<unk> <unk> , die <unk> <unk> für die <unk> des <unk> <unk> <unk> , &quot; <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> <unk> sich die <unk> , wenn diese <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> ist ein <unk> , aber eine <unk> , die mit <unk> <unk> <unk> <unk> <unk> <unk>
+Doch <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> der <unk>
+<unk> auch <unk> <unk> <unk> <unk> <unk> <unk> , wenn <unk> <unk> <unk> werden .
+<unk> <unk> ich <unk> , dass er die <unk> <unk> <unk> .
+<unk> ist <unk> , die <unk> <unk> .
+<unk> <unk> auch <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> , die eine <unk> <unk> <unk> , <unk> <unk> der <unk> .
+<unk> <unk> er sich <unk> , dass die <unk> <unk> <unk> <unk> <unk> , weil er <unk> ist , <unk> <unk> , dass China er <unk> hat !
+Die <unk> <unk> <unk> <unk> , die <unk> und <unk> <unk> <unk> gegen <unk> , <unk> , dass er <unk> ist , die <unk> <unk> in <unk> <unk> <unk> .
+<unk> Sie die <unk> von <unk> <unk> in <unk> <unk> , ist auch die <unk> <unk> <unk> .
+<unk> ist von der <unk> <unk> <unk> <unk> <unk> , ein <unk> <unk> .
+Die <unk> der <unk> <unk> <unk> , dass die <unk> auch auch die <unk> <unk> <unk> <unk> .
+Sie <unk> , dass die <unk> <unk> eine <unk> und die <unk> <unk> <unk> <unk> <unk> .
+<unk> mit <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Doch die <unk> ist nicht <unk> .
+<unk> als <unk> <unk> <unk> die <unk> des <unk> , die <unk> <unk> .
+<unk> <unk> es <unk> <unk> , die <unk> in <unk> .
+Und in der <unk> ist es zu <unk> , um ihre <unk> zu <unk> , die <unk> zu <unk> , ist <unk> <unk> .
+<unk> <unk> , eine neue <unk> für die <unk> der <unk> in Europa in Europa .
+Das <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> und <unk> <unk> .
+Es ist <unk> , <unk> für die <unk> des <unk> <unk> .
+<unk> , die <unk> <unk> <unk> <unk> , <unk> die <unk> mit &quot; <unk> &quot; .
+<unk> <unk> <unk> <unk> pro <unk> und der Regierung <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> , die <unk> <unk> <unk> , die <unk> <unk> <unk> , die <unk> <unk> , die <unk> <unk> <unk> und seine <unk> <unk> <unk> .
+Mit diesem neuen <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Ein <unk> <unk> ist es , die <unk> von <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Und wenn die Möglichkeit einer <unk> <unk> <unk> <unk> <unk> ist .
+Für die <unk> <unk> dieses <unk> ist eine <unk> .
+<unk> war <unk> <unk> für die <unk> und die <unk> .
+Die <unk> werden <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Diese zwei Länder wird <unk> über die <unk> <unk> , es wird <unk> <unk> , die <unk> , Russland zu <unk> , <unk> zu <unk> .
+Im <unk> <unk> <unk> die Aussprache , die <unk> nicht <unk> <unk> <unk> <unk> <unk> , &quot; <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+Das ist der <unk> <unk> <unk> .
+<unk> <unk> hat diese <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Aber in der Nähe des <unk> hat die <unk> eine <unk> zwischen <unk> und <unk> Europa .
+Russland hat <unk> <unk> als 5 Jahren <unk> , die <unk> <unk> zwischen Russland und die <unk> <unk> , die <unk> <unk> <unk> , und deren <unk> sind <unk> .
+Die <unk> ist eine <unk> von <unk> mit Russland , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> der <unk> <unk> auf der <unk> der <unk> <unk> , <unk> <unk> , <unk> <unk> der <unk> .
+Die <unk> dieses <unk> ist auch eine <unk> <unk> .
+Die <unk> <unk> ist von <unk> <unk> in <unk> , um die <unk> von <unk> &quot; <unk> &quot; .
+<unk> <unk> auf die <unk> des <unk> , in einem <unk> <unk> von <unk> <unk> .
+Um die <unk> <unk> ist , <unk> zu <unk> <unk> zu <unk> .
+<unk> &quot; <unk> <unk> <unk> oder <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Es war auch <unk> , <unk> der <unk> und die <unk> .
+Die <unk> ist ein <unk> <unk> <unk> , der <unk> <unk> , die <unk> <unk> , <unk> <unk> und keine <unk> <unk> .
+Ein <unk> war <unk> <unk> in der <unk> <unk> <unk> <unk> , aber die <unk> <unk> <unk> sie nicht auf <unk> <unk> .
+<unk> &quot; <unk> <unk> wir die <unk> für eine <unk> <unk> , &quot; <unk> <unk> <unk> .
+In der Fall eines <unk> , die <unk> <unk> in den <unk> <unk> .
+Doch dies ist der <unk> <unk> , durch die <unk> der <unk> <unk> <unk> <unk> <unk> .
+Die <unk> der <unk> ist durch eine <unk> <unk> der <unk> <unk> <unk> , die von einer <unk> <unk> <unk> <unk> , als <unk> <unk> <unk> .
+<unk> <unk> , es ist <unk> der <unk> <unk> , und es ist <unk> <unk> der <unk> .
+Im <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> wurde <unk> <unk> , um die <unk> <unk> <unk> .
+Die <unk> <unk> ist <unk> durch ihre <unk> .
+Das <unk> <unk> bietet <unk> <unk> und <unk> <unk> .
+<unk> Unternehmen ihre <unk> zu <unk> .
+Die <unk> ist <unk> , die <unk> <unk> der <unk> .
+Die <unk> sind <unk> und <unk> <unk> <unk> und <unk> <unk> und die <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+<unk> <unk> <unk> ein <unk> <unk> <unk> <unk> <unk> , <unk> , <unk> und <unk> .
+Die <unk> in <unk> in <unk> , wo <unk> ist <unk> <unk> .
+Als <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> , die gesamte <unk> <unk> .
+&quot; <unk> wird die <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> .
+Die <unk> der <unk> wurde der <unk> der <unk> <unk> und <unk> von <unk> <unk> .
+<unk> <unk> die <unk> werden <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> werden <unk> <unk> <unk> .
+Doch die <unk> <unk> sind <unk> , die <unk> , weil die <unk> <unk> <unk> wird .
+Die <unk> <unk> von der <unk> mit <unk> auf <unk> <unk> .
+<unk> <unk> <unk> <unk> die <unk> <unk> .
+<unk> <unk> <unk> , <unk> und die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Im <unk> werden 3 <unk> ein <unk> <unk> und in <unk> <unk> <unk> <unk> .
+<unk> , eine <unk> <unk> .
+<unk> <unk> Jahren <unk> <unk> <unk> , wird die <unk> der Richtlinie .
+Es ist eine <unk> der <unk> , der zwischen einer der <unk> <unk> <unk> .
+Die <unk> <unk> ist <unk> <unk> , durch ihre <unk> <unk> <unk> , ihre <unk> <unk> <unk> .
+<unk> , die <unk> <unk> , <unk> wir wissen , war es in <unk> .
+Das <unk> <unk> <unk> <unk> , <unk> in <unk> , <unk> , <unk> , eine <unk> <unk> .
+<unk> <unk> , die eine <unk> der <unk> <unk> , hat <unk> eine <unk> des <unk> .
+Die <unk> <unk> die <unk> von einer <unk> <unk> , die <unk> , die <unk> , die <unk> , die <unk> <unk> <unk> für <unk> <unk> , <unk> .
+Diese <unk> ist sehr <unk> , <unk> und <unk> .
+&quot; <unk> ist <unk> <unk> , die <unk> <unk> für eine <unk> und <unk> <unk> , die mit <unk> <unk> <unk> , <unk> <unk> <unk> .
+<unk> ist es <unk> .
+<unk> 2006 und 2010 , <unk> <unk> von <unk> <unk> <unk> <unk> .
+<unk> hat die <unk> der ersten Jahre <unk> , wenn nur <unk> <unk> wurde .
+<unk> ist die <unk> <unk> und ist die <unk> <unk> .
+Es ist <unk> <unk> , eine <unk> der <unk> <unk> , weil die <unk> eine <unk> und eine <unk> .
+<unk> sind <unk> , <unk> und <unk> .
+Die neue <unk> <unk> , die <unk> <unk> <unk> , hat jetzt <unk> <unk> <unk> und zwei <unk> <unk> , eine in <unk> und <unk> <unk> .
+<unk> <unk> seine <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; Wir <unk> die <unk> des <unk> und der Notwendigkeit der <unk> <unk> , die die <unk> <unk> , &quot; <unk> <unk> <unk> .
+Diese <unk> <unk> <unk> die Entwicklung von <unk> , <unk> , <unk> , <unk> oder <unk> <unk> .
+In <unk> ist es auch ein <unk> <unk> auf die <unk> der <unk> in <unk> .
+<unk> seine Erfolg und die <unk> <unk> , <unk> ihre <unk> zu <unk> , <unk> , <unk> , <unk> .
+Ein Erfolg , die <unk> in der <unk> 2006 <unk> , <unk> <unk> wurde der <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> ist der <unk> der <unk> <unk> <unk> <unk> <unk> ?
+<unk> <unk> von <unk> sind <unk> für <unk> .
+Die <unk> Woche für die <unk> des <unk> <unk> heute .
+<unk> ein <unk> <unk> in <unk> , <unk> der <unk> der <unk> ist noch <unk> als <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+<unk> ?
+&quot; <unk> , <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> und <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> <unk> war , dass die <unk> der <unk> nicht <unk> , sondern <unk> <unk> .
+&quot; <unk> ist jedoch noch ein <unk> <unk> .
+Es muss sehr <unk> <unk> , dass für die <unk> , die noch viele <unk> <unk> sind .
+<unk> sind <unk> <unk> .
+Sie haben ein <unk> <unk> von <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> ist <unk> , <unk> für die <unk> <unk> <unk> <unk> .
+Die <unk> sind <unk> , die <unk> <unk> , die eine <unk> <unk> , und die <unk> der <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk>
+<unk> sind einige der <unk> .
+Es ist <unk> <unk> , <unk> , <unk> , <unk> , aber auch <unk> .
+Ein <unk> und <unk> in <unk> von der <unk> <unk> <unk> , dass die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> - <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Die <unk> <unk> <unk> sich auf eine <unk> <unk> .
+<unk> <unk> , &quot; <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> &quot; <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk>
+Die <unk> der <unk> , die die <unk> , die eine <unk> <unk> , <unk> <unk> , <unk> <unk> <unk> .
+Die <unk> <unk> auch eine <unk> von <unk> , in <unk> in <unk> <unk> .
+<unk> , <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> &quot; <unk> &quot; <unk>
+<unk> <unk> die <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+Wir <unk> nicht als <unk> , dass es <unk> <unk> , aber die <unk> ist <unk> .
+Die <unk> von <unk> <unk> <unk> <unk> , <unk> <unk> und <unk> <unk> <unk> .
+<unk> <unk> die <unk> der <unk> der Türkei , die <unk> kann nur <unk> <unk> werden .
+&quot; Ich bin sehr <unk> <unk> mit <unk> , weil er <unk> ist .
+&quot; Ich möchte die <unk> <unk> .
+Im <unk> der <unk> und <unk> <unk> , &quot; es ist der <unk> , wenn es <unk> ist .
+Die <unk> , die die <unk> nicht <unk> , ist ich <unk> , die nicht die Fall <unk> .
+<unk> möchte ich <unk> .
+<unk> auf <unk> auf die <unk> <unk> in den <unk> gegen <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> <unk> die <unk> der <unk> .
+<unk> <unk> die <unk> von <unk> Jahren <unk> und <unk> <unk> .
+&quot; Ich glaube auch <unk> , er <unk> <unk> .
+Das <unk> <unk> in <unk> <unk> <unk> die <unk> dieses <unk> .
+Der <unk> <unk> ist seit <unk> <unk> <unk> <unk> <unk> und <unk> <unk> <unk> er <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk>
+&quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> <unk> &quot; <unk> &quot; <unk> &quot; .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+&quot; <unk> &quot; <unk> " <unk> in &quot; <unk> <unk> .
+&quot; <unk> &quot; auch in <unk> <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot; <unk> &quot;
+&quot; <unk> <unk> war ein <unk> , er <unk> <unk> .
+<unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> <unk> .
+<unk> <unk> <unk> <unk> , <unk> er <unk> .
+Die <unk> sind <unk> <unk> , sie sind <unk> <unk> .
+&quot; <unk> wird diese als <unk> der <unk> <unk> .
+<unk> ist sehr <unk>
+Die <unk> der <unk> <unk> <unk> seine <unk> gegen <unk> <unk> <unk> , <unk> dieses <unk> in Lissabon .
+Am <unk> gibt es auch <unk> , <unk> <unk> zu <unk> .
+&quot; <unk> &quot; <unk> <unk> , <unk> , <unk> , <unk> , <unk> , <unk> .
+<unk> <unk> bereits in <unk> und in der <unk> .
+Die <unk> ist nicht <unk> von einer <unk> , die <unk> , die er <unk> hat , seit <unk> <unk> <unk> .
+<unk> ist nur <unk> <unk> .
+<unk> ist es <unk> , um <unk> zu <unk> .
+In der <unk> über die <unk> in der <unk> in der <unk> ist <unk> , dass die <unk> nicht nur nicht <unk> .
+<unk> <unk> <unk> die <unk> für eine <unk> , die in diesem <unk> nicht <unk> haben , <unk> <unk> , <unk> , <unk> .
+<unk> ist eine <unk> <unk> , die eine <unk> <unk> &quot; <unk> &quot; <unk> &quot; .
+Doch die <unk> <unk> , in den <unk> <unk> , <unk> die <unk> <unk> , dass sie <unk> werden , dass sie <unk> in <unk> <unk> werden , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> , <unk> ,
+Die <unk> sind eine sehr <unk> <unk> , aber wir sind <unk> , dass wir die <unk> <unk> <unk> <unk> .
+&quot; Wir haben eine <unk> <unk> von <unk> , <unk> &quot; <unk> &quot; <unk> &quot; <unk> .
+Die <unk> der <unk> von <unk> aus <unk> <unk> die <unk> zu <unk> .
+Ein <unk> <unk> werden für die <unk> .
+Die <unk> ist ein <unk> <unk> , die <unk> <unk> , <unk> <unk> .

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -195,7 +195,7 @@ class Trainer(object):
                                 logger.info('GpuRank %d: gather valid stat \
                                             step %d' % (self.gpu_rank, step))
                             valid_stats = self._maybe_gather_stats(valid_stats)
-                            if self.gpu_verbos_level > 0:
+                            if self.gpu_verbose_level > 0:
                                 logger.info('GpuRank %d: report stat step %d'
                                             % (self.gpu_rank, step))
                             self._report_step(self.optim.learning_rate,


### PR DESCRIPTION
This is urgent for the fix in trainer.py (typo)

otherwise it just adds the heads / transformer_ff options (to train a big transformer for instance)

config for base:
-word_vec_size 512 -rnn_size 512 -heads 8 -transformer_ff 2048
config for big:
-words_vec_size 1024 -rnn_size 1024 -heads 16 -transformer_ff 4096

