### PR TITLE
Relax the constraint: word_vec_size must equal to pretrained_size

### DIFF
--- a/onmt/modules/embeddings.py
+++ b/onmt/modules/embeddings.py
@@ -98,6 +98,8 @@ class Embeddings(nn.Module):
             feat_padding_idx = []
         self.word_padding_idx = word_padding_idx
 
+        self.word_vec_size = word_vec_size
+
         # Dimensions and padding for constructing the word embedding matrix
         vocab_sizes = [word_vocab_size]
         emb_dims = [word_vec_size]
@@ -168,7 +170,13 @@ class Embeddings(nn.Module):
         """
         if emb_file:
             pretrained = torch.load(emb_file)
-            self.word_lut.weight.data.copy_(pretrained)
+            pretrained_vec_size = pretrained.size(1)
+            if self.word_vec_size > pretrained_vec_size:
+                self.word_lut.weight.data[:,:pretrained_vec_size] = pretrained
+            elif self.word_vec_size < pretrained_vec_size:
+                self.word_lut.weight.data.copy_(pretrained[:,:self.word_vec_size])
+            else:
+                self.word_lut.weight.data.copy_(pretrained)
             if fixed:
                 self.word_lut.weight.requires_grad = False
 

--- a/onmt/modules/embeddings.py
+++ b/onmt/modules/embeddings.py
@@ -174,7 +174,8 @@ class Embeddings(nn.Module):
             if self.word_vec_size > pretrained_vec_size:
                 self.word_lut.weight.data[:,:pretrained_vec_size] = pretrained
             elif self.word_vec_size < pretrained_vec_size:
-                self.word_lut.weight.data.copy_(pretrained[:,:self.word_vec_size])
+                self.word_lut.weight.data \
+                    .copy_(pretrained[:,:self.word_vec_size])
             else:
                 self.word_lut.weight.data.copy_(pretrained)
             if fixed:

--- a/onmt/modules/embeddings.py
+++ b/onmt/modules/embeddings.py
@@ -172,10 +172,10 @@ class Embeddings(nn.Module):
             pretrained = torch.load(emb_file)
             pretrained_vec_size = pretrained.size(1)
             if self.word_vec_size > pretrained_vec_size:
-                self.word_lut.weight.data[:,:pretrained_vec_size] = pretrained
+                self.word_lut.weight.data[:, :pretrained_vec_size] = pretrained
             elif self.word_vec_size < pretrained_vec_size:
                 self.word_lut.weight.data \
-                    .copy_(pretrained[:,:self.word_vec_size])
+                    .copy_(pretrained[:, :self.word_vec_size])
             else:
                 self.word_lut.weight.data.copy_(pretrained)
             if fixed:


### PR DESCRIPTION
OpenNMT-py requires input embedding size ( word_vec_size ) equals to pretrained embedding size. I relax this constraint: (1) If word_vec_size > pretrained_size, we initialize part of input embedding layer, and the rest is uninitialized. (2) If word_vec_size < pretrained_size, we use the truncated pretrained vector for initialization.

 

Relaxing above constraint has the following advantages:

1. It is common that we only have 300d pretrained vectors, but the default d_model of transformer is 512. And 300%8 != 0, where 8 is the default number of self-attention head. The transformer can not utilize pretrained vectors before the change.

2. We witness the better performance by initializing part of input embedding layer, i.e. the setting (word_vec_size=500, pretrained_size=300) performs much better than the setting (word_vec_size=300, pretrained_size=300). I don’t compare them the setting (word_vec_size=500, pretrained_size=500) because I don’t have pretrained vectors with 500 dimension. 