### PR TITLE
Removing extra logger initiatilzation

### DIFF
--- a/onmt/utils/logging.py
+++ b/onmt/utils/logging.py
@@ -18,6 +18,6 @@ def init_logger(log_file=None):
 
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(log_format)
-    logger.addHandler(console_handler)
+    logger.handlers = [console_handler]
 
     return logger

--- a/train.py
+++ b/train.py
@@ -9,7 +9,6 @@ import argparse
 import onmt.opts as opts
 from onmt.train_multi import main as multi_main
 from onmt.train_single import main as single_main
-from onmt.utils.logging import init_logger
 
 
 def main(opt):

--- a/train.py
+++ b/train.py
@@ -13,8 +13,6 @@ from onmt.utils.logging import init_logger
 
 
 def main(opt):
-    init_logger(opt.log_file)
-
     if opt.rnn_type == "SRU" and not opt.gpuid:
         raise AssertionError("Using SRU requires -gpuid set.")
 


### PR DESCRIPTION
First, Commit d36316e10e92bd0196d050978cb893dcda1464d7 was meant to fix logging for multi-device setup. In this case, `init_logger` was called in `train.py`, then, sub-process would print.

In order to fix that, we should've **moved** tje `init_logger` from train.py to `train_single.py`, but instead, it has been duplicated.

This problem has been discussed in https://github.com/OpenNMT/OpenNMT-py/pull/821 (which is replaced by this PR).

----
In addition, I remove `addHandler` in order to avoid output duplication. 