### PR TITLE
Fix the error in block ngram repeat 

### DIFF
--- a/onmt/translate/beam.py
+++ b/onmt/translate/beam.py
@@ -111,8 +111,7 @@ class Beam(object):
                     gram = []
                     for i in range(le - 1):
                         # Last n tokens, n = block_ngram_repeat
-                        gram = (gram + [hyp[i]])[-self.block_ngram_repeat:]
-                        gram = [t.item() for t in gram]
+                        gram = (gram + [hyp[i].item()])[-self.block_ngram_repeat:]
                         # Skip the blocking if it is in the exclusion list
                         if set(gram) & self.exclusion_tokens:
                             continue

--- a/onmt/translate/beam.py
+++ b/onmt/translate/beam.py
@@ -111,7 +111,8 @@ class Beam(object):
                     gram = []
                     for i in range(le - 1):
                         # Last n tokens, n = block_ngram_repeat
-                        gram = (gram + [hyp[i].item()])[-self.block_ngram_repeat:]
+                        gram = (gram + \
+                                [hyp[i].item()])[-self.block_ngram_repeat:]
                         # Skip the blocking if it is in the exclusion list
                         if set(gram) & self.exclusion_tokens:
                             continue

--- a/onmt/translate/beam.py
+++ b/onmt/translate/beam.py
@@ -112,6 +112,7 @@ class Beam(object):
                     for i in range(le - 1):
                         # Last n tokens, n = block_ngram_repeat
                         gram = (gram + [hyp[i]])[-self.block_ngram_repeat:]
+                        gram = [t.item() for t in gram]
                         # Skip the blocking if it is in the exclusion list
                         if set(gram) & self.exclusion_tokens:
                             continue

--- a/onmt/translate/beam.py
+++ b/onmt/translate/beam.py
@@ -111,7 +111,7 @@ class Beam(object):
                     gram = []
                     for i in range(le - 1):
                         # Last n tokens, n = block_ngram_repeat
-                        gram = (gram + \
+                        gram = (gram +
                                 [hyp[i].item()])[-self.block_ngram_repeat:]
                         # Skip the blocking if it is in the exclusion list
                         if set(gram) & self.exclusion_tokens:


### PR DESCRIPTION
Block_ngram_repeat is invalid. Notice that line 118 in beam.py  will never be triggered.
```
if tuple(gram) in ngrams:
    fail = True
```
It is because torch.tensor is not compatible with set() in python.
Look at the following code:
```
a = torch.tensor(1)
b = set()
b.add(torch.tensor(1))
print (a in b)
```

the result is false.
I think an elegant way of solving the problem is using .item() to transform tensor to number in python.
