### PR TITLE
Fix parameter docs

### DIFF
--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -21,7 +21,7 @@ class TransformerDecoderLayer(nn.Module):
                        the first-layer of the PositionwiseFeedForward.
       heads (int): the number of heads for MultiHeadedAttention.
       d_ff (int): the second-layer of the PositionwiseFeedForward.
-      droput (float): dropout probability(0-1.0).
+      dropout (float): dropout probability(0-1.0).
       self_attn_type (string): type of self-attention scaled-dot, average
     """
 

--- a/onmt/modules/global_attention.py
+++ b/onmt/modules/global_attention.py
@@ -136,7 +136,7 @@ class GlobalAttention(nn.Module):
         """
 
         Args:
-          input (`FloatTensor`): query vectors `[batch x tgt_len x dim]`
+          source (`FloatTensor`): query vectors `[batch x tgt_len x dim]`
           memory_bank (`FloatTensor`): source vectors `[batch x src_len x dim]`
           memory_lengths (`LongTensor`): the source context lengths `[batch]`
           coverage (`FloatTensor`): None (not supported yet)


### PR DESCRIPTION
In GlobalAttention class, it is documented that `forward` method takes `input` parameter.

```
class GlobalAttention(nn.Module):

    ...

    def forward(self, source, memory_bank, memory_lengths=None, coverage=None):
        """

        Args:
          input (`FloatTensor`): query vectors `[batch x tgt_len x dim]`
          memory_bank (`FloatTensor`): source vectors `[batch x src_len x dim]`
          memory_lengths (`LongTensor`): the source context lengths `[batch]`
          coverage (`FloatTensor`): None (not supported yet)

        Returns:
          (`FloatTensor`, `FloatTensor`):

          * Computed vector `[tgt_len x batch x dim]`
          * Attention distribtutions for each query
             `[tgt_len x batch x src_len]`
        """
```


However, it actually takes `source` parameter. So the code below would produce an error.

```
>>> attn = onmt.modules.GlobalAttention(
            dim=hidden_size, coverage=coverage_attn,
            attn_type=attn_type
        )
>>> decoder_outputs, p_attn = attn(
            input=rnn_output.transpose(0, 1).contiguous(),
            memory_bank=memory_bank.transpose(0, 1),
            memory_lengths=memory_lengths
        )

TypeError: forward() got an unexpected keyword argument 'input'
```
Therefore, I made a small change to the doc and fixed the incorrect documentation problem.

Also, I found a typo in parameter doc of transformer decoder (`droput` where it should be `dropout`)