### PR TITLE
Fix #880

### DIFF
--- a/onmt/modules/average_attn.py
+++ b/onmt/modules/average_attn.py
@@ -43,8 +43,9 @@ class AverageAttention(nn.Module):
             * A Tensor of shape `[batch_size x input_len x input_len]`
         """
 
-        triangle = torch.tril(torch.ones((inputs_len, inputs_len)))
-        weights = torch.ones((1, inputs_len)) / torch.arange(1, inputs_len + 1)
+        triangle = torch.tril(torch.ones(inputs_len, inputs_len))
+        weights = torch.ones(1, inputs_len) / torch.arange(
+            1, inputs_len + 1, dtype=torch.float)
         mask = triangle * weights.transpose(0, 1)
 
         return mask.unsqueeze(0).expand(batch_size, inputs_len, inputs_len)

--- a/onmt/modules/embeddings.py
+++ b/onmt/modules/embeddings.py
@@ -23,8 +23,8 @@ class PositionalEncoding(nn.Module):
     def __init__(self, dropout, dim, max_len=5000):
         pe = torch.zeros(max_len, dim)
         position = torch.arange(0, max_len).unsqueeze(1)
-        div_term = torch.exp((torch.arange(0, dim, 2) *
-                             -(math.log(10000.0) / dim)).float())
+        div_term = torch.exp((torch.arange(0, dim, 2, dtype=torch.float) *
+                             -(math.log(10000.0) / dim)))
         pe[:, 0::2] = torch.sin(position.float() * div_term)
         pe[:, 1::2] = torch.cos(position.float() * div_term)
         pe = pe.unsqueeze(1)


### PR DESCRIPTION
This pull request fixes #880, in which it was reported that multiplication between two tensors breaks because the default return type of `torch.arange` changed between 0.4.0 and 0.4.1. In addition to the bug in average_attn.py, this PR fixes a related but distinct bug in the `PositionEncoding` module in embeddings.py: the result of the expression `div_term = torch.exp((torch.arange(0, dim, 2) * -(math.log(10000.0) / dim)))` differs depending on the range's dtype. I don't know if anyone has reported problems with position encoding yet, but this would have failed silently.