### PR TITLE
Do not require preprocessing.py to redundantly load datasets it just created

### DIFF
--- a/onmt/inputters/__init__.py
+++ b/onmt/inputters/__init__.py
@@ -7,7 +7,7 @@ from onmt.inputters.inputter import collect_feature_vocabs, make_features, \
     collect_features, get_num_features, \
     load_fields_from_vocab, get_fields, \
     fields_to_vocab, build_dataset, \
-    build_vocab, merge_vocabs, OrderedIterator
+    merge_vocabs, OrderedIterator
 from onmt.inputters.dataset_base import DatasetBase, PAD_WORD, BOS_WORD, \
     EOS_WORD, UNK
 from onmt.inputters.text_dataset import TextDataset, ShardedTextCorpusIterator
@@ -20,6 +20,6 @@ __all__ = ['PAD_WORD', 'BOS_WORD', 'EOS_WORD', 'UNK', 'DatasetBase',
            'collect_features', 'get_num_features',
            'load_fields_from_vocab', 'get_fields',
            'fields_to_vocab', 'build_dataset',
-           'build_vocab', 'merge_vocabs', 'OrderedIterator',
+           'merge_vocabs', 'OrderedIterator',
            'TextDataset', 'ImageDataset', 'AudioDataset',
            'ShardedTextCorpusIterator']

--- a/onmt/inputters/__init__.py
+++ b/onmt/inputters/__init__.py
@@ -6,7 +6,7 @@ e.g., from a line of text to a sequence of embeddings.
 from onmt.inputters.inputter import collect_feature_vocabs, make_features, \
     collect_features, get_num_features, \
     load_fields_from_vocab, get_fields, \
-    save_fields_to_vocab, build_dataset, \
+    fields_to_vocab, build_dataset, \
     build_vocab, merge_vocabs, OrderedIterator
 from onmt.inputters.dataset_base import DatasetBase, PAD_WORD, BOS_WORD, \
     EOS_WORD, UNK
@@ -19,7 +19,7 @@ __all__ = ['PAD_WORD', 'BOS_WORD', 'EOS_WORD', 'UNK', 'DatasetBase',
            'collect_feature_vocabs', 'make_features',
            'collect_features', 'get_num_features',
            'load_fields_from_vocab', 'get_fields',
-           'save_fields_to_vocab', 'build_dataset',
+           'fields_to_vocab', 'build_dataset',
            'build_vocab', 'merge_vocabs', 'OrderedIterator',
            'TextDataset', 'ImageDataset', 'AudioDataset',
            'ShardedTextCorpusIterator']

--- a/onmt/inputters/__init__.py
+++ b/onmt/inputters/__init__.py
@@ -7,7 +7,7 @@ from onmt.inputters.inputter import collect_feature_vocabs, make_features, \
     collect_features, get_num_features, \
     load_fields_from_vocab, get_fields, \
     fields_to_vocab, build_dataset, \
-    build_fields, merge_vocabs, OrderedIterator
+    build_vocabs, merge_vocabs, OrderedIterator
 from onmt.inputters.dataset_base import DatasetBase, PAD_WORD, BOS_WORD, \
     EOS_WORD, UNK
 from onmt.inputters.text_dataset import TextDataset, ShardedTextCorpusIterator
@@ -20,6 +20,6 @@ __all__ = ['PAD_WORD', 'BOS_WORD', 'EOS_WORD', 'UNK', 'DatasetBase',
            'collect_features', 'get_num_features',
            'load_fields_from_vocab', 'get_fields',
            'fields_to_vocab', 'build_dataset',
-           'build_fields', 'merge_vocabs', 'OrderedIterator',
+           'build_vocabs', 'merge_vocabs', 'OrderedIterator',
            'TextDataset', 'ImageDataset', 'AudioDataset',
            'ShardedTextCorpusIterator']

--- a/onmt/inputters/__init__.py
+++ b/onmt/inputters/__init__.py
@@ -4,18 +4,16 @@ Inputters implement the logic of transforming raw data to vectorized inputs,
 e.g., from a line of text to a sequence of embeddings.
 """
 from onmt.inputters.inputter import collect_feature_vocabs, make_features, \
-    num_features, \
-    get_fields, vocab_to_fields, \
-    fields_to_vocab, build_dataset, \
-    build_vocabs, merge_vocabs, OrderedIterator
+    num_features, get_fields, vocab_to_fields, fields_to_vocab, \
+    build_dataset, build_vocabs, merge_vocabs, OrderedIterator
 from onmt.inputters.dataset_base import DatasetBase, PAD_WORD, BOS_WORD, \
-    EOS_WORD, UNK
+    EOS_WORD
 from onmt.inputters.text_dataset import TextDataset, ShardedTextCorpusIterator
 from onmt.inputters.image_dataset import ImageDataset
 from onmt.inputters.audio_dataset import AudioDataset
 
 
-__all__ = ['PAD_WORD', 'BOS_WORD', 'EOS_WORD', 'UNK', 'DatasetBase',
+__all__ = ['PAD_WORD', 'BOS_WORD', 'EOS_WORD', 'DatasetBase',
            'collect_feature_vocabs', 'make_features',
            'num_features', 'get_fields', 'vocab_to_fields',
            'fields_to_vocab', 'build_dataset',

--- a/onmt/inputters/__init__.py
+++ b/onmt/inputters/__init__.py
@@ -5,18 +5,18 @@ e.g., from a line of text to a sequence of embeddings.
 """
 from onmt.inputters.inputter import collect_feature_vocabs, make_features, \
     num_features, get_fields, vocab_to_fields, fields_to_vocab, \
-    build_dataset, build_vocabs, merge_vocabs, OrderedIterator
+    build_dataset, build_vocabs, merge_vocabs, OrderedIterator, shard_corpus
 from onmt.inputters.dataset_base import DatasetBase, PAD_WORD, BOS_WORD, \
-    EOS_WORD
-from onmt.inputters.text_dataset import TextDataset, ShardedTextCorpusIterator
+    EOS_WORD, UNK_WORD
+from onmt.inputters.text_dataset import TextDataset
 from onmt.inputters.image_dataset import ImageDataset
 from onmt.inputters.audio_dataset import AudioDataset
 
 
-__all__ = ['PAD_WORD', 'BOS_WORD', 'EOS_WORD', 'DatasetBase',
+__all__ = ['PAD_WORD', 'BOS_WORD', 'EOS_WORD', 'UNK_WORD', 'DatasetBase',
            'collect_feature_vocabs', 'make_features',
            'num_features', 'get_fields', 'vocab_to_fields',
            'fields_to_vocab', 'build_dataset',
            'build_vocabs', 'merge_vocabs', 'OrderedIterator',
            'TextDataset', 'ImageDataset', 'AudioDataset',
-           'ShardedTextCorpusIterator']
+           'shard_corpus']

--- a/onmt/inputters/__init__.py
+++ b/onmt/inputters/__init__.py
@@ -4,7 +4,7 @@ Inputters implement the logic of transforming raw data to vectorized inputs,
 e.g., from a line of text to a sequence of embeddings.
 """
 from onmt.inputters.inputter import collect_feature_vocabs, make_features, \
-    get_num_features, \
+    num_features, \
     get_fields, vocab_to_fields, \
     fields_to_vocab, build_dataset, \
     build_vocabs, merge_vocabs, OrderedIterator
@@ -17,8 +17,7 @@ from onmt.inputters.audio_dataset import AudioDataset
 
 __all__ = ['PAD_WORD', 'BOS_WORD', 'EOS_WORD', 'UNK', 'DatasetBase',
            'collect_feature_vocabs', 'make_features',
-           'get_num_features',
-           'get_fields', 'vocab_to_fields',
+           'num_features', 'get_fields', 'vocab_to_fields',
            'fields_to_vocab', 'build_dataset',
            'build_vocabs', 'merge_vocabs', 'OrderedIterator',
            'TextDataset', 'ImageDataset', 'AudioDataset',

--- a/onmt/inputters/__init__.py
+++ b/onmt/inputters/__init__.py
@@ -4,7 +4,7 @@ Inputters implement the logic of transforming raw data to vectorized inputs,
 e.g., from a line of text to a sequence of embeddings.
 """
 from onmt.inputters.inputter import collect_feature_vocabs, make_features, \
-    collect_features, get_num_features, \
+    get_num_features, \
     load_fields_from_vocab, get_fields, \
     fields_to_vocab, build_dataset, \
     build_vocabs, merge_vocabs, OrderedIterator
@@ -17,7 +17,7 @@ from onmt.inputters.audio_dataset import AudioDataset
 
 __all__ = ['PAD_WORD', 'BOS_WORD', 'EOS_WORD', 'UNK', 'DatasetBase',
            'collect_feature_vocabs', 'make_features',
-           'collect_features', 'get_num_features',
+           'get_num_features',
            'load_fields_from_vocab', 'get_fields',
            'fields_to_vocab', 'build_dataset',
            'build_vocabs', 'merge_vocabs', 'OrderedIterator',

--- a/onmt/inputters/__init__.py
+++ b/onmt/inputters/__init__.py
@@ -7,7 +7,7 @@ from onmt.inputters.inputter import collect_feature_vocabs, make_features, \
     collect_features, get_num_features, \
     load_fields_from_vocab, get_fields, \
     fields_to_vocab, build_dataset, \
-    merge_vocabs, OrderedIterator
+    build_fields, merge_vocabs, OrderedIterator
 from onmt.inputters.dataset_base import DatasetBase, PAD_WORD, BOS_WORD, \
     EOS_WORD, UNK
 from onmt.inputters.text_dataset import TextDataset, ShardedTextCorpusIterator
@@ -20,6 +20,6 @@ __all__ = ['PAD_WORD', 'BOS_WORD', 'EOS_WORD', 'UNK', 'DatasetBase',
            'collect_features', 'get_num_features',
            'load_fields_from_vocab', 'get_fields',
            'fields_to_vocab', 'build_dataset',
-           'merge_vocabs', 'OrderedIterator',
+           'build_fields', 'merge_vocabs', 'OrderedIterator',
            'TextDataset', 'ImageDataset', 'AudioDataset',
            'ShardedTextCorpusIterator']

--- a/onmt/inputters/__init__.py
+++ b/onmt/inputters/__init__.py
@@ -5,7 +5,7 @@ e.g., from a line of text to a sequence of embeddings.
 """
 from onmt.inputters.inputter import collect_feature_vocabs, make_features, \
     get_num_features, \
-    load_fields_from_vocab, get_fields, \
+    get_fields, vocab_to_fields, \
     fields_to_vocab, build_dataset, \
     build_vocabs, merge_vocabs, OrderedIterator
 from onmt.inputters.dataset_base import DatasetBase, PAD_WORD, BOS_WORD, \
@@ -18,7 +18,7 @@ from onmt.inputters.audio_dataset import AudioDataset
 __all__ = ['PAD_WORD', 'BOS_WORD', 'EOS_WORD', 'UNK', 'DatasetBase',
            'collect_feature_vocabs', 'make_features',
            'get_num_features',
-           'load_fields_from_vocab', 'get_fields',
+           'get_fields', 'vocab_to_fields',
            'fields_to_vocab', 'build_dataset',
            'build_vocabs', 'merge_vocabs', 'OrderedIterator',
            'TextDataset', 'ImageDataset', 'AudioDataset',

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -83,7 +83,7 @@ class AudioDataset(DatasetBase):
         return ex.src.size(1)
 
     @classmethod
-    def make_examples_nfeats_tpl(cls, path, audio_dir, sample_rate,
+    def make_examples_nfeats_tpl(cls, path, directory, sample_rate,
                                  window_size, window_stride, window,
                                  normalize_audio, truncate=None, **kwargs):
         """

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -36,13 +36,13 @@ class AudioDataset(DatasetBase):
                 out examples?
     """
 
+    data_type = 'audio'
+
     def __init__(self, fields, src_examples_iter, tgt_examples_iter,
                  num_src_feats=0, num_tgt_feats=0,
                  tgt_seq_length=0, sample_rate=0,
                  window_size=0.0, window_stride=0.0, window=None,
                  normalize_audio=True, use_filter_pred=True):
-        self.data_type = 'audio'
-
         self.sample_rate = sample_rate
         self.window_size = window_size
         self.window_stride = window_stride

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -83,10 +83,9 @@ class AudioDataset(DatasetBase):
         return ex.src.size(1)
 
     @classmethod
-    def make_examples_nfeats_tpl(cls, path, audio_dir,
-                                 sample_rate, window_size,
-                                 window_stride, window,
-                                 normalize_audio, truncate=None):
+    def make_examples_nfeats_tpl(cls, path, audio_dir, sample_rate,
+                                 window_size, window_stride, window,
+                                 normalize_audio, truncate=None, **kwargs):
         """
         Args:
             path (str): location of a src file containing audio paths.
@@ -102,6 +101,8 @@ class AudioDataset(DatasetBase):
         Returns:
             (example_dict iterator, num_feats) tuple
         """
+        if path is None:
+            raise ValueError("AudioDataset requires a non None path")
         examples_iter = cls.read_audio_file(
             path, audio_dir, "src", sample_rate,
             window_size, window_stride, window,

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -74,11 +74,12 @@ class AudioDataset(DatasetBase):
             else:
                 return True
 
-        filter_pred = filter_pred if use_filter_pred else lambda x: True
+        filter_pred = filter_pred if use_filter_pred else None
 
         super(AudioDataset, self).__init__(examples, out_fields, filter_pred)
 
-    def sort_key(self, ex):
+    @staticmethod
+    def sort_key(ex):
         """ Sort using duration time of the sound spectrogram. """
         return ex.src.size(1)
 

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -67,7 +67,7 @@ class AudioDataset(DatasetBase):
             window_size, window_stride, window,
             normalize_audio, truncate)
 
-        return examples_iter, 0
+        return examples_iter
 
     @classmethod
     def read_audio_file(cls, path, src_dir, side, sample_rate, window_size,

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -104,7 +104,7 @@ class AudioDataset(DatasetBase):
         if path is None:
             raise ValueError("AudioDataset requires a non None path")
         examples_iter = cls.read_audio_file(
-            path, audio_dir, "src", sample_rate,
+            path, directory, "src", sample_rate,
             window_size, window_stride, window,
             normalize_audio, truncate)
 

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -6,10 +6,8 @@ import codecs
 import os
 
 import torch
-import torchtext
 
-from onmt.inputters.dataset_base import DatasetBase, PAD_WORD, BOS_WORD, \
-    EOS_WORD
+from onmt.inputters.dataset_base import DatasetBase
 
 
 class AudioDataset(DatasetBase):
@@ -194,79 +192,6 @@ class AudioDataset(DatasetBase):
                 index += 1
 
                 yield example_dict
-
-    @staticmethod
-    def get_fields(n_src_features, n_tgt_features):
-        """
-        Args:
-            n_src_features: the number of source features to
-                create `torchtext.data.Field` for.
-            n_tgt_features: the number of target features to
-                create `torchtext.data.Field` for.
-
-        Returns:
-            A dictionary whose keys are strings and whose values
-            are the corresponding Field objects.
-        """
-        fields = {}
-
-        def make_audio(data, vocab):
-            """ ? """
-            nfft = data[0].size(0)
-            t = max([t.size(1) for t in data])
-            sounds = torch.zeros(len(data), 1, nfft, t)
-            for i, spect in enumerate(data):
-                sounds[i, :, :, 0:spect.size(1)] = spect
-            return sounds
-
-        fields["src"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.float,
-            postprocessing=make_audio, sequential=False)
-
-        for j in range(n_src_features):
-            fields["src_feat_" + str(j)] = \
-                torchtext.data.Field(pad_token=PAD_WORD)
-
-        fields["tgt"] = torchtext.data.Field(
-            init_token=BOS_WORD, eos_token=EOS_WORD,
-            pad_token=PAD_WORD)
-
-        for j in range(n_tgt_features):
-            fields["tgt_feat_" + str(j)] = \
-                torchtext.data.Field(init_token=BOS_WORD, eos_token=EOS_WORD,
-                                     pad_token=PAD_WORD)
-
-        def make_src(data, vocab):
-            """ ? """
-            src_size = max([t.size(0) for t in data])
-            src_vocab_size = max([t.max() for t in data]) + 1
-            alignment = torch.zeros(src_size, len(data), src_vocab_size)
-            for i, sent in enumerate(data):
-                for j, t in enumerate(sent):
-                    alignment[j, i, t] = 1
-            return alignment
-
-        fields["src_map"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.float,
-            postprocessing=make_src, sequential=False)
-
-        def make_tgt(data, vocab):
-            """ ? """
-            tgt_size = max([t.size(0) for t in data])
-            alignment = torch.zeros(tgt_size, len(data)).long()
-            for i, sent in enumerate(data):
-                alignment[:sent.size(0), i] = sent
-            return alignment
-
-        fields["alignment"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.long,
-            postprocessing=make_tgt, sequential=False)
-
-        fields["indices"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.long,
-            sequential=False)
-
-        return fields
 
     @staticmethod
     def get_num_features(corpus_file, side):

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -6,7 +6,6 @@ import codecs
 import os
 
 import torch
-from torchtext.data import Example
 
 from onmt.inputters.dataset_base import DatasetBase
 
@@ -35,47 +34,7 @@ class AudioDataset(DatasetBase):
             use_filter_pred (bool): use a custom filter predicate to filter
                 out examples?
     """
-
     data_type = 'audio'
-
-    def __init__(self, fields, src_examples_iter, tgt_examples_iter,
-                 num_src_feats=0, num_tgt_feats=0,
-                 tgt_seq_length=0, sample_rate=0,
-                 window_size=0.0, window_stride=0.0, window=None,
-                 normalize_audio=True, use_filter_pred=True):
-        self.sample_rate = sample_rate
-        self.window_size = window_size
-        self.window_stride = window_stride
-        self.window = window
-        self.normalize_audio = normalize_audio
-
-        self.n_src_feats = num_src_feats
-        self.n_tgt_feats = num_tgt_feats
-
-        if tgt_examples_iter is not None:
-            examples_iter = (self._join_dicts(src, tgt) for src, tgt in
-                             zip(src_examples_iter, tgt_examples_iter))
-        else:
-            examples_iter = src_examples_iter
-
-        # Peek at the first to see which fields are used.
-        ex, examples_iter = self._peek(examples_iter)
-        keys = ex.keys()
-
-        fields = [(k, fields[k]) if k in fields else (k, None) for k in keys]
-        example_values = ([ex[k] for k in keys] for ex in examples_iter)
-        examples = [Example.fromlist(ev, fields) for ev in example_values]
-
-        def filter_pred(example):
-            """    ?    """
-            if tgt_examples_iter is not None:
-                return 0 < len(example.tgt) <= tgt_seq_length
-            else:
-                return True
-
-        filter_pred = filter_pred if use_filter_pred else None
-
-        super(AudioDataset, self).__init__(examples, fields, filter_pred)
 
     @staticmethod
     def sort_key(ex):

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -192,26 +192,3 @@ class AudioDataset(DatasetBase):
                 index += 1
 
                 yield example_dict
-
-    @staticmethod
-    def get_num_features(corpus_file, side):
-        """
-        For audio corpus, source side is in form of audio, thus
-        no feature; while target side is in form of text, thus
-        we can extract its text features.
-
-        Args:
-            corpus_file (str): file path to get the features.
-            side (str): 'src' or 'tgt'.
-
-        Returns:
-            number of features on `side`.
-        """
-        if side == 'src':
-            num_feats = 0
-        else:
-            with codecs.open(corpus_file, "r", "utf-8") as cf:
-                f_line = cf.readline().strip().split()
-                _, _, num_feats = AudioDataset.extract_text_features(f_line)
-
-        return num_feats

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -42,9 +42,9 @@ class AudioDataset(DatasetBase):
         return ex.src.size(1)
 
     @classmethod
-    def _make_examples(cls, iterator, **kwargs):
-        for i, (spect, line) in enumerate(iterator):
-            yield {'src': spect, 'src_path': line.strip(), 'indices': i}
+    def _make_example(cls, pair, **kwargs):
+        spect, line = pair
+        return {'src': spect, 'src_path': line.strip()}
 
     @classmethod
     def _make_iterator_from_file(

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -42,9 +42,9 @@ class AudioDataset(DatasetBase):
         return ex.src.size(1)
 
     @classmethod
-    def make_examples_nfeats_tpl(cls, path, directory, sample_rate,
-                                 window_size, window_stride, window,
-                                 normalize_audio, truncate=None, **kwargs):
+    def make_examples(cls, path, directory, sample_rate,
+                      window_size, window_stride, window,
+                      normalize_audio, truncate=None, **kwargs):
         """
         Args:
             path (str): location of a src file containing audio paths.
@@ -62,7 +62,7 @@ class AudioDataset(DatasetBase):
         """
         if path is None:
             raise ValueError("AudioDataset requires a non None path")
-        examples_iter = cls.read_audio_file(
+        examples_iter = cls.make_iterator_from_file(
             path, directory, "src", sample_rate,
             window_size, window_stride, window,
             normalize_audio, truncate)
@@ -70,9 +70,9 @@ class AudioDataset(DatasetBase):
         return examples_iter
 
     @classmethod
-    def read_audio_file(cls, path, src_dir, side, sample_rate, window_size,
-                        window_stride, window, normalize_audio,
-                        truncate=None):
+    def make_iterator_from_file(
+        cls, path, src_dir, side, sample_rate, window_size,
+        window_stride, window, normalize_audio, truncate=None):
         """
         Args:
             path (str): location of a src file containing audio paths.

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -161,6 +161,7 @@ class AudioDataset(DatasetBase):
                     if sound.size(0) > truncate:
                         continue
 
+                # TODO: find out what this is supposed to be
                 assert sample_rate == sample_rate, \
                     'Sample rate of %s != -sample_rate (%d vs %d)' \
                     % (audio_path, sample_rate, sample_rate)

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -60,7 +60,7 @@ class DatasetBase(Dataset):
         super(DatasetBase, self).__init__(examples, fields, filter_pred)
 
     @classmethod
-    def make_examples(cls, path, **kwargs):
+    def make_examples(cls, path=None, lines=None, **kwargs):
         """
         path: location of a corpus file
         remaining arguments are passed to _make_iterator_from_file and
@@ -68,7 +68,11 @@ class DatasetBase(Dataset):
         returns an iterator of dictionaries, one for each example in the corpus
         file
         """
-        for i, line in enumerate(cls._make_iterator_from_file(path, **kwargs)):
+        assert (path is not None or lines is not None) \
+            and (path is None or lines is None)
+        if path is not None:
+            lines = cls._make_iterator_from_file(path, **kwargs)
+        for i, line in enumerate(lines):
             example = cls._make_example(line, **kwargs)
             example['indices'] = i
             yield example

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -49,8 +49,6 @@ class DatasetBase(torchtext.data.Dataset):
         self.fields = dict([(k, f) for (k, f) in fields.items()
                             if k in self.examples[0].__dict__])
 
-    # Below are helper functions for intra-class use only.
-
     def _join_dicts(self, *args):
         """
         Args:
@@ -61,7 +59,8 @@ class DatasetBase(torchtext.data.Dataset):
         """
         return dict(chain(*[d.items() for d in args]))
 
-    def _peek(self, seq):
+    @classmethod
+    def _peek(cls, seq):
         """
         Args:
             seq: an iterator.

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -88,17 +88,6 @@ class DatasetBase(Dataset):
         "This is a hack. Something is broken with torch pickle."
         return super(DatasetBase, self).__reduce_ex__()
 
-    def load_fields(self, vocab_dict):
-        """ Load fields from vocab.pt, and set the `fields` attribute.
-
-        Args:
-            vocab_dict (dict): a dict of loaded vocab from vocab.pt file.
-        """
-        fields = onmt.inputters.inputter.load_fields_from_vocab(
-            vocab_dict.items(), self.data_type)
-        self.fields = dict([(k, f) for (k, f) in fields.items()
-                            if k in self.examples[0].__dict__])
-
     def _join_dicts(self, *args):
         """
         Args:

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -47,6 +47,8 @@ class DatasetBase(Dataset):
             examples_iter = (self._dynamic_dict(ex) for ex in examples_iter)
 
         fields = list(fields.items())
+        # there's a problem here if the dataset doesn't have a tgt at
+        # translation time
         example_values = ([ex[k] for k, v in fields] for ex in examples_iter)
 
         examples = [Example.fromlist(ev, fields) for ev in example_values]
@@ -54,17 +56,16 @@ class DatasetBase(Dataset):
         super(DatasetBase, self).__init__(examples, fields, filter_pred)
 
     @classmethod
-    def make_examples(cls, iterator, path, **kwargs):
+    def make_examples(cls, path, **kwargs):
         """
-        TODO: fix documentation
+        path: location of a corpus file
+        remaining arguments are passed to _make_iterator_from_file and
+        _make_examples
+        returns an iterator of dictionaries, one for each example in the corpus
+        file
         """
-        if iterator is None and path is None:
-            raise ValueError("'iterator' and 'path' must not both be None")
-        if path is not None:
-            iterator = cls._make_iterator_from_file(path, **kwargs)
-
+        iterator = cls._make_iterator_from_file(path, **kwargs)
         examples_iter = cls._make_examples(iterator, **kwargs)
-
         return examples_iter
 
     @classmethod

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -54,14 +54,8 @@ class DatasetBase(Dataset):
         if dynamic_dict:
             examples_iter = (self._dynamic_dict(ex) for ex in examples_iter)
 
-        # Peek at the first to see which fields are used.
-        ex, examples_iter = self._peek(examples_iter)
-        keys = ex.keys()
-
-        # why are the fields in the examples_iter different from the ones
-        # in the fields argument?
-        fields = [(k, fields[k]) if k in fields else (k, None) for k in keys]
-        example_values = ([ex[k] for k in keys] for ex in examples_iter)
+        fields = list(fields.items())
+        example_values = ([ex[k] for k, v in fields] for ex in examples_iter)
 
         examples = [Example.fromlist(ev, fields) for ev in example_values]
 

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -29,16 +29,11 @@ class DatasetBase(Dataset):
         objects, and not necessarily having the same keys as the input fields.
     """
     def __init__(self, fields, src_examples_iter, tgt_examples_iter,
-                 num_src_feats=0, num_tgt_feats=0,
                  src_seq_length=0, tgt_seq_length=0,
                  dynamic_dict=False, filter_pred=None):
         # self.src_vocabs: mutated in dynamic_dict, used in translation.py
         self.src_vocabs = []
 
-        # shouldn't need to pass either of these things because it should be
-        # clear from the fields. Not obvious you NEED these attributes, though
-        self.n_src_feats = num_src_feats
-        self.n_tgt_feats = num_tgt_feats
         # another question: why is the Dataset constructor used in preprocess
         # and translate but not train?
 

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -1,9 +1,10 @@
 # coding: utf-8
-"""
-    Base dataset class and constants
-"""
+
+from collections import Counter
 from itertools import chain
-import torchtext
+import torch
+from torchtext.vocab import Vocab
+from torchtext.data import Example, Dataset
 
 import onmt
 
@@ -14,7 +15,7 @@ BOS_WORD = '<s>'
 EOS_WORD = '</s>'
 
 
-class DatasetBase(torchtext.data.Dataset):
+class DatasetBase(Dataset):
     """
     A dataset basically supports iteration over all the examples
     it contains. We currently have 3 datasets inheriting this base
@@ -27,6 +28,44 @@ class DatasetBase(torchtext.data.Dataset):
      `fields`: a dictionary associating str keys with `torchtext.data.Field`
         objects, and not necessarily having the same keys as the input fields.
     """
+    def __init__(self, fields, src_examples_iter, tgt_examples_iter,
+                 num_src_feats=0, num_tgt_feats=0,
+                 src_seq_length=0, tgt_seq_length=0,
+                 dynamic_dict=False, filter_pred=None):
+        # self.src_vocabs: mutated in dynamic_dict, used in translation.py
+        self.src_vocabs = []
+
+        # shouldn't need to pass either of these things because it should be
+        # clear from the fields. Not obvious you NEED these attributes, though
+        self.n_src_feats = num_src_feats
+        self.n_tgt_feats = num_tgt_feats
+        # another question: why is the Dataset constructor used in preprocess
+        # and translate but not train?
+
+        # Each element of an example is a dictionary whose keys represents
+        # at minimum the src tokens and their indices and potentially also
+        # the src and tgt features and alignment information.
+        if tgt_examples_iter is not None:
+            examples_iter = (self._join_dicts(src, tgt) for src, tgt in
+                             zip(src_examples_iter, tgt_examples_iter))
+        else:
+            examples_iter = src_examples_iter
+
+        if dynamic_dict:
+            examples_iter = (self._dynamic_dict(ex) for ex in examples_iter)
+
+        # Peek at the first to see which fields are used.
+        ex, examples_iter = self._peek(examples_iter)
+        keys = ex.keys()
+
+        # why are the fields in the examples_iter different from the ones
+        # in the fields argument?
+        fields = [(k, fields[k]) if k in fields else (k, None) for k in keys]
+        example_values = ([ex[k] for k in keys] for ex in examples_iter)
+
+        examples = [Example.fromlist(ev, fields) for ev in example_values]
+
+        super(DatasetBase, self).__init__(examples, fields, filter_pred)
 
     def __getstate__(self):
         return self.__dict__
@@ -58,6 +97,29 @@ class DatasetBase(torchtext.data.Dataset):
             a single dictionary that has the union of these keys.
         """
         return dict(chain(*[d.items() for d in args]))
+
+    def _dynamic_dict(self, example):
+        """
+        examples_iter: (self._join_dicts(src, tgt) for src, tgt in
+                        zip(src_examples_iter, tgt_examples_iter))
+        yields: dicts.
+        """
+        # this basically says that if you're using dynamic dict, you're
+        # going to need some extra fields, and they get created in a
+        # different way from other fields.
+        src = example["src"]
+        src_vocab = Vocab(Counter(src), specials=[UNK_WORD, PAD_WORD])
+        self.src_vocabs.append(src_vocab)
+        # Mapping source tokens to indices in the dynamic dict.
+        src_map = torch.LongTensor([src_vocab.stoi[w] for w in src])
+        example["src_map"] = src_map
+
+        if "tgt" in example:
+            tgt = example["tgt"]
+            mask = torch.LongTensor(
+                [0] + [src_vocab.stoi[w] for w in tgt] + [0])
+            example["alignment"] = mask
+        return example
 
     @classmethod
     def _peek(cls, seq):

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -64,16 +64,17 @@ class DatasetBase(Dataset):
         returns an iterator of dictionaries, one for each example in the corpus
         file
         """
-        iterator = cls._make_iterator_from_file(path, **kwargs)
-        examples_iter = cls._make_examples(iterator, **kwargs)
-        return examples_iter
+        for i, line in enumerate(cls._make_iterator_from_file(path, **kwargs)):
+            example = cls._make_example(line, **kwargs)
+            example['indices'] = i
+            yield example
 
     @classmethod
     def _make_iterator_from_file(cls, path, **kwargs):
         return NotImplemented
 
     @classmethod
-    def _make_examples(cls, *args, **kwargs):
+    def _make_example(cls, *args, **kwargs):
         return NotImplemented
 
     def __getstate__(self):

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -73,23 +73,3 @@ class DatasetBase(torchtext.data.Dataset):
         """
         first = next(seq)
         return first, chain([first], seq)
-
-    def _construct_example_fromlist(self, data, fields):
-        """
-        Args:
-            data: the data to be set as the value of the attributes of
-                the to-be-created `Example`, associating with respective
-                `Field` objects with same key.
-            fields: a dict of `torchtext.data.Field` objects. The keys
-                are attributes of the to-be-created `Example`.
-
-        Returns:
-            the created `Example` object.
-        """
-        ex = torchtext.data.Example()
-        for (name, field), val in zip(fields, data):
-            if field is not None:
-                setattr(ex, name, field.preprocess(val))
-            else:
-                setattr(ex, name, val)
-        return ex

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -49,30 +49,6 @@ class DatasetBase(torchtext.data.Dataset):
         self.fields = dict([(k, f) for (k, f) in fields.items()
                             if k in self.examples[0].__dict__])
 
-    @staticmethod
-    def extract_text_features(tokens):
-        """
-        Args:
-            tokens: A list of tokens, where each token consists of a word,
-                optionally followed by u"￨"-delimited features.
-        Returns:
-            A sequence of words, a sequence of features, and num of features.
-        """
-        if not tokens:
-            return [], [], -1
-
-        split_tokens = [token.split(u"￨") for token in tokens]
-        split_tokens = [token for token in split_tokens if token[0]]
-        token_size = len(split_tokens[0])
-
-        assert all(len(token) == token_size for token in split_tokens), \
-            "all words must have the same number of features"
-        words_and_features = list(zip(*split_tokens))
-        words = words_and_features[0]
-        features = words_and_features[1:]
-
-        return words, features, token_size - 1
-
     # Below are helper functions for intra-class use only.
 
     def _join_dicts(self, *args):

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -56,6 +56,28 @@ class DatasetBase(Dataset):
 
         super(DatasetBase, self).__init__(examples, fields, filter_pred)
 
+    @classmethod
+    def make_examples(cls, iterator, path, **kwargs):
+        """
+        TODO: fix documentation
+        """
+        if iterator is None and path is None:
+            raise ValueError("'iterator' and 'path' must not both be None")
+        if path is not None:
+            iterator = cls._make_iterator_from_file(path, **kwargs)
+
+        examples_iter = cls._make_examples(iterator, **kwargs)
+
+        return examples_iter
+
+    @classmethod
+    def _make_iterator_from_file(cls, path, **kwargs):
+        return NotImplemented
+
+    @classmethod
+    def _make_examples(cls, *args, **kwargs):
+        return NotImplemented
+
     def __getstate__(self):
         return self.__dict__
 
@@ -109,17 +131,3 @@ class DatasetBase(Dataset):
                 [0] + [src_vocab.stoi[w] for w in tgt] + [0])
             example["alignment"] = mask
         return example
-
-    @classmethod
-    def _peek(cls, seq):
-        """
-        Args:
-            seq: an iterator.
-
-        Returns:
-            the first thing returned by calling next() on the iterator
-            and an iterator created by re-chaining that value to the beginning
-            of the iterator.
-        """
-        first = next(seq)
-        return first, chain([first], seq)

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -8,7 +8,6 @@ from torchtext.data import Example, Dataset
 
 PAD_WORD = '<blank>'
 UNK_WORD = '<unk>'
-UNK = 0
 BOS_WORD = '<s>'
 EOS_WORD = '</s>'
 

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -6,8 +6,6 @@ import torch
 from torchtext.vocab import Vocab
 from torchtext.data import Example, Dataset
 
-import onmt
-
 PAD_WORD = '<blank>'
 UNK_WORD = '<unk>'
 UNK = 0
@@ -29,7 +27,6 @@ class DatasetBase(Dataset):
         objects, and not necessarily having the same keys as the input fields.
     """
     def __init__(self, fields, src_examples_iter, tgt_examples_iter,
-                 src_seq_length=0, tgt_seq_length=0,
                  dynamic_dict=False, filter_pred=None):
         # self.src_vocabs: mutated in dynamic_dict, used in translation.py
         self.src_vocabs = []

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -60,11 +60,12 @@ class ImageDataset(DatasetBase):
             else:
                 return True
 
-        filter_pred = filter_pred if use_filter_pred else lambda x: True
+        filter_pred = filter_pred if use_filter_pred else None
 
         super(ImageDataset, self).__init__(examples, out_fields, filter_pred)
 
-    def sort_key(self, ex):
+    @staticmethod
+    def sort_key(ex):
         """ Sort using the size of the image: (width, height)."""
         return ex.src.size(2), ex.src.size(1)
 

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -66,7 +66,7 @@ class ImageDataset(DatasetBase):
         return ex.src.size(2), ex.src.size(1)
 
     @classmethod
-    def make_examples_nfeats_tpl(cls, img_iter, img_path, img_dir):
+    def make_examples_nfeats_tpl(cls, iterator, path, directory, **kwargs):
         """
         Note: one of img_iter and img_path must be not None
         Args:
@@ -79,12 +79,12 @@ class ImageDataset(DatasetBase):
         Returns:
             (example_dict iterator, num_feats) tuple
         """
-        # this method disregards one of its arguments...
-        if img_iter is None and img_path is None:
-            raise ValueError("'img_iter' and 'img_path' must not both be None")
+        # This method disregards one of its arguments. This should not be.
+        if iterator is None and path is None:
+            raise ValueError("'iterator' and 'path' must not both be None")
 
-        img_iter = cls.make_iterator_from_file(img_path, img_dir)
-        examples_iter = cls.make_examples(img_iter, img_dir, 'src')
+        iterator = cls.make_iterator_from_file(path, directory)
+        examples_iter = cls.make_examples(iterator, directory, 'src')
 
         return examples_iter, 0
 

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -44,7 +44,7 @@ class ImageDataset(DatasetBase):
             src_dir (str): location of source images
 
         Returns:
-            (example_dict iterator, num_feats) tuple
+            example_dict iterator
         """
         # This method disregards one of its arguments. This should not be.
         if iterator is None and path is None:
@@ -53,7 +53,7 @@ class ImageDataset(DatasetBase):
         iterator = cls.make_iterator_from_file(path, directory)
         examples_iter = cls.make_examples(iterator, directory, 'src')
 
-        return examples_iter, 0
+        return examples_iter
 
     @classmethod
     def make_examples(cls, img_iter, src_dir, side, truncate=None):

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -30,11 +30,11 @@ class ImageDataset(DatasetBase):
                 out examples?
     """
 
+    data_type = 'img'
+
     def __init__(self, fields, src_examples_iter, tgt_examples_iter,
                  num_src_feats=0, num_tgt_feats=0,
                  tgt_seq_length=0, use_filter_pred=True):
-        self.data_type = 'img'
-
         self.n_src_feats = num_src_feats
         self.n_tgt_feats = num_tgt_feats
 
@@ -53,14 +53,12 @@ class ImageDataset(DatasetBase):
         example_values = ([ex[k] for k in keys] for ex in examples_iter)
         examples = [Example.fromlist(ev, out_fields) for ev in example_values]
 
-        def filter_pred(example):
+        def filter_pred(ex):
             """ ? """
-            if tgt_examples_iter is not None:
-                return 0 < len(example.tgt) <= tgt_seq_length
-            else:
-                return True
+            return 0 < len(ex.tgt) <= tgt_seq_length
 
-        filter_pred = filter_pred if use_filter_pred else None
+        filter_pred = filter_pred if use_filter_pred \
+            and tgt_examples_iter is not None else None
 
         super(ImageDataset, self).__init__(examples, out_fields, filter_pred)
 

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -6,11 +6,7 @@
 import codecs
 import os
 
-import torch
-import torchtext
-
-from onmt.inputters.dataset_base import DatasetBase, PAD_WORD, BOS_WORD, \
-    EOS_WORD
+from onmt.inputters.dataset_base import DatasetBase
 
 
 class ImageDataset(DatasetBase):
@@ -156,79 +152,6 @@ class ImageDataset(DatasetBase):
 
                 img = transforms.ToTensor()(Image.open(img_path))
                 yield img, filename
-
-    @staticmethod
-    def get_fields(n_src_features, n_tgt_features):
-        """
-        Args:
-            n_src_features: the number of source features to
-                create `torchtext.data.Field` for.
-            n_tgt_features: the number of target features to
-                create `torchtext.data.Field` for.
-
-        Returns:
-            A dictionary whose keys are strings and whose values
-            are the corresponding Field objects.
-        """
-        fields = {}
-
-        def make_img(data, vocab):
-            """ ? """
-            c = data[0].size(0)
-            h = max([t.size(1) for t in data])
-            w = max([t.size(2) for t in data])
-            imgs = torch.zeros(len(data), c, h, w).fill_(1)
-            for i, img in enumerate(data):
-                imgs[i, :, 0:img.size(1), 0:img.size(2)] = img
-            return imgs
-
-        fields["src"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.float,
-            postprocessing=make_img, sequential=False)
-
-        for j in range(n_src_features):
-            fields["src_feat_" + str(j)] = \
-                torchtext.data.Field(pad_token=PAD_WORD)
-
-        fields["tgt"] = torchtext.data.Field(
-            init_token=BOS_WORD, eos_token=EOS_WORD, pad_token=PAD_WORD)
-
-        for j in range(n_tgt_features):
-            fields["tgt_feat_" + str(j)] = \
-                torchtext.data.Field(init_token=BOS_WORD, eos_token=EOS_WORD,
-                                     pad_token=PAD_WORD)
-
-        def make_src(data, vocab):
-            """ ? """
-            src_size = max([t.size(0) for t in data])
-            src_vocab_size = max([t.max() for t in data]) + 1
-            alignment = torch.zeros(src_size, len(data), src_vocab_size)
-            for i, sent in enumerate(data):
-                for j, t in enumerate(sent):
-                    alignment[j, i, t] = 1
-            return alignment
-
-        fields["src_map"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.float,
-            postprocessing=make_src, sequential=False)
-
-        def make_tgt(data, vocab):
-            """ ? """
-            tgt_size = max([t.size(0) for t in data])
-            alignment = torch.zeros(tgt_size, len(data)).long()
-            for i, sent in enumerate(data):
-                alignment[:sent.size(0), i] = sent
-            return alignment
-
-        fields["alignment"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.long,
-            postprocessing=make_tgt, sequential=False)
-
-        fields["indices"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.long,
-            sequential=False)
-
-        return fields
 
     @staticmethod
     def get_num_features(corpus_file, side):

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -191,8 +191,7 @@ class ImageDataset(DatasetBase):
                 torchtext.data.Field(pad_token=PAD_WORD)
 
         fields["tgt"] = torchtext.data.Field(
-            init_token=BOS_WORD, eos_token=EOS_WORD,
-            pad_token=PAD_WORD)
+            init_token=BOS_WORD, eos_token=EOS_WORD, pad_token=PAD_WORD)
 
         for j in range(n_tgt_features):
             fields["tgt_feat_" + str(j)] = \

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -33,7 +33,7 @@ class ImageDataset(DatasetBase):
         return ex.src.size(2), ex.src.size(1)
 
     @classmethod
-    def _make_examples(cls, iterator, truncate=None, **kwargs):
+    def _make_example(cls, pair, truncate=None, **kwargs):
         """
         Args:
             path (str): location of a src file containing image paths
@@ -44,17 +44,19 @@ class ImageDataset(DatasetBase):
         Yields:
             a dictionary containing image data, path and index for each line.
         """
-        for i, (img, filename) in enumerate(iterator):
-            # problem is that the value of truncate getting passed is an int,
-            # which is not subscriptable
-            if truncate and truncate != (0, 0):
-                if not (img.size(1) <= truncate[0]
-                        and img.size(2) <= truncate[1]):
-                    continue
-
-            # if the continue statement is reached, then the outputs of this
-            # function will have missing indices
-            yield {'src': img, 'src_path': filename, 'indices': i}
+        img, filename = pair
+        # problem is that the value of truncate getting passed is an int,
+        # which is not subscriptable
+        # gonna ignore the image truncating logic for now...
+        # truncating doesn't really appear to truncate for images, it
+        # filters out images that are too big.
+        """
+        if truncate and truncate != (0, 0):
+            if not (img.size(1) <= truncate[0]
+                    and img.size(2) <= truncate[1]):
+                continue
+        """
+        return {'src': img, 'src_path': filename}
 
     @classmethod
     def _make_iterator_from_file(cls, path, directory, **kwargs):

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -72,7 +72,7 @@ class ImageDataset(DatasetBase):
 
     def sort_key(self, ex):
         """ Sort using the size of the image: (width, height)."""
-        return (ex.src.size(2), ex.src.size(1))
+        return ex.src.size(2), ex.src.size(1)
 
     @staticmethod
     def make_image_examples_nfeats_tpl(img_iter, img_path, img_dir):
@@ -98,7 +98,7 @@ class ImageDataset(DatasetBase):
         examples_iter = ImageDataset.make_examples(img_iter, img_dir, 'src')
         num_feats = 0  # Source side(img) has no features.
 
-        return (examples_iter, num_feats)
+        return examples_iter, num_feats
 
     @staticmethod
     def make_examples(img_iter, src_dir, side, truncate=None):
@@ -152,26 +152,3 @@ class ImageDataset(DatasetBase):
 
                 img = transforms.ToTensor()(Image.open(img_path))
                 yield img, filename
-
-    @staticmethod
-    def get_num_features(corpus_file, side):
-        """
-        For image corpus, source side is in form of image, thus
-        no feature; while target side is in form of text, thus
-        we can extract its text features.
-
-        Args:
-            corpus_file (str): file path to get the features.
-            side (str): 'src' or 'tgt'.
-
-        Returns:
-            number of features on `side`.
-        """
-        if side == 'src':
-            num_feats = 0
-        else:
-            with codecs.open(corpus_file, "r", "utf-8") as cf:
-                f_line = cf.readline().strip().split()
-                _, _, num_feats = ImageDataset.extract_text_features(f_line)
-
-        return num_feats

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -33,7 +33,7 @@ class ImageDataset(DatasetBase):
         return ex.src.size(2), ex.src.size(1)
 
     @classmethod
-    def make_examples_nfeats_tpl(cls, iterator, path, directory, **kwargs):
+    def make_examples(cls, iterator, path, directory, **kwargs):
         """
         Note: one of img_iter and img_path must be not None
         Args:
@@ -51,12 +51,12 @@ class ImageDataset(DatasetBase):
             raise ValueError("'iterator' and 'path' must not both be None")
 
         iterator = cls.make_iterator_from_file(path, directory)
-        examples_iter = cls.make_examples(iterator, directory, 'src')
+        examples_iter = cls._make_examples(iterator, directory, 'src')
 
         return examples_iter
 
     @classmethod
-    def make_examples(cls, img_iter, src_dir, side, truncate=None):
+    def _make_examples(cls, img_iter, src_dir, side, truncate=None):
         """
         Args:
             path (str): location of a src file containing image paths

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -1,12 +1,7 @@
 # -*- coding: utf-8 -*-
-"""
-    ImageDataset
-"""
 
 import codecs
 import os
-
-from torchtext.data import Example
 
 from onmt.inputters.dataset_base import DatasetBase
 
@@ -31,34 +26,6 @@ class ImageDataset(DatasetBase):
     """
 
     data_type = 'img'
-
-    def __init__(self, fields, src_examples_iter, tgt_examples_iter,
-                 num_src_feats=0, num_tgt_feats=0,
-                 tgt_seq_length=0, use_filter_pred=True):
-        self.n_src_feats = num_src_feats
-        self.n_tgt_feats = num_tgt_feats
-
-        if tgt_examples_iter is not None:
-            examples_iter = (self._join_dicts(src, tgt) for src, tgt in
-                             zip(src_examples_iter, tgt_examples_iter))
-        else:
-            examples_iter = src_examples_iter
-
-        # Peek at the first to see which fields are used.
-        ex, examples_iter = self._peek(examples_iter)
-        keys = ex.keys()
-
-        fields = [(k, fields[k]) if k in fields else (k, None) for k in keys]
-        example_values = ([ex[k] for k in keys] for ex in examples_iter)
-        examples = [Example.fromlist(ev, fields) for ev in example_values]
-
-        def filter_pred(ex):
-            return 0 < len(ex.tgt) <= tgt_seq_length
-
-        filter_pred = filter_pred if use_filter_pred \
-            and tgt_examples_iter is not None else None
-
-        super(ImageDataset, self).__init__(examples, fields, filter_pred)
 
     @staticmethod
     def sort_key(ex):

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -45,6 +45,8 @@ class ImageDataset(DatasetBase):
             a dictionary containing image data, path and index for each line.
         """
         for i, (img, filename) in enumerate(iterator):
+            # problem is that the value of truncate getting passed is an int,
+            # which is not subscriptable
             if truncate and truncate != (0, 0):
                 if not (img.size(1) <= truncate[0]
                         and img.size(2) <= truncate[1]):

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -558,7 +558,7 @@ def lazily_load_dataset(corpus_type, path):
         yield dataset
 
 
-def _load_fields(dataset, data_type, opt, checkpoint):
+def load_fields(dataset, data_type, opt, checkpoint):
     if checkpoint is not None:
         logger.info('Loading vocab from checkpoint at %s.' % opt.train_from)
         fields = load_fields_from_vocab(checkpoint['vocab'], data_type)
@@ -578,7 +578,7 @@ def _load_fields(dataset, data_type, opt, checkpoint):
     return fields
 
 
-def _collect_report_features(fields):
+def collect_report_features(fields):
     src_features = collect_features(fields, side='src')
     tgt_features = collect_features(fields, side='tgt')
 

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -75,7 +75,7 @@ def make_audio(data, vocab):
     return sounds
 
 
-def get_fields(data_type, n_src_features, n_tgt_features):
+def get_fields(data_type, n_src_features, n_tgt_features, dynamic_dict=False):
     """
     Args:
         data_type: type of the source input. Options are [text|img|audio].
@@ -125,13 +125,14 @@ def get_fields(data_type, n_src_features, n_tgt_features):
         use_vocab=False, dtype=torch.long,
         sequential=False, tokenize=str.split)
 
-    fields["src_map"] = torchtext.data.Field(
-        use_vocab=False, dtype=torch.float,
-        postprocessing=make_src, sequential=False, tokenize=str.split)
+    if dynamic_dict:
+        fields["src_map"] = torchtext.data.Field(
+            use_vocab=False, dtype=torch.float,
+            postprocessing=make_src, sequential=False, tokenize=str.split)
 
-    fields["alignment"] = torchtext.data.Field(
-        use_vocab=False, dtype=torch.long,
-        postprocessing=make_tgt, sequential=False, tokenize=str.split)
+        fields["alignment"] = torchtext.data.Field(
+            use_vocab=False, dtype=torch.long,
+            postprocessing=make_tgt, sequential=False, tokenize=str.split)
 
     return fields
 
@@ -402,7 +403,7 @@ def build_vocabs(datasets, data_type, share_vocab,
                 min_freq=tgt_words_min_frequency)
             if tgt_vocab is not None:
                 field.vocab = filtered_vocab(field.vocab, tgt_vocab)
-        else:
+        elif field.use_vocab:
             field.build_vocab(*datasets)
 
     if data_type == 'text':

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -324,13 +324,14 @@ def build_dataset(fields, data_type, src_data_iter=None, src_path=None,
     # it will be disregarded silently, no need to raise an error.
 
     # text is the choice on the target side
-    tgt_examples_iter, num_tgt_feats = \
+    # TODO: look at make_examples_nfeats_tpl because nfeats isn't necessary
+    tgt_examples_iter, _ = \
         TextDataset.make_examples_nfeats_tpl(
             tgt_data_iter, tgt_path, tgt_seq_length_trunc, "tgt")
 
     src_data_cls = src_data_classes[data_type]
 
-    src_examples_iter, num_src_feats = src_data_cls.make_examples_nfeats_tpl(
+    src_examples_iter, _ = src_data_cls.make_examples_nfeats_tpl(
         iterator=src_data_iter, path=src_path,
         truncate=src_seq_length_trunc,
         side="src", directory=src_dir,
@@ -351,7 +352,6 @@ def build_dataset(fields, data_type, src_data_iter=None, src_path=None,
 
     dataset = src_data_cls(
         fields, src_examples_iter, tgt_examples_iter,
-        num_src_feats, num_tgt_feats,
         src_seq_length=src_seq_length,
         tgt_seq_length=tgt_seq_length,
         dynamic_dict=dynamic_dict,
@@ -416,12 +416,12 @@ def build_vocabs(datasets, data_type, share_vocab,
         logger.info(" * src vocab size: %d." % len(fields["src"].vocab))
     logger.info(" * tgt vocab size: %d." % len(fields["tgt"].vocab))
 
-    for j in range(datasets[0].n_src_feats):
-        key = "src_feat_" + str(j)
-        logger.info(" * %s vocab size: %d." % (key, len(fields[key].vocab)))
-    for j in range(datasets[0].n_tgt_feats):
-        key = "tgt_feat_" + str(j)
-        logger.info(" * %s vocab size: %d." % (key, len(fields[key].vocab)))
+    src_feats = sorted(name for name in fields if "src_feat_" in name)
+    tgt_feats = sorted(name for name in fields if "tgt_feat_" in name)
+    for i, feat in enumerate(src_feats, 1):
+        logger.info(" * %s vocab size: %d." % (feat, len(fields[feat].vocab)))
+    for i, feat in enumerate(tgt_feats, 1):
+        logger.info(" * %s vocab size: %d." % (feat, len(fields[feat].vocab)))
 
     if data_type == 'text' and share_vocab:
         # Merge the input and output vocabularies.

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -318,8 +318,7 @@ def build_dataset(fields, data_type, src_data_iter=None, src_path=None,
             tgt_data_iter, tgt_path, tgt_seq_length_trunc, "tgt")
 
     src_data_cls = src_data_classes[data_type]
-    # discussion: since make_examples_nfeats_tpl is used only here, why not
-    # move it into the constructor of the dataset?
+
     src_examples_iter, num_src_feats = src_data_cls.make_examples_nfeats_tpl(
         iterator=src_data_iter, path=src_path,
         truncate=src_seq_length_trunc,

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -73,7 +73,9 @@ def load_fields_from_vocab(vocab, data_type="text"):
 
 def fields_to_vocab(fields):
     """
-    Save Vocab objects in Field objects to `vocab.pt` file. NOT TRUE
+    fields: a dict whose keys are strings and whose values are Field objects
+    returns: a list of 2-tuples whose first items are keys of the fields dict
+             and whose values are the vocabs of the corresponding Fields.
     """
     return [(k, f.vocab) for k, f in fields.items()
             if f is not None and 'vocab' in f.__dict__]

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -587,27 +587,3 @@ def lazily_load_dataset(corpus_type, path):
         logger.info('Loading %s dataset from %s, number of examples: %d' %
                     (corpus_type, pt, len(dataset)))
         yield dataset
-
-
-def load_fields(dataset, data_type, opt, checkpoint):
-    # used only in train_single.py, because the dataset loaded from the file
-    # doesn't have fields anymore.
-    # idea: since rebuilding datasets is such a hassle, write a dataset
-    # classmethod that takes care of it.
-    if checkpoint is not None:
-        logger.info('Loading vocab from checkpoint at %s.' % opt.train_from)
-        fields = load_fields_from_vocab(checkpoint['vocab'], data_type)
-    else:
-        fields = load_fields_from_vocab(
-            torch.load(opt.data + '.vocab.pt'), data_type)
-    fields = dict([(k, f) for (k, f) in fields.items()
-                   if k in dataset.examples[0].__dict__])
-
-    if data_type == 'text':
-        logger.info(' * vocabulary size. source = %d; target = %d' %
-                    (len(fields['src'].vocab), len(fields['tgt'].vocab)))
-    else:
-        logger.info(' * vocabulary size. target = %d' %
-                    (len(fields['tgt'].vocab)))
-
-    return fields

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -322,7 +322,7 @@ def build_dataset(fields, data_type, src_data_iter=None, src_path=None,
     # make_examples_nfeats_tpl is used only in this function
     # text is the choice on the target side
     tgt_examples_iter = TextDataset.make_examples(
-            tgt_data_iter, tgt_path, tgt_seq_length_trunc, "tgt")
+            tgt_data_iter, tgt_path, truncate=tgt_seq_length_trunc, side="tgt")
 
     src_data_cls = src_data_classes[data_type]
 

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -323,10 +323,7 @@ def build_dataset(fields, data_type, src_data_iter=None, src_path=None,
 
     dataset = src_data_cls(
         fields, src_examples_iter, tgt_examples_iter,
-        src_seq_length=src_seq_length,
-        tgt_seq_length=tgt_seq_length,
-        dynamic_dict=dynamic_dict,
-        filter_pred=fp)
+        dynamic_dict=dynamic_dict, filter_pred=fp)
 
     return dataset
 

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -388,7 +388,6 @@ def build_vocabs(datasets, fields, data_type, share_vocab,
 
     src_vocab = load_vocabulary(src_vocab_path, tag="source")
     tgt_vocab = load_vocabulary(tgt_vocab_path, tag="target")
-    print(datasets[0].fields)
 
     for name, field in fields.items():
         if name == 'src':

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -280,43 +280,43 @@ def collect_feature_vocabs(fields, side):
     return feature_vocabs
 
 
-def build_dataset(fields, data_type, src_data_iter=None, src_path=None,
-                  src_dir=None, tgt_data_iter=None, tgt_path=None,
+def build_dataset(fields, data_type, src_path, tgt_path, src_dir=None,
                   src_seq_length=0, tgt_seq_length=0,
                   src_seq_length_trunc=0, tgt_seq_length_trunc=0,
                   dynamic_dict=True, sample_rate=0,
                   window_size=0, window_stride=0, window=None,
                   normalize_audio=True, use_filter_pred=True):
     """
-    A quasi-constructor for a Dataset.
+    A quasi-constructor for a Dataset. Give it a pair of paths and some kwargs,
+    it'll make a Dataset object. Would it be better if this were a @classmethod
+    alternate constructor for a Dataset class? Probably, but this is about
+    incremental progress.
     """
     # used in preprocess.py and translator.py
     # in preprocess.py, it is called if you are not doing sharding, currently
-    # meaning if you are not using text. The src_path and tgt_path should not
-    # be None is this case. src_data_iter and tgt_data_iter are not specified
-    # so will be None.
-    # in translator.py, both the path and iter arguments are passed to
+    # meaning if you are not using text.
+    # in translator.py, path and iter arguments are passed to
     # build_dataset, but when it's actually called in translate.py the iter
     # arguments are also unspecified and thus None.
-    assert src_data_iter is not None or src_path is not None
-    assert src_data_iter is None or src_path is None
-
-    assert tgt_data_iter is not None or tgt_path is not None
-    assert tgt_data_iter is None or tgt_path is None
+    if src_path is None:
+        raise ValueError("You must specify a path for src data")
 
     src_data_classes = {'text': TextDataset, 'img': ImageDataset,
                         'audio': AudioDataset}
     assert data_type in src_data_classes
 
+    # you can have a None tgt_path because you can translate without a gold
+    # target
     # make_examples is used only in this function
-    tgt_examples_iter = TextDataset.make_examples(
-            tgt_data_iter, tgt_path, truncate=tgt_seq_length_trunc, side="tgt")
+    if tgt_path is not None:
+        tgt_examples_iter = TextDataset.make_examples(
+                tgt_path, truncate=tgt_seq_length_trunc, side="tgt")
+    else:
+        tgt_examples_iter = None
 
     src_data_cls = src_data_classes[data_type]
-
-    # why are a path and an iterator both required?
     src_examples_iter = src_data_cls.make_examples(
-        iterator=src_data_iter, path=src_path,
+        src_path,
         truncate=src_seq_length_trunc,
         side="src", directory=src_dir,
         sample_rate=sample_rate, window_size=window_size,

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -81,6 +81,8 @@ def get_fields(data_type, n_src_features, n_tgt_features):
             create `torchtext.data.Field` for.
         n_tgt_features: the number of target features to
             create `torchtext.data.Field` for.
+        dynamic_dict (bool): whether the model has a dynamic dict/copy attn.
+            If so, additional fields are required.
 
     Returns:
         A dictionary whose keys are strings and whose values are the
@@ -121,9 +123,6 @@ def get_fields(data_type, n_src_features, n_tgt_features):
         use_vocab=False, dtype=torch.long,
         sequential=False, tokenize=str.split)
 
-    # src_map and alignment are only relevant for copy attention. It is a
-    # mystery why they are created when there is no copy attention, because
-    # they will not end up being used.
     fields["src_map"] = torchtext.data.Field(
         use_vocab=False, dtype=torch.float,
         postprocessing=make_src, sequential=False, tokenize=str.split)
@@ -364,7 +363,7 @@ def filtered_vocab(vocab, wordset):
     return Vocab(counts, specials=[UNK_WORD, PAD_WORD, BOS_WORD, EOS_WORD])
 
 
-def build_vocabs(datasets, fields, data_type, share_vocab,
+def build_vocabs(datasets, data_type, share_vocab,
                  src_vocab_path, src_vocab_size, src_words_min_frequency,
                  tgt_vocab_path, tgt_vocab_size, tgt_words_min_frequency):
     """
@@ -389,6 +388,7 @@ def build_vocabs(datasets, fields, data_type, share_vocab,
     src_vocab = load_vocabulary(src_vocab_path, tag="source")
     tgt_vocab = load_vocabulary(tgt_vocab_path, tag="target")
 
+    fields = datasets[0].fields
     for name, field in fields.items():
         if name == 'src':
             field.build_vocab(

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -390,20 +390,21 @@ def build_vocabs(datasets, data_type, share_vocab,
     fields = datasets[0].fields
     for name, field in fields.items():
         # beware of a case where field is None
-        if name == 'src':
-            field.build_vocab(
-                *datasets, max_size=src_vocab_size,
-                min_freq=src_words_min_frequency)
-            if src_vocab is not None:
-                field.vocab = filtered_vocab(field.vocab, src_vocab)
-        elif name == 'tgt':
-            field.build_vocab(
-                *datasets, max_size=tgt_vocab_size,
-                min_freq=tgt_words_min_frequency)
-            if tgt_vocab is not None:
-                field.vocab = filtered_vocab(field.vocab, tgt_vocab)
-        elif field.use_vocab:
-            field.build_vocab(*datasets)
+        if field.use_vocab:
+            if name == 'src':
+                field.build_vocab(
+                    *datasets, max_size=src_vocab_size,
+                    min_freq=src_words_min_frequency)
+                if src_vocab is not None:
+                    field.vocab = filtered_vocab(field.vocab, src_vocab)
+            elif name == 'tgt':
+                field.build_vocab(
+                    *datasets, max_size=tgt_vocab_size,
+                    min_freq=tgt_words_min_frequency)
+                if tgt_vocab is not None:
+                    field.vocab = filtered_vocab(field.vocab, tgt_vocab)
+            else:
+                field.build_vocab(*datasets)
 
     if data_type == 'text':
         logger.info(" * src vocab size: %d." % len(fields["src"].vocab))

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -321,13 +321,13 @@ def build_dataset(fields, data_type, src_data_iter=None, src_path=None,
 
     # make_examples_nfeats_tpl is used only in this function
     # text is the choice on the target side
-    tgt_examples_iter = TextDataset.make_examples_nfeats_tpl(
+    tgt_examples_iter = TextDataset.make_examples(
             tgt_data_iter, tgt_path, tgt_seq_length_trunc, "tgt")
 
     src_data_cls = src_data_classes[data_type]
 
     # why are a path and an iterator both required?
-    src_examples_iter = src_data_cls.make_examples_nfeats_tpl(
+    src_examples_iter = src_data_cls.make_examples(
         iterator=src_data_iter, path=src_path,
         truncate=src_seq_length_trunc,
         side="src", directory=src_dir,

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -389,6 +389,7 @@ def build_vocabs(datasets, data_type, share_vocab,
 
     fields = datasets[0].fields
     for name, field in fields.items():
+        # beware of a case where field is None
         if name == 'src':
             field.build_vocab(
                 *datasets, max_size=src_vocab_size,
@@ -533,7 +534,7 @@ def build_dataset_iter(datasets, opt, is_train=True):
     # used only in train_single.py in the return of the train_iter_fct
     # and valid_iter_fct functions, which uses lazily_load_dataset() as
     # the first argument.
-    # actual use of the thing this function returns:
+    # In no case in the current code is is_train set to False
     batch_size = opt.batch_size if is_train else opt.valid_batch_size
     if is_train and opt.batch_type == "tokens":
         def batch_size_fn(new, count, sofar):

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -543,8 +543,6 @@ def build_dataset_iter(datasets, opt, is_train=True):
             return max(src_elements, tgt_elements)
     else:
         batch_size_fn = None
-    # device = opt.device_id if opt.gpuid else -1
-    # breaking change torchtext 0.3
     device = "cuda" if opt.gpuid else "cpu"
 
     return DatasetLazyIter(datasets, batch_size, batch_size_fn,

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -294,12 +294,12 @@ def build_dataset(fields, data_type, src_data_iter=None, src_path=None,
         # necessary
         if data_type == 'text':
             src_examples_iter, num_src_feats = \
-                TextDataset.make_text_examples_nfeats_tpl(
+                TextDataset.make_examples_nfeats_tpl(
                     src_data_iter, src_path, src_seq_length_trunc, "src")
 
         elif data_type == 'img':
             src_examples_iter, num_src_feats = \
-                ImageDataset.make_image_examples_nfeats_tpl(
+                ImageDataset.make_examples_nfeats_tpl(
                     src_data_iter, src_path, src_dir)
 
         elif data_type == 'audio':
@@ -310,7 +310,7 @@ def build_dataset(fields, data_type, src_data_iter=None, src_path=None,
             if src_path is None:
                 raise ValueError("AudioDataset requires a non None path")
             src_examples_iter, num_src_feats = \
-                AudioDataset.make_audio_examples_nfeats_tpl(
+                AudioDataset.make_examples_nfeats_tpl(
                     src_path, src_dir, sample_rate,
                     window_size, window_stride, window,
                     normalize_audio)
@@ -326,7 +326,7 @@ def build_dataset(fields, data_type, src_data_iter=None, src_path=None,
 
     # For all data types, the tgt side corpus is in form of text.
     tgt_examples_iter, num_tgt_feats = \
-        TextDataset.make_text_examples_nfeats_tpl(
+        TextDataset.make_examples_nfeats_tpl(
             tgt_data_iter, tgt_path, tgt_seq_length_trunc, "tgt")
 
     if data_type == 'text':

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -218,6 +218,7 @@ def make_features(batch, side, data_type='text'):
         A sequence of src/tgt tensors with optional feature tensors
         of size (len x batch).
     """
+    # this should be a field issue
     assert side in ['src', 'tgt']
     if isinstance(batch.__dict__[side], tuple):
         data = batch.__dict__[side][0]
@@ -242,6 +243,7 @@ def collect_features(fields, side="src"):
     side: src or tgt
     returns: list of the string names of the features on the given side
     """
+    # this is currently not used outside of inputter.py
     assert side in ["src", "tgt"]
     feats = []
     for j in count():

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -163,19 +163,16 @@ def load_fields_from_vocab(vocab, data_type="text"):
     # model_builder.build_base_model, which needs the fields as an argument
     # to inputters.collect_feature_vocabs, which it uses so that it can
     # have access to the feature vocabularies.
-    vocab = dict(vocab)
-    n_src_features = len([name for name in vocab if 'src_feat' in name])
-    n_tgt_features = len([name for name in vocab if 'tgt_feat' in name])
+    n_src_features = len([name for name, v in vocab if 'src_feat' in name])
+    n_tgt_features = len([name for name, v in vocab if 'tgt_feat' in name])
     fields = get_fields(data_type, n_src_features, n_tgt_features)
-    # why turn vocab from a sequence of tuples into a dict and then back into
-    # a sequence of tuples? It might make sense if the vocab arg might have a
-    # different type
-    for k, v in vocab.items():
+
+    for name, v in vocab:
         # Hack. Can't pickle defaultdict :(
         # bp: this isn't true, you can pickle a defaultdict if the callable
         # is defined at the top level of the class. You can't pickle lambdas.
         v.stoi = defaultdict(lambda: 0, v.stoi)
-        fields[k].vocab = v
+        fields[name].vocab = v
     return fields
 
 

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -288,10 +288,22 @@ def build_dataset(fields, data_type, src_data_iter=None, src_path=None,
                   window_size=0, window_stride=0, window=None,
                   normalize_audio=True, use_filter_pred=True):
     """
-    Build src/tgt examples iterator from corpus files, also extract
-    number of features.
+    A quasi-constructor for a Dataset.
     """
     # used in preprocess.py and translator.py
+    # in preprocess.py, it is called if you are not doing sharding, currently
+    # meaning if you are not using text. The src_path and tgt_path should not
+    # be None is this case. src_data_iter and tgt_data_iter are not specified
+    # so will be None.
+    # in translator.py, both the path and iter arguments are passed to
+    # build_dataset, but when it's actually called in translate.py the iter
+    # arguments are also unspecified and thus None.
+    assert src_data_iter is not None or src_path is not None
+    assert src_data_iter is None or src_path is None
+
+    assert tgt_data_iter is not None or tgt_path is not None
+    assert tgt_data_iter is None or tgt_path is None
+
     src_data_classes = {'text': TextDataset, 'img': ImageDataset,
                         'audio': AudioDataset}
     assert data_type in src_data_classes

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -145,8 +145,6 @@ def load_fields_from_vocab(vocab, data_type="text"):
         values are fields created by a call to get_fields.
     """
     # this function is used:
-    # 1) elsewhere in inputter.py (in load_fields, which
-    # is used to create the data in train_single.py)
     # 2) in dataset_base.py, in the class method DatasetBase.load_fields, which
     # is used in a .md and a jupyter notebook but not in the actual codebase
     # 3) in model_builder.py, in the function load_test_model, which is used
@@ -481,10 +479,8 @@ class DatasetLazyIter(object):
         is_train (bool): train or valid?
     """
 
-    def __init__(self, datasets, fields, batch_size, batch_size_fn,
-                 device, is_train):
+    def __init__(self, datasets, batch_size, batch_size_fn, device, is_train):
         self.datasets = datasets
-        self.fields = fields
         self.batch_size = batch_size
         self.batch_size_fn = batch_size_fn
         self.device = device
@@ -518,9 +514,6 @@ class DatasetLazyIter(object):
         except StopIteration:
             return None
 
-        # We clear `fields` when saving, restore when loading.
-        self.cur_dataset.fields = self.fields
-
         # Sort batch by decreasing lengths of sentence required by pytorch.
         # sort=False means "Use dataset's sortkey instead of iterator's".
         return OrderedIterator(
@@ -531,7 +524,7 @@ class DatasetLazyIter(object):
             repeat=False)
 
 
-def build_dataset_iter(datasets, fields, opt, is_train=True):
+def build_dataset_iter(datasets, opt, is_train=True):
     """
     This returns user-defined train/validate data iterator for the trainer
     to iterate over. We implement simple ordered iterator strategy here,
@@ -568,7 +561,7 @@ def build_dataset_iter(datasets, fields, opt, is_train=True):
     # breaking change torchtext 0.3
     device = "cuda" if opt.gpuid else "cpu"
 
-    return DatasetLazyIter(datasets, fields, batch_size, batch_size_fn,
+    return DatasetLazyIter(datasets, batch_size, batch_size_fn,
                            device, is_train)
 
 

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -156,8 +156,6 @@ def load_fields_from_vocab(vocab, data_type="text"):
         values are fields created by a call to get_fields.
     """
     # this function is used:
-    # 2) in dataset_base.py, in the class method DatasetBase.load_fields, which
-    # is used in a .md and a jupyter notebook but not in the actual codebase
     # 3) in model_builder.py, in the function load_test_model, which is used
     # in translator.py.
     # 4) in extract_embeddings.py, in order to build the model whose embeddings
@@ -315,23 +313,21 @@ def build_dataset(fields, data_type, src_data_iter=None, src_path=None,
     Build src/tgt examples iterator from corpus files, also extract
     number of features.
     """
+    # "also" is not good in functions
     # used in preprocess.py and translator.py
-    # seems like further simplification should be possible
     src_data_classes = {'text': TextDataset, 'img': ImageDataset,
                         'audio': AudioDataset}
     assert data_type in src_data_classes
-    # check for value of src_data_iter no longer checked for AudioDatasets:
-    # it will be disregarded silently, no need to raise an error.
 
+    # make_examples_nfeats_tpl is used only in this function
     # text is the choice on the target side
-    # TODO: look at make_examples_nfeats_tpl because nfeats isn't necessary
-    tgt_examples_iter, _ = \
-        TextDataset.make_examples_nfeats_tpl(
+    tgt_examples_iter = TextDataset.make_examples_nfeats_tpl(
             tgt_data_iter, tgt_path, tgt_seq_length_trunc, "tgt")
 
     src_data_cls = src_data_classes[data_type]
 
-    src_examples_iter, _ = src_data_cls.make_examples_nfeats_tpl(
+    # why are a path and an iterator both required?
+    src_examples_iter = src_data_cls.make_examples_nfeats_tpl(
         iterator=src_data_iter, path=src_path,
         truncate=src_seq_length_trunc,
         side="src", directory=src_dir,
@@ -395,7 +391,6 @@ def build_vocabs(datasets, data_type, share_vocab,
 
     fields = datasets[0].fields
     for name, field in fields.items():
-        # beware of a case where field is None
         if field.use_vocab:
             if name == 'src':
                 field.build_vocab(

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -164,8 +164,8 @@ def load_fields_from_vocab(vocab, data_type="text"):
     # to inputters.collect_feature_vocabs, which it uses so that it can
     # have access to the feature vocabularies.
     vocab = dict(vocab)
-    n_src_features = len(collect_features(vocab, 'src'))
-    n_tgt_features = len(collect_features(vocab, 'tgt'))
+    n_src_features = len([name for name in vocab if 'src_feat' in name])
+    n_tgt_features = len([name for name in vocab if 'tgt_feat' in name])
     fields = get_fields(data_type, n_src_features, n_tgt_features)
     # why turn vocab from a sequence of tuples into a dict and then back into
     # a sequence of tuples? It might make sense if the vocab arg might have a
@@ -262,24 +262,6 @@ def make_features(batch, side, data_type='text'):
         return torch.cat([level.unsqueeze(2) for level in levels], 2)
     else:
         return levels[0]
-
-
-def collect_features(fields, side="src"):
-    """
-    Collect features from a diction object.
-    fields: a dict whose keys are strings and whose values are Field objects.
-    side: src or tgt
-    returns: list of the string names of the features on the given side
-    """
-    # used only in inputter.py in load_fields_from_vocab
-    assert side in ["src", "tgt"]
-    feats = []
-    for j in count():
-        key = side + "_feat_" + str(j)
-        if key not in fields:
-            break
-        feats.append(key)
-    return feats
 
 
 def collect_feature_vocabs(fields, side):

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -61,12 +61,12 @@ class TextDataset(DatasetBase):
                 out examples?
     """
 
+    data_type = 'text'
+
     def __init__(self, fields, src_examples_iter, tgt_examples_iter,
                  num_src_feats=0, num_tgt_feats=0,
                  src_seq_length=0, tgt_seq_length=0,
                  dynamic_dict=True, use_filter_pred=True):
-        self.data_type = 'text'
-
         # self.src_vocabs: mutated in dynamic_dict, used in
         # collapse_copy_scores and in Translator.py
         self.src_vocabs = []
@@ -96,10 +96,10 @@ class TextDataset(DatasetBase):
 
         examples = [Example.fromlist(ev, out_fields) for ev in example_values]
 
-        def filter_pred(example):
+        def filter_pred(ex):
             """ ? """
-            return 0 < len(example.src) <= src_seq_length \
-                and 0 < len(example.tgt) <= tgt_seq_length
+            return 0 < len(ex.src) <= src_seq_length \
+                and 0 < len(ex.tgt) <= tgt_seq_length
 
         filter_pred = filter_pred if use_filter_pred else None
 
@@ -127,7 +127,7 @@ class TextDataset(DatasetBase):
             fill = []
             index = batch.indices.data[b]
             src_vocab = src_vocabs[index]
-            for i, sw in enumerate(src_vocab, 1):
+            for i in range(1, len(src_vocab)):
                 sw = src_vocab.itos[i]
                 ti = tgt_vocab.stoi[sw]
                 if ti != 0:

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -65,7 +65,7 @@ class TextDataset(DatasetBase):
     def __init__(self, fields, src_examples_iter, tgt_examples_iter,
                  num_src_feats=0, num_tgt_feats=0,
                  src_seq_length=0, tgt_seq_length=0,
-                 dynamic_dict=True, use_filter_pred=True):
+                 dynamic_dict=False, use_filter_pred=True):
         # self.src_vocabs: mutated in dynamic_dict, used in translation.py
         self.src_vocabs = []
 

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -77,8 +77,7 @@ class TextDataset(DatasetBase):
 
         out_examples = []
         for ex_values in example_values:
-            example = self._construct_example_fromlist(
-                ex_values, out_fields)
+            example = self._construct_example_fromlist(ex_values, out_fields)
             src_size += len(example.src)
             out_examples.append(example)
 
@@ -151,15 +150,15 @@ class TextDataset(DatasetBase):
             else:
                 return (None, 0)
 
-        # All examples have same number of features, so we peek first one
-        # to get the num_feats.
+        # All examples have same number of features, so we peek at the first
+        # one to get the num_feats.
         examples_nfeats_iter = \
             TextDataset.make_examples(text_iter, truncate, side)
 
         first_ex = next(examples_nfeats_iter)
         num_feats = first_ex[1]
 
-        # Chain back the first element - we only want to peek it.
+        # Chain back the first element - we only want to peek at it.
         examples_nfeats_iter = chain([first_ex], examples_nfeats_iter)
         examples_iter = (ex for ex, nfeats in examples_nfeats_iter)
 
@@ -181,8 +180,7 @@ class TextDataset(DatasetBase):
             if truncate:
                 line = line[:truncate]
 
-            words, feats, n_feats = \
-                TextDataset.extract_text_features(line)
+            words, feats, n_feats = TextDataset.extract_text_features(line)
 
             example_dict = {side: words, "indices": i}
             if feats:
@@ -221,8 +219,7 @@ class TextDataset(DatasetBase):
                 torchtext.data.Field(pad_token=PAD_WORD)
 
         fields["tgt"] = torchtext.data.Field(
-            init_token=BOS_WORD, eos_token=EOS_WORD,
-            pad_token=PAD_WORD)
+            init_token=BOS_WORD, eos_token=EOS_WORD, pad_token=PAD_WORD)
 
         for j in range(n_tgt_features):
             fields["tgt_feat_" + str(j)] = \

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -99,8 +99,7 @@ class TextDataset(DatasetBase):
         return scores
 
     @classmethod
-    def make_examples_nfeats_tpl(cls, iterator, path,
-                                 truncate, side, **kwargs):
+    def make_examples(cls, iterator, path, truncate, side, **kwargs):
         """
         Args:
             text_iter(iterator): an iterator (or None) that we can loop over
@@ -121,12 +120,12 @@ class TextDataset(DatasetBase):
         if path is not None:
             iterator = cls.make_iterator_from_file(path)
 
-        examples_iter = cls.make_examples(iterator, truncate, side)
+        examples_iter = cls._make_examples(iterator, truncate, side)
 
         return examples_iter
 
     @classmethod
-    def make_examples(cls, text_iter, truncate, side):
+    def _make_examples(cls, text_iter, truncate, side):
         """
         Args:
             text_iter (iterator): iterator of text sequences

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
-"""Define word-based embedders."""
 
 import io
-import codecs
-import sys
 
 import torch
 
 from onmt.inputters.dataset_base import DatasetBase
-from onmt.utils.misc import aeq
 
 
 def extract_text_features(tokens):
@@ -115,130 +111,6 @@ class TextDataset(DatasetBase):
 
     @classmethod
     def _make_iterator_from_file(cls, path, **kwargs):
-        with codecs.open(path, "r", "utf-8") as corpus_file:
+        with io.open(path, "r", encoding="utf-8") as corpus_file:
             for line in corpus_file:
                 yield line
-
-
-class ShardedTextCorpusIterator(object):
-    """
-    This is the iterator for text corpus, used for sharding large text
-    corpus into small shards, to avoid hogging memory.
-
-    Inside this iterator, it automatically divides the corpus file into
-    shards of size `shard_size`. Then, for each shard, it processes
-    into (example_dict, n_features) tuples when iterates.
-    """
-
-    def __init__(self, corpus_path, line_truncate, side, shard_size,
-                 assoc_iter=None):
-        """
-        Args:
-            corpus_path: the corpus file path.
-            line_truncate: the maximum length of a line to read.
-                            0 for unlimited.
-            side: "src" or "tgt".
-            shard_size: the shard size, 0 means not sharding the file.
-            assoc_iter: if not None, it is the associate iterator that
-                        this iterator should align its step with.
-        """
-        try:
-            # The codecs module seems to have bugs with seek()/tell(),
-            # so we use io.open().
-            self.corpus = io.open(corpus_path, "r", encoding="utf-8")
-        except IOError:
-            sys.stderr.write("Failed to open corpus file: %s" % corpus_path)
-            sys.exit(1)
-
-        self.line_truncate = line_truncate
-        self.side = side
-        self.shard_size = shard_size
-        self.assoc_iter = assoc_iter
-        self.last_pos = 0
-        self.line_index = -1
-        self.eof = False
-
-    def __iter__(self):
-        """
-        Iterator of (example_dict, nfeats).
-        On each call, it iterates over as many (example_dict, nfeats) tuples
-        until this shard's size equals to or approximates `self.shard_size`.
-        """
-        iteration_index = -1
-        if self.assoc_iter is not None:
-            # We have associate iterator, just yields tuples
-            # util we run parallel with it.
-            while self.line_index < self.assoc_iter.line_index:
-                line = self.corpus.readline()
-                if line == '':
-                    raise AssertionError(
-                        "The two corpora must have same number of lines!")
-
-                self.line_index += 1
-                iteration_index += 1
-                yield self._example_dict_iter(line, iteration_index)
-
-            if self.assoc_iter.eof:
-                self.eof = True
-                self.corpus.close()
-        else:
-            # Yield tuples util this shard's size reaches the threshold.
-            self.corpus.seek(self.last_pos)
-            while True:
-                if self.shard_size != 0 and self.line_index % 64 == 0:
-                    # This part of check is time consuming on Py2 (but
-                    # it is quite fast on Py3, weird!). So we don't bother
-                    # to check for very line. Instead we chekc every 64
-                    # lines. Thus we are not dividing exactly per
-                    # `shard_size`, but it is not too much difference.
-                    cur_pos = self.corpus.tell()
-                    if cur_pos >= self.last_pos + self.shard_size:
-                        self.last_pos = cur_pos
-                        return
-
-                line = self.corpus.readline()
-                if line == '':
-                    self.eof = True
-                    self.corpus.close()
-                    return
-
-                self.line_index += 1
-                iteration_index += 1
-                yield self._example_dict_iter(line, iteration_index)
-
-    def hit_end(self):
-        """ ? """
-        return self.eof
-
-    @property
-    def num_feats(self):
-        """
-        We peek the first line and seek back to
-        the beginning of the file.
-        """
-        saved_pos = self.corpus.tell()
-
-        line = self.corpus.readline().split()
-        if self.line_truncate:
-            line = line[:self.line_truncate]
-        _, _, self.n_feats = extract_text_features(line)
-
-        self.corpus.seek(saved_pos)
-
-        return self.n_feats
-
-    def _example_dict_iter(self, line, index):
-        line = line.split()
-        if self.line_truncate:
-            line = line[:self.line_truncate]
-        words, feats, n_feats = extract_text_features(line)
-        example_dict = {self.side: words, "indices": index}
-        if feats:
-            # All examples must have same number of features.
-            aeq(self.n_feats, n_feats)
-
-            prefix = self.side + "_feat_"
-            example_dict.update((prefix + str(j), f)
-                                for j, f in enumerate(feats))
-
-        return example_dict

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -10,8 +10,7 @@ import sys
 import torch
 import torchtext
 
-from onmt.inputters.dataset_base import (DatasetBase, UNK_WORD,
-                                         PAD_WORD, BOS_WORD, EOS_WORD)
+from onmt.inputters.dataset_base import DatasetBase, UNK_WORD, PAD_WORD
 from onmt.utils.misc import aeq
 
 
@@ -194,69 +193,6 @@ class TextDataset(DatasetBase):
         with codecs.open(path, "r", "utf-8") as corpus_file:
             for line in corpus_file:
                 yield line
-
-    @staticmethod
-    def get_fields(n_src_features, n_tgt_features):
-        """
-        Args:
-            n_src_features (int): the number of source features to
-                create `torchtext.data.Field` for.
-            n_tgt_features (int): the number of target features to
-                create `torchtext.data.Field` for.
-
-        Returns:
-            A dictionary whose keys are strings and whose values
-            are the corresponding Field objects.
-        """
-        fields = {}
-
-        fields["src"] = torchtext.data.Field(
-            pad_token=PAD_WORD,
-            include_lengths=True)
-
-        for j in range(n_src_features):
-            fields["src_feat_" + str(j)] = \
-                torchtext.data.Field(pad_token=PAD_WORD)
-
-        fields["tgt"] = torchtext.data.Field(
-            init_token=BOS_WORD, eos_token=EOS_WORD, pad_token=PAD_WORD)
-
-        for j in range(n_tgt_features):
-            fields["tgt_feat_" + str(j)] = \
-                torchtext.data.Field(init_token=BOS_WORD, eos_token=EOS_WORD,
-                                     pad_token=PAD_WORD)
-
-        def make_src(data, vocab):
-            """ ? """
-            src_size = max([t.size(0) for t in data])
-            src_vocab_size = max([t.max() for t in data]) + 1
-            alignment = torch.zeros(src_size, len(data), src_vocab_size)
-            for i, sent in enumerate(data):
-                for j, t in enumerate(sent):
-                    alignment[j, i, t] = 1
-            return alignment
-
-        fields["src_map"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.float,
-            postprocessing=make_src, sequential=False)
-
-        def make_tgt(data, vocab):
-            """ ? """
-            tgt_size = max([t.size(0) for t in data])
-            alignment = torch.zeros(tgt_size, len(data)).long()
-            for i, sent in enumerate(data):
-                alignment[:sent.size(0), i] = sent
-            return alignment
-
-        fields["alignment"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.long,
-            postprocessing=make_tgt, sequential=False)
-
-        fields["indices"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.long,
-            sequential=False)
-
-        return fields
 
     @staticmethod
     def get_num_features(corpus_file, side):

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -67,8 +67,6 @@ class TextDataset(DatasetBase):
                  src_seq_length=0, tgt_seq_length=0,
                  dynamic_dict=True, use_filter_pred=True):
         # self.src_vocabs: mutated in dynamic_dict, used in translation.py
-        # at translation time, this is 1 shorter than it is in master, causing
-        # an indexing error
         self.src_vocabs = []
 
         self.n_src_feats = num_src_feats
@@ -98,15 +96,6 @@ class TextDataset(DatasetBase):
         example_values = ([ex[k] for k in keys] for ex in examples_iter)
 
         examples = [Example.fromlist(ev, fields) for ev in example_values]
-        # the examples list for validation is one shorter at test time than
-        # at preprocessing time
-        # test and validation data are handled differently, I suspect, and this
-        # has consequences.
-        # at preprocessing time, inputters.build_dataset is never called in the
-        # text case.
-        # the iter arguments passed also originate in different places and have
-        # different types
-        # print(len(self.src_vocabs))
 
         def filter_pred(ex):
             """ ? """

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -117,15 +117,13 @@ class TextDataset(DatasetBase):
         assert side in ['src', 'tgt']
 
         if iterator is None and path is None:
-            return None, 0
+            return None
         if path is not None:
             iterator = cls.make_iterator_from_file(path)
 
-        examples_nfeats_iter = cls.make_examples(iterator, truncate, side)
-        (_, num_feats), examples_nfeats_iter = cls._peek(examples_nfeats_iter)
-        examples_iter = (ex for ex, nfeats in examples_nfeats_iter)
+        examples_iter = cls.make_examples(iterator, truncate, side)
 
-        return examples_iter, num_feats
+        return examples_iter
 
     @classmethod
     def make_examples(cls, text_iter, truncate, side):
@@ -147,14 +145,14 @@ class TextDataset(DatasetBase):
             if truncate:
                 line = line[:truncate]
 
-            words, feats, n_feats = extract_text_features(line)
+            words, feats, _ = extract_text_features(line)
 
             example_dict = {side: words, "indices": i}
             if feats:
                 prefix = side + "_feat_"
                 example_dict.update((prefix + str(j), f)
                                     for j, f in enumerate(feats))
-            yield example_dict, n_feats
+            yield example_dict
 
     @classmethod
     def make_iterator_from_file(cls, path):

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -145,7 +145,8 @@ class TextDataset(DatasetBase):
         return scores
 
     @classmethod
-    def make_examples_nfeats_tpl(cls, text_iter, text_path, truncate, side):
+    def make_examples_nfeats_tpl(cls, iterator, path,
+                                 truncate, side, **kwargs):
         """
         Args:
             text_iter(iterator): an iterator (or None) that we can loop over
@@ -161,13 +162,12 @@ class TextDataset(DatasetBase):
         """
         assert side in ['src', 'tgt']
 
-        if text_iter is None:
-            if text_path is not None:
-                text_iter = cls.make_iterator_from_file(text_path)
-            else:
-                return None, 0
+        if iterator is None and path is None:
+            return None, 0
+        if path is not None:
+            iterator = cls.make_iterator_from_file(path)
 
-        examples_nfeats_iter = cls.make_examples(text_iter, truncate, side)
+        examples_nfeats_iter = cls.make_examples(iterator, truncate, side)
         _, num_feats = cls._peek(examples_nfeats_iter)
         examples_iter = (ex for ex, nfeats in examples_nfeats_iter)
 
@@ -184,6 +184,9 @@ class TextDataset(DatasetBase):
         Yields:
             (word, features, nfeat) triples for each line.
         """
+        # doesn't make examples.
+        # this and the analogous methods in the other datasets are
+        # used only in the make_examples_nfeats_tpl methods
         for i, line in enumerate(text_iter):
             line = line.strip().split()
             if truncate:

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -99,33 +99,7 @@ class TextDataset(DatasetBase):
         return scores
 
     @classmethod
-    def make_examples(cls, iterator, path, truncate, side, **kwargs):
-        """
-        Args:
-            text_iter(iterator): an iterator (or None) that we can loop over
-                to read examples.
-                It may be an openned file, a string list etc...
-            text_path(str): path to file or None
-            path (str): location of a src or tgt file.
-            truncate (int): maximum sequence length (0 for unlimited).
-            side (str): "src" or "tgt".
-
-        Returns:
-            (example_dict iterator, num_feats) tuple.
-        """
-        assert side in ['src', 'tgt']
-
-        if iterator is None and path is None:
-            return None
-        if path is not None:
-            iterator = cls.make_iterator_from_file(path)
-
-        examples_iter = cls._make_examples(iterator, truncate, side)
-
-        return examples_iter
-
-    @classmethod
-    def _make_examples(cls, text_iter, truncate, side):
+    def _make_examples(cls, iterator, truncate, side, **kwargs):
         """
         Args:
             text_iter (iterator): iterator of text sequences
@@ -136,10 +110,8 @@ class TextDataset(DatasetBase):
             dict, int pairs where the dict is example stuff and the int is
             the number of features
         """
-        # doesn't make examples.
-        # this and the analogous methods in the other datasets are
-        # used only in the make_examples_nfeats_tpl methods
-        for i, line in enumerate(text_iter):
+        assert side in ['src', 'tgt']
+        for i, line in enumerate(iterator):
             line = line.strip().split()
             if truncate:
                 line = line[:truncate]
@@ -154,7 +126,7 @@ class TextDataset(DatasetBase):
             yield example_dict
 
     @classmethod
-    def make_iterator_from_file(cls, path):
+    def _make_iterator_from_file(cls, path, **kwargs):
         with codecs.open(path, "r", "utf-8") as corpus_file:
             for line in corpus_file:
                 yield line

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -99,31 +99,19 @@ class TextDataset(DatasetBase):
         return scores
 
     @classmethod
-    def _make_examples(cls, iterator, truncate, side, **kwargs):
-        """
-        Args:
-            text_iter (iterator): iterator of text sequences
-            truncate (int): maximum sequence length (0 for unlimited).
-            side (str): "src" or "tgt".
+    def _make_example(cls, line, truncate, side, **kwargs):
+        line = line.strip().split()
+        if truncate:
+            line = line[:truncate]
 
-        Yields:
-            dict, int pairs where the dict is example stuff and the int is
-            the number of features
-        """
-        assert side in ['src', 'tgt']
-        for i, line in enumerate(iterator):
-            line = line.strip().split()
-            if truncate:
-                line = line[:truncate]
+        words, feats, _ = extract_text_features(line)
 
-            words, feats, _ = extract_text_features(line)
-
-            example_dict = {side: words, "indices": i}
-            if feats:
-                prefix = side + "_feat_"
-                example_dict.update((prefix + str(j), f)
-                                    for j, f in enumerate(feats))
-            yield example_dict
+        example_dict = {side: words}
+        if feats:
+            prefix = side + "_feat_"
+            example_dict.update((prefix + str(j), f)
+                                for j, f in enumerate(feats))
+        return example_dict
 
     @classmethod
     def _make_iterator_from_file(cls, path, **kwargs):

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -202,7 +202,7 @@ class TextDataset(DatasetBase):
             yield example_dict, n_feats
 
     @classmethod
-    def make_iterator_from_file(path):
+    def make_iterator_from_file(cls, path):
         with codecs.open(path, "r", "utf-8") as corpus_file:
             for line in corpus_file:
                 yield line

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -213,7 +213,7 @@ def build_base_model(model_opt, src_dict, src_feat_dicts,
         else:
             gen_func = nn.LogSoftmax(dim=-1)
         generator = nn.Sequential(
-            nn.Linear(model_opt.rnn_size, len(fields["tgt"].vocab)), gen_func
+            nn.Linear(model_opt.rnn_size, len(tgt_dict)), gen_func
         )
         if model_opt.share_decoder_embeddings:
             generator[0].weight = decoder.embeddings.word_lut.weight

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -129,7 +129,7 @@ def load_test_model(opt, dummy_opt):
     checkpoint = torch.load(opt.model,
                             map_location=lambda storage, loc: storage)
 
-    fields = inputters.load_fields_from_vocab(
+    fields = inputters.vocab_to_fields(
         checkpoint['vocab'], data_type=opt.data_type)
     if opt.data_type == 'text':
         # is model_opt.model_type the same as data_type?

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -128,24 +128,36 @@ def load_test_model(opt, dummy_opt):
     """ Load model for Inference """
     checkpoint = torch.load(opt.model,
                             map_location=lambda storage, loc: storage)
+
     fields = inputters.load_fields_from_vocab(
         checkpoint['vocab'], data_type=opt.data_type)
+    if opt.data_type == 'text':
+        # is model_opt.model_type the same as data_type?
+        src_dict = fields["src"].vocab
+        src_feat_vocabs = inputters.collect_feature_vocabs(fields, 'src')
+    else:
+        src_dict = None
+        src_feat_vocabs = []
+    tgt_dict = fields["tgt"].vocab
+    tgt_feat_vocabs = inputters.collect_feature_vocabs(fields, 'tgt')
 
     model_opt = checkpoint['opt']
     for arg in dummy_opt:
         if arg not in model_opt:
             model_opt.__dict__[arg] = dummy_opt[arg]
-    model = build_base_model(model_opt, fields, use_gpu(opt), checkpoint)
+    model = build_base_model(model_opt, src_dict, src_feat_vocabs, tgt_dict,
+                             tgt_feat_vocabs, use_gpu(opt), checkpoint)
     model.eval()
     model.generator.eval()
     return fields, model, model_opt
 
 
-def build_base_model(model_opt, fields, gpu, checkpoint=None):
+def build_base_model(model_opt, src_dict, src_feat_dicts,
+                     tgt_dict, tgt_feat_dicts, gpu, checkpoint=None):
     """
     Args:
         model_opt: the option loaded from checkpoint.
-        fields: `Field` objects for the model.
+        *_dict and *_feat_dicts: torchtext.data.Vocab objects
         gpu(bool): whether to use gpu.
         checkpoint: the model gnerated by train phase, or a resumed snapshot
                     model from a stopped training.
@@ -153,13 +165,11 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None):
         the NMTModel.
     """
     assert model_opt.model_type in ["text", "img", "audio"], \
-        ("Unsupported model type %s" % (model_opt.model_type))
+        "Unsupported model type %s" % model_opt.model_type
 
     # Build encoder.
     if model_opt.model_type == "text":
-        src_dict = fields["src"].vocab
-        feature_dicts = inputters.collect_feature_vocabs(fields, 'src')
-        src_embeddings = build_embeddings(model_opt, src_dict, feature_dicts)
+        src_embeddings = build_embeddings(model_opt, src_dict, src_feat_dicts)
         encoder = build_encoder(model_opt, src_embeddings)
     elif model_opt.model_type == "img":
         encoder = ImageEncoder(model_opt.enc_layers,
@@ -175,10 +185,8 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None):
                                model_opt.window_size)
 
     # Build decoder.
-    tgt_dict = fields["tgt"].vocab
-    feature_dicts = inputters.collect_feature_vocabs(fields, 'tgt')
     tgt_embeddings = build_embeddings(model_opt, tgt_dict,
-                                      feature_dicts, for_encoder=False)
+                                      tgt_feat_dicts, for_encoder=False)
 
     # Share the embedding matrix - preprocess with share_vocab required.
     if model_opt.share_embeddings:
@@ -199,13 +207,12 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None):
     # Build Generator.
     if not model_opt.copy_attn:
         generator = nn.Sequential(
-            nn.Linear(model_opt.rnn_size, len(fields["tgt"].vocab)),
+            nn.Linear(model_opt.rnn_size, len(tgt_dict)),
             nn.LogSoftmax(dim=-1))
         if model_opt.share_decoder_embeddings:
             generator[0].weight = decoder.embeddings.word_lut.weight
     else:
-        generator = CopyGenerator(model_opt.rnn_size,
-                                  fields["tgt"].vocab)
+        generator = CopyGenerator(model_opt.rnn_size, tgt_dict)
 
     # Load the model states from checkpoint or initialize them.
     if checkpoint is not None:
@@ -232,17 +239,17 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None):
             model.decoder.embeddings.load_pretrained_vectors(
                 model_opt.pre_word_vecs_dec, model_opt.fix_word_vecs_dec)
 
-    # Add generator to model (this registers it as parameter of model).
+    # this registers the generator as a parameter of the model
     model.generator = generator
     model.to(device)
 
     return model
 
 
-def build_model(model_opt, opt, fields, checkpoint):
-    """ Build the Model """
+def build_model(model_opt, opt, src_dict, src_feat_dicts,
+                tgt_dict, tgt_feat_dicts, checkpoint):
     logger.info('Building model...')
-    model = build_base_model(model_opt, fields,
-                             use_gpu(opt), checkpoint)
+    model = build_base_model(model_opt, src_dict, src_feat_dicts, tgt_dict,
+                             tgt_feat_dicts, use_gpu(opt), checkpoint)
     logger.info(model)
     return model

--- a/onmt/models/model_saver.py
+++ b/onmt/models/model_saver.py
@@ -109,7 +109,7 @@ class ModelSaver(ModelSaverBase):
         checkpoint = {
             'model': model_state_dict,
             'generator': generator_state_dict,
-            'vocab': onmt.inputters.save_fields_to_vocab(self.fields),
+            'vocab': onmt.inputters.fields_to_vocab(self.fields),
             'opt': self.model_opt,
             'optim': self.optim,
         }

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -157,12 +157,12 @@ def preprocess_opts(parser):
     group.add_argument('-save_data', required=True,
                        help="Output file for the prepared data")
 
-    group.add_argument('-max_shard_size', type=int, default=0,
-                       help="""For text corpus of large volume, it will
-                       be divided into shards of this size to preprocess.
-                       If 0, the data will be handled as a whole. The unit
-                       is in bytes. Optimal value should be multiples of
-                       64 bytes. A commonly used sharding value is 131072000.
+    group.add_argument('-max_shard_size', type=int, default=-1,
+                       help="""Data is preprocessed in pieces of approximately
+                       this many bytes in order to reduce memory usage. If
+                       unspecified, the data is preprocessed all at once.
+                       Optimal values should be multiples of 64 bytes.
+                       A commonly used sharding value is 131072000.
                        It is recommended to ensure the corpus is shuffled
                        before sharding.""")
 

--- a/onmt/tests/test_preprocess.py
+++ b/onmt/tests/test_preprocess.py
@@ -50,11 +50,13 @@ class TestData(unittest.TestCase):
             with codecs.open(opt.tgt_vocab, 'w', 'utf-8') as f:
                 f.write('a\nb\nc\nd\ne\nf\n')
 
-        train_data_files = preprocess.build_save_dataset('train', fields, opt)
+        train_datasets = preprocess.build_datasets('train', fields, opt)
+        preprocess.save_datasets(train_datasets, 'train', opt.save_data)
 
-        preprocess.build_save_vocab(train_data_files, fields, opt)
+        preprocess.build_vocab(train_datasets, fields, opt)
 
-        preprocess.build_save_dataset('valid', fields, opt)
+        valid_datasets = preprocess.build_datasets('valid', fields, opt)
+        preprocess.save_datasets(valid_datasets, 'valid', opt.save_data)
 
         # Remove the generated *pt files.
         for pt in glob.glob(SAVE_DATA_PREFIX + '*.pt'):

--- a/onmt/tests/test_preprocess.py
+++ b/onmt/tests/test_preprocess.py
@@ -51,9 +51,9 @@ class TestData(unittest.TestCase):
                 f.write('a\nb\nc\nd\ne\nf\n')
 
         train_datasets = preprocess.build_datasets('train', fields, opt)
-        preprocess.save_datasets(train_datasets, 'train', opt.save_data)
-
         preprocess.build_vocab(train_datasets, fields, opt)
+
+        preprocess.save_datasets(train_datasets, 'train', opt.save_data)
 
         valid_datasets = preprocess.build_datasets('valid', fields, opt)
         preprocess.save_datasets(valid_datasets, 'valid', opt.save_data)

--- a/onmt/tests/test_preprocess.py
+++ b/onmt/tests/test_preprocess.py
@@ -51,7 +51,7 @@ class TestData(unittest.TestCase):
                 f.write('a\nb\nc\nd\ne\nf\n')
 
         train_datasets = preprocess.build_datasets('train', fields, opt)
-        preprocess.build_vocab(train_datasets, fields, opt)
+        preprocess.build_vocab(train_datasets, opt)
 
         preprocess.save_datasets(train_datasets, 'train', opt.save_data)
 

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -12,7 +12,7 @@ import torch
 import onmt.opts as opts
 
 from onmt.inputters.inputter import build_dataset_iter, lazily_load_dataset, \
-    load_fields, collect_features
+    load_fields, collect_feature_vocabs
 from onmt.model_builder import build_model
 from onmt.utils.optimizers import build_optim
 from onmt.trainer import build_trainer
@@ -87,22 +87,29 @@ def main(opt):
     first_dataset = next(lazily_load_dataset("train", opt.data))
     data_type = first_dataset.data_type
 
-    # Load fields generated from preprocess phase.
     fields = load_fields(first_dataset, data_type, opt, checkpoint)
 
-    # Report src/tgt features.
+    if model_opt.model_type == 'text':
+        # is model_opt.model_type the same as data_type
+        src_dict = fields["src"].vocab
+        src_feat_vocabs = collect_feature_vocabs(fields, 'src')
+    else:
+        src_dict = None
+        src_feat_vocabs = []
 
-    src_features = collect_features(fields, 'src')
-    tgt_features = collect_features(fields, 'tgt')
-    for j, feat in enumerate(src_features):
-        logger.info(' * src feature %d size = %d'
-                    % (j, len(fields[feat].vocab)))
-    for j, feat in enumerate(tgt_features):
-        logger.info(' * tgt feature %d size = %d'
-                    % (j, len(fields[feat].vocab)))
+    tgt_dict = fields["tgt"].vocab
+    tgt_feat_vocabs = collect_feature_vocabs(fields, 'tgt')
+
+    # Report src/tgt features.
+    for j, src_feat_vocab in enumerate(src_feat_vocabs):
+        logger.info(' * src feature %d size = %d' % (j, len(src_feat_vocab)))
+    for j, tgt_feat_vocab in enumerate(tgt_feat_vocabs):
+        logger.info(' * tgt feature %d size = %d' % (j, len(tgt_feat_vocab)))
 
     # Build model.
-    model = build_model(model_opt, opt, fields, checkpoint)
+    # why does building the model also do data loading stuff?
+    model = build_model(model_opt, opt, src_dict, src_feat_vocabs,
+                        tgt_dict, tgt_feat_vocabs, checkpoint)
     n_params, enc, dec = _tally_parameters(model)
     logger.info('encoder: %d' % enc)
     logger.info('decoder: %d' % dec)

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -82,9 +82,9 @@ def main(opt):
         checkpoint = None
         model_opt = opt
 
-    # Peek the fisrt dataset to determine the data_type.
+    # Peek at the first dataset to determine the data_type.
     # (All datasets have the same data_type).
-    first_dataset = next(lazily_load_dataset("train", opt))
+    first_dataset = next(lazily_load_dataset("train", opt.data))
     data_type = first_dataset.data_type
 
     # Load fields generated from preprocess phase.
@@ -118,10 +118,10 @@ def main(opt):
         opt, model, fields, optim, data_type, model_saver=model_saver)
 
     def train_iter_fct(): return build_dataset_iter(
-        lazily_load_dataset("train", opt), fields, opt)
+        lazily_load_dataset("train", opt.data), fields, opt)
 
     def valid_iter_fct(): return build_dataset_iter(
-        lazily_load_dataset("valid", opt), fields, opt)
+        lazily_load_dataset("valid", opt.data), fields, opt)
 
     # Do training.
     trainer.train(train_iter_fct, valid_iter_fct, opt.train_steps,

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -12,7 +12,7 @@ import torch
 import onmt.opts as opts
 
 from onmt.inputters.inputter import build_dataset_iter, lazily_load_dataset, \
-    load_fields, collect_feature_vocabs
+    collect_feature_vocabs
 from onmt.model_builder import build_model
 from onmt.utils.optimizers import build_optim
 from onmt.trainer import build_trainer
@@ -86,8 +86,13 @@ def main(opt):
     # (All datasets have the same data_type).
     first_dataset = next(lazily_load_dataset("train", opt.data))
     data_type = first_dataset.data_type
-
-    fields = load_fields(first_dataset, data_type, opt, checkpoint)
+    fields = first_dataset.fields
+    if data_type == 'text':
+        logger.info(' * vocabulary size. source = %d; target = %d' %
+                    (len(fields['src'].vocab), len(fields['tgt'].vocab)))
+    else:
+        logger.info(' * vocabulary size. target = %d' %
+                    len(fields['tgt'].vocab))
 
     if model_opt.model_type == 'text':
         # is model_opt.model_type the same as data_type?

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -90,7 +90,7 @@ def main(opt):
     fields = load_fields(first_dataset, data_type, opt, checkpoint)
 
     if model_opt.model_type == 'text':
-        # is model_opt.model_type the same as data_type
+        # is model_opt.model_type the same as data_type?
         src_dict = fields["src"].vocab
         src_feat_vocabs = collect_feature_vocabs(fields, 'src')
     else:

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -12,7 +12,7 @@ import torch
 import onmt.opts as opts
 
 from onmt.inputters.inputter import build_dataset_iter, lazily_load_dataset, \
-    _load_fields, _collect_report_features
+    load_fields, collect_report_features
 from onmt.model_builder import build_model
 from onmt.utils.optimizers import build_optim
 from onmt.trainer import build_trainer
@@ -88,11 +88,11 @@ def main(opt):
     data_type = first_dataset.data_type
 
     # Load fields generated from preprocess phase.
-    fields = _load_fields(first_dataset, data_type, opt, checkpoint)
+    fields = load_fields(first_dataset, data_type, opt, checkpoint)
 
     # Report src/tgt features.
 
-    src_features, tgt_features = _collect_report_features(fields)
+    src_features, tgt_features = collect_report_features(fields)
     for j, feat in enumerate(src_features):
         logger.info(' * src feature %d size = %d'
                     % (j, len(fields[feat].vocab)))

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -131,10 +131,10 @@ def main(opt):
         opt, model, fields, optim, data_type, model_saver=model_saver)
 
     def train_iter_fct(): return build_dataset_iter(
-        lazily_load_dataset("train", opt.data), fields, opt)
+        lazily_load_dataset("train", opt.data), opt)
 
     def valid_iter_fct(): return build_dataset_iter(
-        lazily_load_dataset("valid", opt.data), fields, opt)
+        lazily_load_dataset("valid", opt.data), opt)
 
     # Do training.
     trainer.train(train_iter_fct, valid_iter_fct, opt.train_steps,

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -12,7 +12,7 @@ import torch
 import onmt.opts as opts
 
 from onmt.inputters.inputter import build_dataset_iter, lazily_load_dataset, \
-    load_fields, collect_report_features
+    load_fields, collect_features
 from onmt.model_builder import build_model
 from onmt.utils.optimizers import build_optim
 from onmt.trainer import build_trainer
@@ -92,7 +92,8 @@ def main(opt):
 
     # Report src/tgt features.
 
-    src_features, tgt_features = collect_report_features(fields)
+    src_features = collect_features(fields, 'src')
+    tgt_features = collect_features(fields, 'tgt')
     for j, feat in enumerate(src_features):
         logger.info(' * src feature %d size = %d'
                     % (j, len(fields[feat].vocab)))

--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -22,16 +22,14 @@ class TranslationBuilder(object):
        has_tgt (bool): will the batch have gold targets
     """
 
-    def __init__(self, data, fields, n_best=1, replace_unk=False,
-                 has_tgt=False):
+    def __init__(self, data, n_best=1, replace_unk=False, has_tgt=False):
         self.data = data
-        self.fields = fields
         self.n_best = n_best
         self.replace_unk = replace_unk
         self.has_tgt = has_tgt
 
     def _build_target_tokens(self, src, src_vocab, src_raw, pred, attn):
-        vocab = self.fields["tgt"].vocab
+        vocab = self.data.fields["tgt"].vocab
         tokens = []
         for tok in pred:
             if tok < len(vocab):

--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -41,7 +41,7 @@ class TranslationBuilder(object):
                 break
         if self.replace_unk and (attn is not None) and (src is not None):
             for i in range(len(tokens)):
-                if tokens[i] == vocab.itos[inputters.UNK]:
+                if tokens[i] == inputters.UNK_WORD:
                     _, max_index = attn[i].max(0)
                     tokens[i] = src_raw[max_index[0]]
         return tokens

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -175,7 +175,6 @@ class Translator(object):
 
         if batch_size is None:
             raise ValueError("batch_size must be set")
-        # this invariably uses dynamic dict, which seems like a clear problem
         data = inputters.build_dataset(self.fields,
                                        self.data_type,
                                        src_path=src_path,
@@ -190,10 +189,7 @@ class Translator(object):
                                        use_filter_pred=self.use_filter_pred,
                                        dynamic_dict=dynamic_dict)
 
-        if self.cuda:
-            cur_device = "cuda"
-        else:
-            cur_device = "cpu"
+        cur_device = "cuda" if self.cuda else "cpu"
 
         data_iter = inputters.OrderedIterator(
             dataset=data, device=cur_device,
@@ -201,8 +197,7 @@ class Translator(object):
             sort_within_batch=True, shuffle=False)
 
         builder = onmt.translate.TranslationBuilder(
-            data, self.fields,
-            self.n_best, self.replace_unk, tgt_path)
+            data, self.n_best, self.replace_unk, tgt_path)
 
         # Statistics
         counter = count(1)

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -174,6 +174,7 @@ class Translator(object):
 
         if batch_size is None:
             raise ValueError("batch_size must be set")
+        # this invariably uses dynamic dict, which seems like a clear problem
         data = inputters.build_dataset(self.fields,
                                        self.data_type,
                                        src_path=src_path,

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -178,7 +178,7 @@ class Translator(object):
             raise ValueError("batch_size must be set")
         data = inputters.build_dataset(
             self.fields, self.data_type,
-            src_path, tgt_path,
+            src_path=src_path, tgt_path=tgt_path,
             src_dir=src_dir,
             sample_rate=self.sample_rate,
             window_size=self.window_size,

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -138,16 +138,14 @@ class Translator(object):
                 "log_probs": []}
 
     def translate(self,
-                  src_path=None,
-                  src_data_iter=None,
+                  src_path,
                   tgt_path=None,
-                  tgt_data_iter=None,
                   src_dir=None,
                   batch_size=None,
                   attn_debug=False,
                   dynamic_dict=False):
         """
-        Translate content of `src_data_iter` (if not None) or `src_path`
+        Translate content of `src_path`
         and get gold scores if one of `tgt_data_iter` or `tgt_path` is set.
 
         Note: batch_size must not be None
@@ -155,10 +153,7 @@ class Translator(object):
 
         Args:
             src_path (str): filepath of source data
-            src_data_iter (iterator): an interator generating source data
-                e.g. it may be a list or an openned file
             tgt_path (str): filepath of target data
-            tgt_data_iter (iterator): an interator generating target data
             src_dir (str): source directory path
                 (used for Audio and Image datasets)
             batch_size (int): size of examples per mini-batch
@@ -171,23 +166,20 @@ class Translator(object):
             * all_predictions is a list of `batch_size` lists
                 of `n_best` predictions
         """
-        assert src_data_iter is not None or src_path is not None
+        assert src_path is not None
 
         if batch_size is None:
             raise ValueError("batch_size must be set")
-        data = inputters.build_dataset(self.fields,
-                                       self.data_type,
-                                       src_path=src_path,
-                                       src_data_iter=src_data_iter,
-                                       tgt_path=tgt_path,
-                                       tgt_data_iter=tgt_data_iter,
-                                       src_dir=src_dir,
-                                       sample_rate=self.sample_rate,
-                                       window_size=self.window_size,
-                                       window_stride=self.window_stride,
-                                       window=self.window,
-                                       use_filter_pred=self.use_filter_pred,
-                                       dynamic_dict=dynamic_dict)
+        data = inputters.build_dataset(
+            self.fields, self.data_type,
+            src_path, tgt_path,
+            src_dir=src_dir,
+            sample_rate=self.sample_rate,
+            window_size=self.window_size,
+            window_stride=self.window_stride,
+            window=self.window,
+            use_filter_pred=self.use_filter_pred,
+            dynamic_dict=dynamic_dict)
 
         cur_device = "cuda" if self.cuda else "cpu"
 

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -144,7 +144,8 @@ class Translator(object):
                   tgt_data_iter=None,
                   src_dir=None,
                   batch_size=None,
-                  attn_debug=False):
+                  attn_debug=False,
+                  dynamic_dict=False):
         """
         Translate content of `src_data_iter` (if not None) or `src_path`
         and get gold scores if one of `tgt_data_iter` or `tgt_path` is set.
@@ -186,7 +187,8 @@ class Translator(object):
                                        window_size=self.window_size,
                                        window_stride=self.window_stride,
                                        window=self.window,
-                                       use_filter_pred=self.use_filter_pred)
+                                       use_filter_pred=self.use_filter_pred,
+                                       dynamic_dict=dynamic_dict)
 
         if self.cuda:
             cur_device = "cuda"

--- a/preprocess.py
+++ b/preprocess.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-    Pre-process Data / features files and build vocabulary
+Pre-process Data / features files and build vocabulary
 """
 
 import argparse
@@ -19,13 +19,10 @@ import onmt.opts as opts
 
 def check_existing_pt_files(opt):
     """ Checking if there are existing .pt files to avoid tampering """
-    # We will use glob.glob() to find sharded {train|valid}.[0-9]*.pt
-    # when training, so check to avoid tampering with existing pt files
-    # or mixing them up.
     for t in ['train', 'valid', 'vocab']:
         pattern = opt.save_data + '.' + t + '*.pt'
         if glob.glob(pattern):
-            sys.stderr.write("Please backup existing pt file: %s, "
+            sys.stderr.write("Please back up existing pt file: %s, "
                              "to avoid tampering!\n" % pattern)
             sys.exit(1)
 
@@ -47,35 +44,22 @@ def parse_args():
     return opt
 
 
-def build_save_in_shards(src_corpus, tgt_corpus, fields,
-                         corpus_type, opt):
+def build_sharded_datasets(src_corpus, tgt_corpus, fields, corpus_type, opt):
     """
-    Divide the big corpus into shards, and build dataset separately.
-    This is currently only for data_type=='text'.
+    Supported only if data_type == 'text'
+    A large corpus is represented as a sequence of `shard` datasets: the
+    corpus is read in small pieces of a size that is a multiple of 64 bytes
+    >= `max_shard_size`. This can reduce the memory footprint by ~50%.
 
-    The reason we do this is to avoid taking up too much memory due
-    to sucking in a huge corpus file.
-
-    To tackle this, we only read in part of the corpus file of size
-    `max_shard_size`(actually it is multiples of 64 bytes that equals
-    or is slightly larger than this size), and process it into dataset,
-    then write it to disk along the way. By doing this, we only focus on
-    part of the corpus at any moment, thus effectively reducing memory use.
-    According to test, this method can reduce memory footprint by ~50%.
-
-    Note! As we process along the shards, previous shards might still
+    Note! Previous shards may still remain in memory until they
     stay in memory, but since we are done with them, and no more
     reference to them, if there is memory tight situation, the OS could
     easily reclaim these memory.
-
-    If `max_shard_size` is 0 or is larger than the corpus size, it is
-    effectively preprocessed into one dataset, i.e. no sharding.
-
-    NOTE! `max_shard_size` is measuring the input corpus size, not the
-    output pt file size. So a shard pt file consists of examples of size
-    2 * `max_shard_size`(source + target).
+    If `max_shard_size` is 0 or larger than the corpus size, no sharding is
+    performed.
+    NOTE! Because a dataset contains both source and target, a sharded output
+    file is of size 2 * `max_shard_size` bytes.
     """
-
     corpus_size = os.path.getsize(src_corpus)
     if corpus_size > 10 * (1024 ** 2) and opt.max_shard_size == 0:
         logger.info("Warning. The corpus %s is larger than 10M bytes, "
@@ -84,10 +68,8 @@ def build_save_in_shards(src_corpus, tgt_corpus, fields,
 
     if opt.max_shard_size != 0:
         logger.info(' * divide corpus into shards and build dataset '
-                    'separately (shard_size = %d bytes).'
-                    % opt.max_shard_size)
+                    'separately (shard_size = %d bytes).' % opt.max_shard_size)
 
-    ret_list = []
     src_iter = inputters.ShardedTextCorpusIterator(
         src_corpus, opt.src_seq_length_trunc,
         "src", opt.max_shard_size)
@@ -96,32 +78,20 @@ def build_save_in_shards(src_corpus, tgt_corpus, fields,
         "tgt", opt.max_shard_size,
         assoc_iter=src_iter)
 
-    index = 0
+    ret_list = []
     while not src_iter.hit_end():
-        index += 1
         dataset = inputters.TextDataset(
             fields, src_iter, tgt_iter,
             src_iter.num_feats, tgt_iter.num_feats,
             src_seq_length=opt.src_seq_length,
             tgt_seq_length=opt.tgt_seq_length,
             dynamic_dict=opt.dynamic_dict)
-
-        # We save fields in vocab.pt separately, so make it empty.
-        dataset.fields = []
-
-        pt_file = "{:s}.{:s}.{:d}.pt".format(
-            opt.save_data, corpus_type, index)
-        logger.info(" * saving %s data shard to %s."
-                    % (corpus_type, pt_file))
-        torch.save(dataset, pt_file)
-
-        ret_list.append(pt_file)
+        ret_list.append(dataset)
 
     return ret_list
 
 
-def build_save_dataset(corpus_type, fields, opt):
-    """ Building and saving the dataset """
+def build_datasets(corpus_type, fields, opt):
     assert corpus_type in ['train', 'valid']
 
     if corpus_type == 'train':
@@ -131,16 +101,15 @@ def build_save_dataset(corpus_type, fields, opt):
         src_corpus = opt.valid_src
         tgt_corpus = opt.valid_tgt
 
-    # Currently we only do preprocess sharding for corpus: data_type=='text'.
+    # Currently preprocess sharding is only supported for data_type=='text'
     if opt.data_type == 'text':
-        return build_save_in_shards(
+        return build_sharded_datasets(
             src_corpus, tgt_corpus, fields,
             corpus_type, opt)
 
-    # For data_type == 'img' or 'audio', currently we don't do
-    # preprocess sharding. We only build a monolithic dataset.
-    # But since the interfaces are uniform, it would be not hard
-    # to do this should users need this feature.
+    # For data_type == 'img' or 'audio', preprocess sharding is not supported.
+    # But since the interfaces are uniform, it should not be not hard to
+    # implement this
     dataset = inputters.build_dataset(
         fields, opt.data_type,
         src_path=src_corpus,
@@ -155,38 +124,34 @@ def build_save_dataset(corpus_type, fields, opt):
         window_size=opt.window_size,
         window_stride=opt.window_stride,
         window=opt.window)
-
-    # We save fields in vocab.pt seperately, so make it empty.
-    dataset.fields = []
-
-    pt_file = "{:s}.{:s}.pt".format(opt.save_data, corpus_type)
-    logger.info(" * saving %s dataset to %s." % (corpus_type, pt_file))
-    torch.save(dataset, pt_file)
-
-    return [pt_file]
+    return [dataset]
 
 
-def build_save_vocab(train_dataset, fields, opt):
-    """ Building and saving the vocab """
-    fields = inputters.build_vocab(train_dataset, fields, opt.data_type,
-                                   opt.share_vocab,
-                                   opt.src_vocab,
-                                   opt.src_vocab_size,
-                                   opt.src_words_min_frequency,
-                                   opt.tgt_vocab,
-                                   opt.tgt_vocab_size,
-                                   opt.tgt_words_min_frequency)
+def save_datasets(datasets, corpus_type, save_data):
+    for i, dataset in enumerate(datasets, 1):
+        dataset.fields = []  # fields cannot be saved
 
-    # Can't save fields, so remove/reconstruct at training time.
-    vocab_file = opt.save_data + '.vocab.pt'
-    torch.save(inputters.save_fields_to_vocab(fields), vocab_file)
+        if len(datasets) > 1:
+            pt_file = "{:s}.{:s}.{:d}.pt".format(save_data, corpus_type, i)
+        else:
+            pt_file = "{:s}.{:s}.pt".format(save_data, corpus_type)
+        logger.info(" * saving %s dataset to %s." % (corpus_type, pt_file))
+        torch.save(dataset, pt_file)
+
+
+def build_vocab(train_dataset, fields, opt):
+    fields = inputters.build_fields(
+        train_dataset, fields, opt.data_type, opt.share_vocab,
+        opt.src_vocab, opt.src_vocab_size, opt.src_words_min_frequency,
+        opt.tgt_vocab, opt.tgt_vocab_size, opt.tgt_words_min_frequency)
+    return inputters.fields_to_vocab(fields)
 
 
 def main():
     opt = parse_args()
     init_logger(opt.log_file)
-    logger.info("Extracting features...")
 
+    logger.info("Extracting features...")
     src_nfeats = inputters.get_num_features(
         opt.data_type, opt.train_src, 'src')
     tgt_nfeats = inputters.get_num_features(
@@ -198,13 +163,16 @@ def main():
     fields = inputters.get_fields(opt.data_type, src_nfeats, tgt_nfeats)
 
     logger.info("Building & saving training data...")
-    train_dataset_files = build_save_dataset('train', fields, opt)
+    train_datasets = build_datasets('train', fields, opt)
+    save_datasets(train_datasets, 'train', opt.save_data)
 
     logger.info("Building & saving vocabulary...")
-    build_save_vocab(train_dataset_files, fields, opt)
+    vocab = build_vocab(train_datasets, fields, opt)
+    torch.save(vocab, opt.save_data + '.vocab.pt')
 
     logger.info("Building & saving validation data...")
-    build_save_dataset('valid', fields, opt)
+    valid_datasets = build_datasets('valid', fields, opt)
+    save_datasets(valid_datasets, 'valid', opt.save_data)
 
 
 if __name__ == "__main__":

--- a/preprocess.py
+++ b/preprocess.py
@@ -126,8 +126,6 @@ def build_datasets(corpus_type, fields, opt):
 
 def save_datasets(datasets, corpus_type, save_data):
     for i, dataset in enumerate(datasets, 1):
-        dataset.fields = []  # fields probably CAN be saved, actually!
-
         if len(datasets) > 1:
             pt_file = "{:s}.{:s}.{:d}.pt".format(save_data, corpus_type, i)
         else:

--- a/preprocess.py
+++ b/preprocess.py
@@ -139,9 +139,9 @@ def save_datasets(datasets, corpus_type, save_data):
         torch.save(dataset, pt_file)
 
 
-def build_vocab(train_dataset, fields, opt):
+def build_vocab(train_dataset, opt):
     fields = inputters.build_vocabs(
-        train_dataset, fields, opt.data_type, opt.share_vocab,
+        train_dataset, opt.data_type, opt.share_vocab,
         opt.src_vocab, opt.src_vocab_size, opt.src_words_min_frequency,
         opt.tgt_vocab, opt.tgt_vocab_size, opt.tgt_words_min_frequency)
     return inputters.fields_to_vocab(fields)
@@ -163,8 +163,9 @@ def main():
     fields = inputters.get_fields(opt.data_type, src_nfeats, tgt_nfeats)
 
     logger.info("Building training data and vocabulary...")
+
     train_datasets = build_datasets('train', fields, opt)
-    vocab = build_vocab(train_datasets, fields, opt)
+    vocab = build_vocab(train_datasets, opt)
 
     logger.info("Saving training data and vocabulary...")
     save_datasets(train_datasets, 'train', opt.save_data)

--- a/preprocess.py
+++ b/preprocess.py
@@ -81,7 +81,6 @@ def build_sharded_datasets(src_corpus, tgt_corpus, fields, opt):
     while not src_iter.hit_end():
         dataset = inputters.TextDataset(
             fields, src_iter, tgt_iter,
-            src_iter.num_feats, tgt_iter.num_feats,
             src_seq_length=opt.src_seq_length,
             tgt_seq_length=opt.tgt_seq_length,
             dynamic_dict=opt.dynamic_dict)

--- a/preprocess.py
+++ b/preprocess.py
@@ -79,10 +79,9 @@ def build_sharded_datasets(src_corpus, tgt_corpus, fields, opt):
 
     ret_list = []
     while not src_iter.hit_end():
+        # problem here: can't use filter pred at the moment
         dataset = inputters.TextDataset(
             fields, src_iter, tgt_iter,
-            src_seq_length=opt.src_seq_length,
-            tgt_seq_length=opt.tgt_seq_length,
             dynamic_dict=opt.dynamic_dict)
         ret_list.append(dataset)
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -107,9 +107,7 @@ def build_datasets(corpus_type, fields, opt):
     # But since the interfaces are uniform, it should not be not hard to
     # implement this
     dataset = inputters.build_dataset(
-        fields, opt.data_type,
-        src_path=src_corpus,
-        tgt_path=tgt_corpus,
+        fields, opt.data_type, src_corpus, tgt_corpus,
         src_dir=opt.src_dir,
         src_seq_length=opt.src_seq_length,
         tgt_seq_length=opt.tgt_seq_length,

--- a/preprocess.py
+++ b/preprocess.py
@@ -102,6 +102,7 @@ def build_datasets(corpus_type, fields, opt):
 
     # Currently preprocess sharding is only supported for data_type=='text'
     if opt.data_type == 'text':
+        # TODO: the dataset is built in a different way in this method. Unify.
         return build_sharded_datasets(src_corpus, tgt_corpus, fields, opt)
 
     # For data_type == 'img' or 'audio', preprocess sharding is not supported.

--- a/preprocess.py
+++ b/preprocess.py
@@ -129,7 +129,7 @@ def build_datasets(corpus_type, fields, opt):
 
 def save_datasets(datasets, corpus_type, save_data):
     for i, dataset in enumerate(datasets, 1):
-        dataset.fields = []  # fields cannot be saved
+        dataset.fields = []  # fields probably CAN be saved, actually!
 
         if len(datasets) > 1:
             pt_file = "{:s}.{:s}.{:d}.pt".format(save_data, corpus_type, i)
@@ -140,7 +140,7 @@ def save_datasets(datasets, corpus_type, save_data):
 
 
 def build_vocab(train_dataset, fields, opt):
-    fields = inputters.build_fields(
+    fields = inputters.build_vocabs(
         train_dataset, fields, opt.data_type, opt.share_vocab,
         opt.src_vocab, opt.src_vocab_size, opt.src_words_min_frequency,
         opt.tgt_vocab, opt.tgt_vocab_size, opt.tgt_words_min_frequency)
@@ -162,12 +162,12 @@ def main():
     logger.info("Building `Fields` object...")
     fields = inputters.get_fields(opt.data_type, src_nfeats, tgt_nfeats)
 
-    logger.info("Building & saving training data...")
+    logger.info("Building training data and vocabulary...")
     train_datasets = build_datasets('train', fields, opt)
-    save_datasets(train_datasets, 'train', opt.save_data)
-
-    logger.info("Building & saving vocabulary...")
     vocab = build_vocab(train_datasets, fields, opt)
+
+    logger.info("Saving training data and vocabulary...")
+    save_datasets(train_datasets, 'train', opt.save_data)
     torch.save(vocab, opt.save_data + '.vocab.pt')
 
     logger.info("Building & saving validation data...")

--- a/preprocess.py
+++ b/preprocess.py
@@ -144,10 +144,9 @@ def main():
     init_logger(opt.log_file)
 
     logger.info("Extracting features...")
-    src_nfeats = inputters.get_num_features(
-        opt.data_type, opt.train_src, 'src')
-    tgt_nfeats = inputters.get_num_features(
-        opt.data_type, opt.train_tgt, 'tgt')
+    src_nfeats = inputters.num_features(opt.train_src) \
+        if opt.data_type == 'text' else 0
+    tgt_nfeats = inputters.num_features(opt.train_tgt)
     logger.info(" * number of source features: %d." % src_nfeats)
     logger.info(" * number of target features: %d." % tgt_nfeats)
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -43,7 +43,7 @@ def parse_args():
     return opt
 
 
-def build_sharded_datasets(src_corpus, tgt_corpus, fields, corpus_type, opt):
+def build_sharded_datasets(src_corpus, tgt_corpus, fields, opt):
     """
     Supported only if data_type == 'text'
     A large corpus is represented as a sequence of `shard` datasets: the
@@ -102,9 +102,7 @@ def build_datasets(corpus_type, fields, opt):
 
     # Currently preprocess sharding is only supported for data_type=='text'
     if opt.data_type == 'text':
-        return build_sharded_datasets(
-            src_corpus, tgt_corpus, fields,
-            corpus_type, opt)
+        return build_sharded_datasets(src_corpus, tgt_corpus, fields, opt)
 
     # For data_type == 'img' or 'audio', preprocess sharding is not supported.
     # But since the interfaces are uniform, it should not be not hard to
@@ -159,7 +157,8 @@ def main():
     logger.info(" * number of target features: %d." % tgt_nfeats)
 
     logger.info("Building `Fields` object...")
-    fields = inputters.get_fields(opt.data_type, src_nfeats, tgt_nfeats)
+    fields = inputters.get_fields(
+        opt.data_type, src_nfeats, tgt_nfeats, opt.dynamic_dict)
 
     logger.info("Building training data and vocabulary...")
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -28,7 +28,6 @@ def check_existing_pt_files(opt):
 
 
 def parse_args():
-    """ Parsing arguments """
     parser = argparse.ArgumentParser(
         description='preprocess.py',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
@@ -61,9 +60,9 @@ def build_sharded_datasets(src_corpus, tgt_corpus, fields, corpus_type, opt):
     file is of size 2 * `max_shard_size` bytes.
     """
     corpus_size = os.path.getsize(src_corpus)
-    if corpus_size > 10 * (1024 ** 2) and opt.max_shard_size == 0:
+    if corpus_size > 10 * 1024 ** 2 and opt.max_shard_size == 0:
         logger.info("Warning. The corpus %s is larger than 10M bytes, "
-                    "you can set '-max_shard_size' to process it by "
+                    "you can set '-max_shard_size' to process it in "
                     "small shards to use less memory." % src_corpus)
 
     if opt.max_shard_size != 0:

--- a/tools/extract_embeddings.py
+++ b/tools/extract_embeddings.py
@@ -44,7 +44,7 @@ def main():
     src_dict = checkpoint['vocab'][1][1]
     tgt_dict = checkpoint['vocab'][0][1]
 
-    fields = onmt.inputters.load_fields_from_vocab(checkpoint['vocab'])
+    fields = onmt.inputters.vocab_to_fields(checkpoint['vocab'])
 
     model_opt = checkpoint['opt']
     for arg in dummy_opt.__dict__:

--- a/translate.py
+++ b/translate.py
@@ -21,7 +21,8 @@ def main(opt):
                          tgt_path=opt.tgt,
                          src_dir=opt.src_dir,
                          batch_size=opt.batch_size,
-                         attn_debug=opt.attn_debug)
+                         attn_debug=opt.attn_debug,
+                         dynamic_dict=opt.dynamic_dict)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request is the first in a series designed to clarify the preprocessing code so that it is easier to maintain and extend. It does this by changing some misleading function names, changing out-of-date documentation, and changing the structure of preprocess.py so that 

1. Building objects and serializing them are not handled in the same function
2. It is not necessary to reload a serialized dataset immediately after it was created (this was not obvious because it happened under a couple layers of method calls)
