### PR TITLE
handle pyonmttok options in server config

### DIFF
--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -227,12 +227,15 @@ class ServerModel:
         timer.tick("model_loading")
         if self.tokenizer_opt is not None:
             self.logger.info("Loading tokenizer")
-            mandatory = ["type", "model"]
-            for m in mandatory:
-                if m not in self.tokenizer_opt:
-                    raise ValueError("Missing mandatory tokenizer option '%s'"
-                                     % m)
+
+            if "type" not in self.tokenizer_opt:
+                raise ValueError(
+                    "Missing mandatory tokenizer option 'type'")
+
             if self.tokenizer_opt['type'] == 'sentencepiece':
+                if "model" not in self.tokenizer_opt:
+                    raise ValueError(
+                        "Missing mandatory tokenizer option 'model'")
                 import sentencepiece as spm
                 sp = spm.SentencePieceProcessor()
                 model_path = os.path.join(self.model_root,
@@ -240,6 +243,9 @@ class ServerModel:
                 sp.Load(model_path)
                 self.tokenizer = sp
             elif self.tokenizer_opt['type'] == 'pyonmttok':
+                if "params" not in self.tokenizer_opt:
+                    raise ValueError(
+                        "Missing mandatory tokenizer option 'params'")
                 import pyonmttok
                 if self.tokenizer_opt["mode"] is not None:
                     mode = self.tokenizer_opt["mode"]

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -239,17 +239,20 @@ class ServerModel:
                                           self.tokenizer_opt['model'])
                 sp.Load(model_path)
                 self.tokenizer = sp
-            elif self.tokenizer_opt['type'] == 'bpe_onmt_tokenizer':
+            elif self.tokenizer_opt['type'] == 'pyonmttok':
                 import pyonmttok
-                model_path = os.path.join(self.model_root,
-                                          self.tokenizer_opt['model'])
-                tokenizer = pyonmttok.Tokenizer(
-                    "aggressive",
-                    bpe_model_path=model_path,
-                    joiner_annotate=True,
-                    joiner_new=True,
-                    preserve_placeholders=True)
+                if self.tokenizer_opt["mode"] is not None:
+                    mode = self.tokenizer_opt["mode"]
+                else:
+                    mode = None
+                for key, value in self.tokenizer_opt["params"].items():
+                    if key.endswith("path"):
+                        self.tokenizer_opt["params"][key]= os.path.join(
+                            self.model_root, value)
+                tokenizer = pyonmttok.Tokenizer(mode,
+                                                **self.tokenizer_opt["params"])
                 self.tokenizer = tokenizer
+
             else:
                 raise ValueError("Invalid value for tokenizer type")
 
@@ -422,7 +425,7 @@ class ServerModel:
         if self.tokenizer_opt["type"] == "sentencepiece":
             tok = self.tokenizer.EncodeAsPieces(sequence)
             tok = " ".join(tok)
-        elif self.tokenizer_opt["type"] == "bpe_onmt_tokenizer":
+        elif self.tokenizer_opt["type"] == "pyonmttok":
             tok, _ = self.tokenizer.tokenize(sequence)
             tok = " ".join(tok)
         return tok
@@ -446,7 +449,7 @@ class ServerModel:
 
         if self.tokenizer_opt["type"] == "sentencepiece":
             detok = self.tokenizer.DecodePieces(sequence.split())
-        elif self.tokenizer_opt["type"] == "bpe_onmt_tokenizer":
+        elif self.tokenizer_opt["type"] == "pyonmttok":
             detok = self.tokenizer.detokenize(sequence.split())
 
         return detok

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -247,7 +247,7 @@ class ServerModel:
                     mode = None
                 for key, value in self.tokenizer_opt["params"].items():
                     if key.endswith("path"):
-                        self.tokenizer_opt["params"][key]= os.path.join(
+                        self.tokenizer_opt["params"][key] = os.path.join(
                             self.model_root, value)
                 tokenizer = pyonmttok.Tokenizer(mode,
                                                 **self.tokenizer_opt["params"])


### PR DESCRIPTION
This PR aims to allow passing pyonmttok options directly in the models config file (`available_models/conf.json`).
(Thanks @guillaumekln for the advice.)

For now, I kept "model" in mandatory ([#L230](https://github.com/francoishernandez/OpenNMT-py/blob/245ef7c311d42e38a2178306e450d6e1515e8771/onmt/translate/translation_server.py#L230)) because it may be a useful warning, but the model (bpe for instance) is passed in `"params"` for pyonmttok. A solution would be to change the behaviour of the sentencepiece option, or remove it at once and only allow pyonmttok.
Any thoughts, @guillaumekln @vince62s @pltrdy @srush ?

Example:
```
{
    "models_root": "directory_containing_models",
    "models": [{
            "id": 1,
            "name": "my_model",
            "model": "my_model.pt",
            "timeout": 15,
            "load": false,
            "on_timeout": "to_cpu",
            "opt": {
                "gpu": 0
            },
            "tokenizer": {
                "type": "pyonmttok",
		"mode": "aggressive",
                "params": {
			"bpe_model_path": "my_model.bpe",
			"joiner_annotate": true
		}
            }
        },{
            "id": 2,
            "name": "my_model2",
            "model": "my_model2.pt",
            "timeout": 15,
            "load": false,
            "on_timeout": "to_cpu",
            "opt": {
                "gpu": 0
            },
            "tokenizer": {
                "type": "sentencepiece",
		"model": "my_model2.model"
            }
        }
    ]
}
```