### PR TITLE
Updated im2text docs

### DIFF
--- a/docs/source/im2text.md
+++ b/docs/source/im2text.md
@@ -44,7 +44,7 @@ python preprocess.py -data_type img -src_dir data/im2text/images/ -train_src dat
 
 ```
 python train.py -model_type img -data data/im2text/demo -save_model demo-model -gpuid 0 -batch_size 20 \
-				-max_grad_norm 20 -learning_rate 0.1 -word_vec_size 80
+				-max_grad_norm 20 -learning_rate 0.1 -word_vec_size 80 -encoder_type brnn
 ```
 
 3) Translate the images.

--- a/docs/source/im2text.md
+++ b/docs/source/im2text.md
@@ -34,19 +34,24 @@ wget -O data/im2text.tgz http://lstm.seas.harvard.edu/latex/im2text_small.tgz; t
 1) Preprocess the data.
 
 ```
-python preprocess.py -data_type img -src_dir data/im2text/images/ -train_src data/im2text/src-train.txt -train_tgt data/im2text/tgt-train.txt -valid_src data/im2text/src-val.txt -valid_tgt data/im2text/tgt-val.txt -save_data data/im2text/demo
+python preprocess.py -data_type img -src_dir data/im2text/images/ -train_src data/im2text/src-train.txt \
+					 -train_tgt data/im2text/tgt-train.txt -valid_src data/im2text/src-val.txt \
+					 -valid_tgt data/im2text/tgt-val.txt -save_data data/im2text/demo \
+					 -tgt_seq_length 150 -tgt_words_min_frequency 2
 ```
 
 2) Train the model.
 
 ```
-python train.py -model_type img -data data/im2text/demo -save_model demo-model -gpuid 0 -batch_size 20 -max_grad_norm 20 -learning_rate 0.1
+python train.py -model_type img -data data/im2text/demo -save_model demo-model -gpuid 0 -batch_size 20 \
+				-max_grad_norm 20 -learning_rate 0.1 -word_vec_size 80
 ```
 
 3) Translate the images.
 
 ```
-python translate.py -data_type img -model demo-model_acc_x_ppl_x_e13.pt -src_dir data/im2text/images -src data/im2text/src-test.txt -output pred.txt -gpu 0 -verbose
+python translate.py -data_type img -model demo-model_acc_x_ppl_x_e13.pt -src_dir data/im2text/images \
+					-src data/im2text/src-test.txt -output pred.txt -beam_size 5 -gpu 0 -verbose
 ```
 
 The above dataset is sampled from the [im2latex-100k-dataset](http://lstm.seas.harvard.edu/latex/im2text.tgz). We provide a trained model [[link]](http://lstm.seas.harvard.edu/latex/py-model.pt) on this dataset.

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -46,7 +46,7 @@ def model_opts(parser):
                        embedding sizes will be set to N^feat_vec_exponent
                        where N is the number of values the feature takes.""")
 
-    # Encoder-Deocder Options
+    # Encoder-Decoder Options
     group = parser.add_argument_group('Model- Encoder-Decoder')
     group.add_argument('-model_type', default='text',
                        help="""Type of source model to use. Allows

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -82,7 +82,7 @@ def main(opt):
         checkpoint = None
         model_opt = opt
 
-    # Peek the fisrt dataset to determine the data_type.
+    # Peek the first dataset to determine the data_type.
     # (All datasets have the same data_type).
     first_dataset = next(lazily_load_dataset("train", opt))
     data_type = first_dataset.data_type


### PR DESCRIPTION
Hi!
I've updated the markdown file of the im2text example to reflect the changes commented in #672 (-tgt_seq_length  150 and -tgt_words_min_frequency 2) as well as two changes that [your paper](https://arxiv.org/pdf/1609.04938.pdf) points out (-word_vec_size 80 and -beam_size 5) but are not reflected in the web.

Luckily I found the issue early on, but it has been a pity finding out the other two changes after performing all the tests. So let's make sure I'm the last one having that problem

**EDIT:** Also, according to the paper the encoder LSTM has to be bidirectional, which is not by default