### PR TITLE
Do not explicitly raise StopIteration

### DIFF
--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -375,13 +375,13 @@ class ShardedTextCorpusIterator(object):
                     cur_pos = self.corpus.tell()
                     if cur_pos >= self.last_pos + self.shard_size:
                         self.last_pos = cur_pos
-                        raise StopIteration
+                        return
 
                 line = self.corpus.readline()
                 if line == '':
                     self.eof = True
                     self.corpus.close()
-                    raise StopIteration
+                    return
 
                 self.line_index += 1
                 iteration_index += 1


### PR DESCRIPTION
This pull request is a quick fix for #911, which is caused by the fact that explicitly raising `StopIteration` is no longer merely frowned upon, but actually raises an error now. All `raise StopIteration` lines have been converted into bare returns.