### PR TITLE
Remove need for cur_dataset attribute in the loss class (inherent to batch)

### DIFF
--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -440,23 +440,19 @@ class DatasetLazyIter(object):
         assert self.cur_iter is not None
         return len(self.cur_iter)
 
-    def get_cur_dataset(self):
-        """ Return the current dataset settings """
-        return self.cur_dataset
-
     def _next_dataset_iterator(self, dataset_iter):
         try:
-            self.cur_dataset = next(dataset_iter)
+            cur_dataset = next(dataset_iter)
         except StopIteration:
             return None
 
         # We clear `fields` when saving, restore when loading.
-        self.cur_dataset.fields = self.fields
+        cur_dataset.fields = self.fields
 
         # Sort batch by decreasing lengths of sentence required by pytorch.
         # sort=False means "Use dataset's sortkey instead of iterator's".
         return OrderedIterator(
-            dataset=self.cur_dataset, batch_size=self.batch_size,
+            dataset=cur_dataset, batch_size=self.batch_size,
             batch_size_fn=self.batch_size_fn,
             device=self.device, train=self.is_train,
             sort=False, sort_within_batch=True,

--- a/onmt/modules/copy_generator.py
+++ b/onmt/modules/copy_generator.py
@@ -153,10 +153,6 @@ class CopyGeneratorLossCompute(loss.LossComputeBase):
                  eps=1e-20):
         super(CopyGeneratorLossCompute, self).__init__(
             generator, tgt_vocab)
-
-        # We lazily load datasets when there are more than one, so postpone
-        # the setting of cur_dataset.
-        self.cur_dataset = None
         self.force_copy = force_copy
         self.normalize_by_length = normalize_by_length
         self.criterion = CopyGeneratorCriterion(len(tgt_vocab), force_copy,
@@ -194,7 +190,7 @@ class CopyGeneratorLossCompute(loss.LossComputeBase):
         scores_data = scores.data.clone()
         scores_data = inputters.TextDataset.collapse_copy_scores(
             self._unbottle(scores_data, batch.batch_size),
-            batch, self.tgt_vocab, self.cur_dataset.src_vocabs)
+            batch, self.tgt_vocab, batch.dataset.src_vocabs)
         scores_data = self._bottle(scores_data)
 
         # Correct target copy token instead of <unk>

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -145,8 +145,6 @@ class Trainer(object):
                     if self.gpu_verbose_level > 1:
                         logger.info("GpuRank %d: index: %d accum: %d"
                                     % (self.gpu_rank, i, accum))
-                    cur_dataset = train_iter.get_cur_dataset()
-                    self.train_loss.cur_dataset = cur_dataset
 
                     true_batchs.append(batch)
 
@@ -221,9 +219,6 @@ class Trainer(object):
         stats = onmt.utils.Statistics()
 
         for batch in valid_iter:
-            cur_dataset = valid_iter.get_cur_dataset()
-            self.valid_loss.cur_dataset = cur_dataset
-
             src = inputters.make_features(batch, 'src', self.data_type)
             if self.data_type == 'text':
                 _, src_lengths = batch.src


### PR DESCRIPTION
Fix #746 

@srush @JianyuZhan I don't really know why the get_cur_dataset() was needed at one point in time.
All I can say, it is not used in the code except in the training loop, but we can remove it since the batch object embeds the current dataset.

It also fixes the case when we use collapse_copy_scores (because copy_attn) with the accum_count option and sharding. see #746 