### PR TITLE
[FIX] Open files in test_rouge.py

### DIFF
--- a/tools/test_rouge.py
+++ b/tools/test_rouge.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
                         help='reference file')
     args = parser.parse_args()
     if args.c.upper() == "STDIN":
-        args.c = sys.stdin
+        candidates = sys.stdin
     else:
         candidates = open(args.c)
     references = open(args.r)

--- a/tools/test_rouge.py
+++ b/tools/test_rouge.py
@@ -5,6 +5,7 @@ import time
 import pyrouge
 import shutil
 import sys
+import codecs
 
 from onmt.utils.logging import init_logger, logger
 
@@ -67,8 +68,8 @@ if __name__ == "__main__":
     if args.c.upper() == "STDIN":
         candidates = sys.stdin
     else:
-        candidates = open(args.c)
-    references = open(args.r)
+        candidates = codecs.open(args.c, encoding="utf-8")
+    references = codecs.open(args.r, encoding="utf-8")
 
     results_dict = test_rouge(candidates, references)
     logger.info(rouge_results_to_str(results_dict))

--- a/tools/test_rouge.py
+++ b/tools/test_rouge.py
@@ -66,5 +66,9 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.c.upper() == "STDIN":
         args.c = sys.stdin
-    results_dict = test_rouge(args.c, args.r)
+    else:
+        candidates = open(args.c)
+    references = open(args.r)
+
+    results_dict = test_rouge(candidates, references)
     logger.info(rouge_results_to_str(results_dict))


### PR DESCRIPTION
test_rouge function takes iterator as parameter since b8d807.
Thus we need to provide opened files instead of path.

* Fixes: https://github.com/OpenNMT/OpenNMT-py/issues/953 