### PR TITLE
model_root prepended multiple times if model is reloaded

### DIFF
--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -267,12 +267,14 @@ class ServerModel:
                     mode = self.tokenizer_opt["mode"]
                 else:
                     mode = None
+                # load can be called multiple times: modify copy
+                tokenizer_params = dict(self.tokenizer_opt["params"])
                 for key, value in self.tokenizer_opt["params"].items():
                     if key.endswith("path"):
-                        self.tokenizer_opt["params"][key] = os.path.join(
+                        tokenizer_params[key] = os.path.join(
                             self.model_root, value)
                 tokenizer = pyonmttok.Tokenizer(mode,
-                                                **self.tokenizer_opt["params"])
+                                                **tokenizer_params)
                 self.tokenizer = tokenizer
             else:
                 raise ValueError("Invalid value for tokenizer type")


### PR DESCRIPTION
`ServerModel.load()` in translation server mutates `self.tokenizer_opt["params"]` by prepending `self.model_root`. This yields the correct path after the first call to `load`, but on subsequent calls the model root is duplicated. Multiple loading occurs e.g. after a model is unloaded on timeout.

The proposed fix mutates a temporary copy of the parameter dict.