### PR TITLE
Remove valid from vocabulary.

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -228,7 +228,7 @@ def main():
     valid_dataset_files = build_save_dataset('valid', fields, opt)
 
     logger.info("Building & saving vocabulary...")
-    build_save_vocab(train_dataset_files + valid_dataset_files, fields, opt)
+    build_save_vocab(train_dataset_files, fields, opt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
An earlier commit (#957) created the vocabulary from train union valid.
This commit reverts that.