### PR TITLE
Change how existing vocabularies are loaded in preprocessing

### DIFF
--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -308,6 +308,8 @@ def build_vocab(train_dataset_files, fields, data_type, share_vocab,
     src_vocab_size = len(src_vocab)
     logger.info('Loaded source vocab has %d tokens.' % src_vocab_size)
     for i, token in enumerate(src_vocab):
+        # keep the order of tokens specified in the vocab file by
+        # adding them to the counter with decreasing vounting values
         counter['src'][token] = src_vocab_size - i
 
     tgt_vocab = load_vocabulary(tgt_vocab_path, tag="target")

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -309,7 +309,7 @@ def build_vocab(train_dataset_files, fields, data_type, share_vocab,
         logger.info('Loaded source vocab has %d tokens.' % src_vocab_size)
         for i, token in enumerate(src_vocab):
             # keep the order of tokens specified in the vocab file by
-            # adding them to the counter with decreasing vounting values
+            # adding them to the counter with decreasing counting values
             counter['src'][token] = src_vocab_size - i
 
     tgt_vocab = load_vocabulary(tgt_vocab_path, tag="target")

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -304,20 +304,20 @@ def build_vocab(train_dataset_files, fields, data_type, share_vocab,
 
     # Load vocabulary
     src_vocab = load_vocabulary(src_vocab_path, tag="source")
-
-    src_vocab_size = len(src_vocab)
-    logger.info('Loaded source vocab has %d tokens.' % src_vocab_size)
-    for i, token in enumerate(src_vocab):
-        # keep the order of tokens specified in the vocab file by
-        # adding them to the counter with decreasing vounting values
-        counter['src'][token] = src_vocab_size - i
+    if src_vocab is not None:
+        src_vocab_size = len(src_vocab)
+        logger.info('Loaded source vocab has %d tokens.' % src_vocab_size)
+        for i, token in enumerate(src_vocab):
+            # keep the order of tokens specified in the vocab file by
+            # adding them to the counter with decreasing vounting values
+            counter['src'][token] = src_vocab_size - i
 
     tgt_vocab = load_vocabulary(tgt_vocab_path, tag="target")
-
-    tgt_vocab_size = len(tgt_vocab)
-    logger.info('Loaded source vocab has %d tokens.' % tgt_vocab_size)
-    for i, token in enumerate(tgt_vocab):
-        counter['tgt'][token] = tgt_vocab_size - i
+    if tgt_vocab is not None:
+        tgt_vocab_size = len(tgt_vocab)
+        logger.info('Loaded source vocab has %d tokens.' % tgt_vocab_size)
+        for i, token in enumerate(tgt_vocab):
+            counter['tgt'][token] = tgt_vocab_size - i
 
     for index, path in enumerate(train_dataset_files):
         dataset = torch.load(path)

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -304,7 +304,18 @@ def build_vocab(train_dataset_files, fields, data_type, share_vocab,
 
     # Load vocabulary
     src_vocab = load_vocabulary(src_vocab_path, tag="source")
+
+    src_vocab_size = len(src_vocab)
+    logger.info('Loaded source vocab has %d tokens.' % src_vocab_size)
+    for i, token in enumerate(src_vocab):
+        counter['src'][token] = src_vocab_size - i
+
     tgt_vocab = load_vocabulary(tgt_vocab_path, tag="target")
+
+    tgt_vocab_size = len(tgt_vocab)
+    logger.info('Loaded source vocab has %d tokens.' % tgt_vocab_size)
+    for i, token in enumerate(tgt_vocab):
+        counter['tgt'][token] = tgt_vocab_size - i
 
     for index, path in enumerate(train_dataset_files):
         dataset = torch.load(path)
@@ -315,9 +326,9 @@ def build_vocab(train_dataset_files, fields, data_type, share_vocab,
                 if not fields[k].sequential:
                     continue
                 elif k == 'src' and src_vocab:
-                    val = [item for item in val if item in src_vocab]
+                    continue
                 elif k == 'tgt' and tgt_vocab:
-                    val = [item for item in val if item in tgt_vocab]
+                    continue
                 counter[k].update(val)
 
         # Drop the none-using from memory but keep the last
@@ -378,7 +389,7 @@ def load_vocabulary(vocabulary_path, tag=""):
     """
     vocabulary = None
     if vocabulary_path:
-        vocabulary = set([])
+        vocabulary = []
         logger.info("Loading {} vocabulary from {}".format(tag,
                                                            vocabulary_path))
 
@@ -391,7 +402,7 @@ def load_vocabulary(vocabulary_path, tag=""):
                     if len(line.strip()) == 0:
                         continue
                     word = line.strip().split()[0]
-                    vocabulary.add(word)
+                    vocabulary.append(word)
     return vocabulary
 
 

--- a/tools/create_vocabulary.py
+++ b/tools/create_vocabulary.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import argparse
+import sys
+
+
+def read_files_batch(file_list):
+    """Reads the provided files in batches"""
+    batch = []  # Keep batch for each file
+    fd_list = []  # File descriptor list
+
+    exit = False  # Flag used for quitting the program in case of error
+
+    try:
+        for filename in file_list:
+            fd_list.append(open(filename))
+
+        for lines in zip(*fd_list):
+            for i, line in enumerate(lines):
+                line = line.rstrip("\n").split(" ")
+                batch.append(line)
+
+            yield batch
+            batch = []  # Reset batch
+
+    except IOError:
+        print("Error reading file " + filename + ".")
+        exit = True  # Flag to exit the program
+
+    finally:
+        for fd in fd_list:
+            fd.close()
+
+        if exit:  # An error occurred, end execution
+            sys.exit(-1)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-file_type', default='text',
+                        choices=['text', 'field'], required=True,
+                        help="""Options for vocabulary creation.
+                               The default is 'text' where the user passes
+                               a corpus or a list of corpora files for which
+                               they want to create a vocabulary from.
+                               If choosing the option 'field', we assume
+                               the file passed is a torch file created during
+                               the preprocessing stage of an already
+                               preprocessed corpus. The vocabulary file created
+                               will just be the vocabulary inside the field
+                               corresponding to the argument 'side'.""")
+    parser.add_argument("-file", type=str, nargs="+", required=True)
+    parser.add_argument("-out_file", type=str, required=True)
+    parser.add_argument("-side", type=str)
+
+    opt = parser.parse_args()
+
+    vocabulary = {}
+    if opt.file_type == 'text':
+        print("Reading input file...")
+        for batch in read_files_batch(opt.file):
+            for sentence in batch:
+                for w in sentence:
+                    if w in vocabulary:
+                        vocabulary[w] += 1
+                    else:
+                        vocabulary[w] = 1
+
+        print("Writing vocabulary file...")
+        with open(opt.out_file, "w") as f:
+            for w, count in sorted(vocabulary.items(), key=lambda x: x[1],
+                                   reverse=True):
+                f.write("{0}\n".format(w))
+    else:
+        import torch
+        print("Reading input file...")
+        vocabs = torch.load(opt.file[0])
+        word_list = dict(vocabs)[opt.side].itos
+
+        print("Writing vocabulary file...")
+        with open(opt.out_file, "w") as f:
+            for w in word_list:
+                f.write("{0}\n".format(w))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR addresses the issue #945 (and possibly #989?). Instead of ignoring tokens that are not present in the current corpus, it keeps all the tokens referenced in the vocab path and also in the specified order of said file.

A new script is also added to the `tools` directory - `create_vocabulary.py`. This script allows to take a previously preprocessed corpus' `*.vocab.pt` file or a corpus text file (or several) and create a vocabulary file to use in the preprocessing stage.
