### PR TITLE
fix serialization protocol bug

### DIFF
--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -36,7 +36,7 @@ class DatasetBase(torchtext.data.Dataset):
 
     def __reduce_ex__(self, proto):
         "This is a hack. Something is broken with torch pickle."
-        return super(DatasetBase, self).__reduce_ex__()
+        return super(DatasetBase, self).__reduce_ex__(proto)
 
     def load_fields(self, vocab_dict):
         """ Load fields from vocab.pt, and set the `fields` attribute.


### PR DESCRIPTION
__reduce_ex__() requires proto as a parameter. I don't know why it is triggered though.