### PR TITLE
[WIP] Ability to reset optimizer or just its states

### DIFF
--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -135,13 +135,7 @@ def load_test_model(opt, dummy_opt, model_path=None):
         checkpoint['vocab'], data_type=opt.data_type)
 
     model_opt = checkpoint['opt']
-    if model_opt.rnn_size != -1:
-        model_opt.enc_rnn_size = model_opt.rnn_size
-        model_opt.dec_rnn_size = model_opt.rnn_size
-        if model_opt.model_type == 'text' and \
-           model_opt.enc_rnn_size != model_opt.dec_rnn_size:
-                raise AssertionError("""We do not support different encoder and
-                                     decoder rnn sizes for translation now.""")
+
     for arg in dummy_opt:
         if arg not in model_opt:
             model_opt.__dict__[arg] = dummy_opt[arg]
@@ -164,6 +158,15 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None):
     """
     assert model_opt.model_type in ["text", "img", "audio"], \
         ("Unsupported model type %s" % (model_opt.model_type))
+
+    # for backward compatibility
+    if model_opt.rnn_size != -1:
+        model_opt.enc_rnn_size = model_opt.rnn_size
+        model_opt.dec_rnn_size = model_opt.rnn_size
+        if model_opt.model_type == 'text' and \
+           model_opt.enc_rnn_size != model_opt.dec_rnn_size:
+                raise AssertionError("""We do not support different encoder and
+                                     decoder rnn sizes for translation now.""")
 
     # Build encoder.
     if model_opt.model_type == "text":

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -301,6 +301,9 @@ def train_opts(parser):
     group.add_argument('-train_from', default='', type=str,
                        help="""If training from a checkpoint then this is the
                        path to the pretrained model's state_dict.""")
+    group.add_argument('-reset_optim', default='none',
+                       choices=['none', 'all', 'states'],
+                       help="""Optimization resetter when train_from.""")
 
     # Pretrained word vectors
     group.add_argument('-pre_word_vecs_enc',

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -302,7 +302,7 @@ def train_opts(parser):
                        help="""If training from a checkpoint then this is the
                        path to the pretrained model's state_dict.""")
     group.add_argument('-reset_optim', default='none',
-                       choices=['none', 'all', 'states'],
+                       choices=['none', 'all', 'states', 'keep_states'],
                        help="""Optimization resetter when train_from.""")
 
     # Pretrained word vectors

--- a/onmt/utils/optimizers.py
+++ b/onmt/utils/optimizers.py
@@ -10,14 +10,15 @@ def build_optim(model, opt, checkpoint):
     """ Build optimizer """
     saved_optimizer_state_dict = None
 
-    if opt.train_from:
+    if opt.train_from and opt.reset_optim != 'all':
         optim = checkpoint['optim']
         # We need to save a copy of optim.optimizer.state_dict() for setting
         # the, optimizer state later on in Stage 2 in this method, since
         # the method optim.set_parameters(model.parameters()) will overwrite
         # optim.optimizer, and with ith the values stored in
         # optim.optimizer.state_dict()
-        saved_optimizer_state_dict = optim.optimizer.state_dict()
+        if opt.reset_optim == 'none':
+            saved_optimizer_state_dict = optim.optimizer.state_dict()
     else:
         optim = Optimizer(
             opt.optim, opt.learning_rate, opt.max_grad_norm,
@@ -40,7 +41,7 @@ def build_optim(model, opt, checkpoint):
     # parameters from the model.
     optim.set_parameters(model.named_parameters())
 
-    if opt.train_from:
+    if opt.train_from and opt.reset_optim == 'none':
         # Stage 2: In this stage, which is only performed when loading an
         # optimizer from a checkpoint, we load the saved_optimizer_state_dict
         # into the re-created optimizer, to set the optim.optimizer.state

--- a/onmt/utils/optimizers.py
+++ b/onmt/utils/optimizers.py
@@ -20,15 +20,15 @@ def build_optim(model, opt, checkpoint):
         if opt.reset_optim != 'states':
             saved_optimizer_state_dict = optim.optimizer.state_dict()
             if opt.reset_optim == 'keep_states':
-                optim.method = opt.method
+                optim.method = opt.optim
                 optim.learning_rate = opt.learning_rate
                 optim.original_lr = opt.learning_rate
                 optim.max_grad_norm = opt.max_grad_norm
-                optim.lr_decay = opt.lr_decay
+                optim.lr_decay = opt.learning_rate_decay
                 optim.start_decay_steps = opt.start_decay_steps
                 optim.decay_steps = opt.decay_steps
-                optim.betas = [opt.beta1, opt.beta2]
-                optim.adagrad_accum = opt.adagrad_accum
+                optim.betas = [opt.adam_beta1, opt.adam_beta2]
+                optim.adagrad_accum = opt.adagrad_accumulator_init
                 optim.decay_method = opt.decay_method
                 optim.warmup_steps = opt.warmup_steps
                 optim.model_size = opt.rnn_size
@@ -54,7 +54,7 @@ def build_optim(model, opt, checkpoint):
     # parameters from the model.
     optim.set_parameters(model.named_parameters())
 
-    if opt.train_from and (opt.reset_optim in ['none', 'keep_state']):
+    if opt.train_from and (opt.reset_optim in ['none', 'keep_states']):
         # Stage 2: In this stage, which is only performed when loading an
         # optimizer from a checkpoint, we load the saved_optimizer_state_dict
         # into the re-created optimizer, to set the optim.optimizer.state

--- a/onmt/utils/optimizers.py
+++ b/onmt/utils/optimizers.py
@@ -17,8 +17,21 @@ def build_optim(model, opt, checkpoint):
         # the method optim.set_parameters(model.parameters()) will overwrite
         # optim.optimizer, and with ith the values stored in
         # optim.optimizer.state_dict()
-        if opt.reset_optim == 'none':
+        if opt.reset_optim != 'states':
             saved_optimizer_state_dict = optim.optimizer.state_dict()
+            if opt.reset_optim == 'keep_states':
+                optim.method = opt.method
+                optim.learning_rate = opt.learning_rate
+                optim.original_lr = opt.learning_rate
+                optim.max_grad_norm = opt.max_grad_norm
+                optim.lr_decay = opt.lr_decay
+                optim.start_decay_steps = opt.start_decay_steps
+                optim.decay_steps = opt.decay_steps
+                optim.betas = [opt.beta1, opt.beta2]
+                optim.adagrad_accum = opt.adagrad_accum
+                optim.decay_method = opt.decay_method
+                optim.warmup_steps = opt.warmup_steps
+                optim.model_size = opt.rnn_size
     else:
         optim = Optimizer(
             opt.optim, opt.learning_rate, opt.max_grad_norm,
@@ -41,7 +54,7 @@ def build_optim(model, opt, checkpoint):
     # parameters from the model.
     optim.set_parameters(model.named_parameters())
 
-    if opt.train_from and opt.reset_optim == 'none':
+    if opt.train_from and (opt.reset_optim in ['none', 'keep_state']):
         # Stage 2: In this stage, which is only performed when loading an
         # optimizer from a checkpoint, we load the saved_optimizer_state_dict
         # into the re-created optimizer, to set the optim.optimizer.state


### PR DESCRIPTION
#970 #768
Idea is as follow: new option along with train_from: -reset_optim

default: 'none' training will just continue (optim loaded from checkpoint, steps same, states loaded)
'all': reset completely the optimizer. it requires to pass a full set of settings (train_steps from zéro, type of optim, ....)
'states': it will load everything from the checkpoint except Adam states that will be reset.
'keep_states": it will load Adam states from the checkpoint but take into account command line changes (egs: learning_rate)

if someone can test, would be good. @wewark ? guys in #768 ?

