### PR TITLE
Codecs in onmt.inputters.inputter.load_vocabulary() for Python 2

### DIFF
--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -4,6 +4,7 @@
 """
 import glob
 import os
+import codecs
 
 from collections import Counter, defaultdict, OrderedDict
 from itertools import count
@@ -399,7 +400,7 @@ def load_vocabulary(vocabulary_path, tag=""):
             raise RuntimeError(
                 "{} vocabulary not found at {}!".format(tag, vocabulary_path))
         else:
-            with open(vocabulary_path) as f:
+            with codecs.open(vocabulary_path, 'r', 'utf-8') as f:
                 for line in f:
                     if len(line.strip()) == 0:
                         continue


### PR DESCRIPTION
I am using OpenNMT-py for English-Japanese translation with Python 2.

In the load_vocabulary function, the vocabulary file is opened without codecs.  This causes that the vocabulary including non-ascii characters does not match with the words in the text because Python 2
distinguishes raw strings and unicode strings.  (This phenomenon is only caused in Python 2.  In Python 3, two strings match.)

I request to fix this problem by using `codecs.open()` in the function.
