### PR TITLE
adding min frequency parameter in vocab merge

### DIFF
--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -84,7 +84,7 @@ def save_fields_to_vocab(fields):
     return vocab
 
 
-def merge_vocabs(vocabs, vocab_size=None):
+def merge_vocabs(vocabs, vocab_size=None, min_frequency=None):
     """
     Merge individual vocabularies (assumed to be generated from disjoint
     documents) into a larger vocabulary.
@@ -92,6 +92,7 @@ def merge_vocabs(vocabs, vocab_size=None):
     Args:
         vocabs: `torchtext.vocab.Vocab` vocabularies to be merged
         vocab_size: `int` the final vocabulary size. `None` for no limit.
+        min_frequency: `int` minimum frequency for word to be retained.
     Return:
         `torchtext.vocab.Vocab`
     """
@@ -99,7 +100,8 @@ def merge_vocabs(vocabs, vocab_size=None):
     return torchtext.vocab.Vocab(merged,
                                  specials=[UNK_WORD, PAD_WORD,
                                            BOS_WORD, EOS_WORD],
-                                 max_size=vocab_size)
+                                 max_size=vocab_size,
+                                 min_freq=min_frequency)
 
 
 def get_num_features(data_type, corpus_file, side):
@@ -375,7 +377,7 @@ def build_vocab(train_dataset_files, fields, data_type, share_vocab,
             logger.info(" * merging src and tgt vocab...")
             merged_vocab = merge_vocabs(
                 [fields["src"].vocab, fields["tgt"].vocab],
-                vocab_size=src_vocab_size)
+                vocab_size=src_vocab_size, min_frequency=src_words_min_frequency)
             fields["src"].vocab = merged_vocab
             fields["tgt"].vocab = merged_vocab
 

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -84,7 +84,7 @@ def save_fields_to_vocab(fields):
     return vocab
 
 
-def merge_vocabs(vocabs, vocab_size=None, min_frequency=None):
+def merge_vocabs(vocabs, vocab_size=None, min_frequency=1):
     """
     Merge individual vocabularies (assumed to be generated from disjoint
     documents) into a larger vocabulary.


### PR DESCRIPTION
Currently while merging vocab when source and target vocabulary are shared, it only checks if max_vocab_size is consistent. However, if someone is trying to control for min_frequency this information is lost while merging. This pull request tries to fix that.