### PR TITLE
Implement repeat and beam_update via map_batch_fn

### DIFF
--- a/onmt/decoders/cnn_decoder.py
+++ b/onmt/decoders/cnn_decoder.py
@@ -137,13 +137,6 @@ class CNNDecoderState(DecoderState):
         self.init_src = (memory_bank + enc_hidden) * SCALE_WEIGHT
         self.previous_input = None
 
-    @property
-    def _all(self):
-        """
-        Contains attributes that need to be updated in self.beam_update().
-        """
-        return (self.previous_input,)
-
     def detach(self):
         self.previous_input = self.previous_input.detach()
 
@@ -151,6 +144,7 @@ class CNNDecoderState(DecoderState):
         """ Called for every decoder forward pass. """
         self.previous_input = new_input
 
-    def repeat_beam_size_times(self, beam_size):
-        """ Repeat beam_size times along batch dimension. """
-        self.init_src = self.init_src.data.repeat(1, beam_size, 1)
+    def map_batch_fn(self, fn):
+        self.init_src = fn(self.init_src, 1)
+        if self.previous_input is not None:
+            self.previous_input = fn(self.previous_input, 1)

--- a/onmt/decoders/ensemble.py
+++ b/onmt/decoders/ensemble.py
@@ -20,14 +20,9 @@ class EnsembleDecoderState(DecoderState):
     def __init__(self, model_decoder_states):
         self.model_decoder_states = tuple(model_decoder_states)
 
-    def beam_update(self, idx, positions, beam_size):
+    def map_batch_fn(self, fn):
         for model_state in self.model_decoder_states:
-            model_state.beam_update(idx, positions, beam_size)
-
-    def repeat_beam_size_times(self, beam_size):
-        """ Repeat beam_size times along batch dimension. """
-        for model_state in self.model_decoder_states:
-            model_state.repeat_beam_size_times(beam_size)
+            model_state.map_batch_fn(fn)
 
     def __getitem__(self, index):
         return self.model_decoder_states[index]


### PR DESCRIPTION
This cleans up the `DecoderState` by using the generic `map_batch_fn` method.