### PR TITLE
show penalty options in documentation of translation.py

### DIFF
--- a/docs/source/options/translate.md
+++ b/docs/source/options/translate.md
@@ -58,10 +58,10 @@ Deprecated, use `-max_length` instead
 Apply penalty at every decoding step. Helpful for summary penalty.
 
 * **-length_penalty [none]** 
-Length Penalty to use.
+Length Penalty to use. Options are [wu | avg]
 
 * **-coverage_penalty [none]** 
-Coverage Penalty to use.
+Coverage Penalty to use. Options are [wu | summary]
 
 * **-alpha []** 
 Google NMT length penalty parameter (higher = longer generation)

--- a/docs/source/options/translate.md
+++ b/docs/source/options/translate.md
@@ -58,10 +58,10 @@ Deprecated, use `-max_length` instead
 Apply penalty at every decoding step. Helpful for summary penalty.
 
 * **-length_penalty [none]** 
-Length Penalty to use. Options are [wu | avg]
+Length Penalty to use. Options are [wu | avg | none]
 
 * **-coverage_penalty [none]** 
-Coverage Penalty to use. Options are [wu | summary]
+Coverage Penalty to use. Options are [wu | summary | none]
 
 * **-alpha []** 
 Google NMT length penalty parameter (higher = longer generation)


### PR DESCRIPTION
Currently the documentation for [translate.py](http://opennmt.net/OpenNMT-py/options/translate.html) shows no options for -length_penalty and -coverage_penalty, although two variants are implemented for each.
This PR adds these options 
```
-length_penalty [none] Length Penalty to use. Options are [wu | avg]

-coverage_penalty [none] Coverage Penalty to use. Options are [wu | summary]
````