### PR TITLE
Remove DecoderState Class (for future Onnx export)

### DIFF
--- a/onmt/decoders/cnn_decoder.py
+++ b/onmt/decoders/cnn_decoder.py
@@ -6,7 +6,6 @@ import torch
 import torch.nn as nn
 
 import onmt.modules
-from onmt.utils.misc import aeq
 from onmt.utils.cnn_factory import shape_transform, GatedConv
 
 SCALE_WEIGHT = 0.5 ** 0.5
@@ -32,6 +31,9 @@ class CNNDecoder(nn.Module):
         self.embeddings = embeddings
         self.dropout = dropout
 
+        # Decoder State
+        self.state = {}
+
         # Build the CNN.
         input_size = self.embeddings.embedding_size
         self.linear = nn.Linear(input_size, self.hidden_size)
@@ -54,22 +56,20 @@ class CNNDecoder(nn.Module):
                 hidden_size, attn_type=attn_type)
             self._copy = True
 
-    def forward(self, tgt, memory_bank, state, memory_lengths=None, step=None):
+    def update_state(self, new_input):
+        """ Called for every decoder forward pass. """
+        self.state["previous_input"] = new_input
+
+    def forward(self, tgt, attn_context, memory_lengths=None, step=None):
         """ See :obj:`onmt.modules.RNNDecoderBase.forward()`"""
         # NOTE: memory_lengths is only here for compatibility reasons
         #       with onmt.modules.RNNDecoderBase.forward()
-        # CHECKS
-        assert isinstance(state, CNNDecoderState)
-        _, tgt_batch, _ = tgt.size()
-        _, contxt_batch, _ = memory_bank.size()
-        aeq(tgt_batch, contxt_batch)
-        # END CHECKS
 
-        if state.previous_input is not None:
-            tgt = torch.cat([state.previous_input, tgt], 0)
+        if self.state["previous_input"] is not None:
+            tgt = torch.cat([self.state["previous_input"], tgt], 0)
 
         # Initialize return variables.
-        outputs = []
+        dec_outs = []
         attns = {"std": []}
         assert not self._copy, "Copy mechanism not yet tested in conv2conv"
         if self._copy:
@@ -80,9 +80,9 @@ class CNNDecoder(nn.Module):
 
         tgt_emb = emb.transpose(0, 1).contiguous()
         # The output of CNNEncoder.
-        src_memory_bank_t = memory_bank.transpose(0, 1).contiguous()
+        src_attn_context_t = attn_context.transpose(0, 1).contiguous()
         # The combination of output of CNNEncoder and source embeddings.
-        src_memory_bank_c = state.init_src.transpose(0, 1).contiguous()
+        src_attn_context_c = self.state["src"].transpose(0, 1).contiguous()
 
         # Run the forward pass of the CNNDecoder.
         emb_reshape = tgt_emb.contiguous().view(
@@ -101,49 +101,37 @@ class CNNDecoder(nn.Module):
             new_target_input = torch.cat([pad, x], 2)
             out = conv(new_target_input)
             c, attn = attention(base_target_emb, out,
-                                src_memory_bank_t, src_memory_bank_c)
+                                src_attn_context_t, src_attn_context_c)
             x = (x + (c + out) * SCALE_WEIGHT) * SCALE_WEIGHT
         output = x.squeeze(3).transpose(1, 2)
 
         # Process the result and update the attentions.
-        outputs = output.transpose(0, 1).contiguous()
-        if state.previous_input is not None:
-            outputs = outputs[state.previous_input.size(0):]
-            attn = attn[:, state.previous_input.size(0):].squeeze()
+        dec_outs = output.transpose(0, 1).contiguous()
+        if self.state["previous_input"] is not None:
+            dec_outs = dec_outs[self.state["previous_input"].size(0):]
+            attn = attn[:, self.state["previous_input"].size(0):].squeeze()
             attn = torch.stack([attn])
         attns["std"] = attn
         if self._copy:
             attns["copy"] = attn
 
         # Update the state.
-        state.update_state(tgt)
+        self.update_state(tgt)
+        # TODO change the way attns is returned dict => list or tuple (onnx)
+        return dec_outs, attns
 
-        return outputs, state, attns
-
-    def init_decoder_state(self, _, memory_bank, enc_hidden, with_cache=False):
+    def init_decoder_state(self, _, attn_context, enc_hidden,
+                           with_cache=False):
         """
         Init decoder state.
         """
-        return CNNDecoderState(memory_bank, enc_hidden)
-
-
-class CNNDecoderState(object):
-    """
-    Init CNN decoder state.
-    """
-
-    def __init__(self, memory_bank, enc_hidden):
-        self.init_src = (memory_bank + enc_hidden) * SCALE_WEIGHT
-        self.previous_input = None
-
-    def detach(self):
-        self.previous_input = self.previous_input.detach()
-
-    def update_state(self, new_input):
-        """ Called for every decoder forward pass. """
-        self.previous_input = new_input
+        self.state["src"] = (attn_context + enc_hidden) * SCALE_WEIGHT
+        self.state["previous_input"] = None
 
     def map_batch_fn(self, fn):
-        self.init_src = fn(self.init_src, 1)
-        if self.previous_input is not None:
-            self.previous_input = fn(self.previous_input, 1)
+        self.state["src"] = fn(self.state["src"], 1)
+        if self.state["previous_input"] is not None:
+            self.state["previous_input"] = fn(self.state["previous_input"], 1)
+
+    def detach(self):
+        self.state["previous_input"] = self.state["previous_input"].detach()

--- a/onmt/decoders/cnn_decoder.py
+++ b/onmt/decoders/cnn_decoder.py
@@ -6,7 +6,6 @@ import torch
 import torch.nn as nn
 
 import onmt.modules
-from onmt.decoders.decoder import DecoderState
 from onmt.utils.misc import aeq
 from onmt.utils.cnn_factory import shape_transform, GatedConv
 
@@ -128,7 +127,7 @@ class CNNDecoder(nn.Module):
         return CNNDecoderState(memory_bank, enc_hidden)
 
 
-class CNNDecoderState(DecoderState):
+class CNNDecoderState(object):
     """
     Init CNN decoder state.
     """

--- a/onmt/decoders/decoder.py
+++ b/onmt/decoders/decoder.py
@@ -122,6 +122,13 @@ class RNNDecoderBase(nn.Module):
         else:  # GRU
             self.state["hidden"] = (_fix_enc_hidden(encoder_final), )
 
+        # Init the input feed.
+        batch_size = self.state["hidden"][0].size(1)
+        h_size = (batch_size, self.hidden_size)
+        self.state["input_feed"] = \
+            self.state["hidden"][0].data.new(*h_size).zero_().unsqueeze(0)
+        self.state["coverage"] = None
+
     def update_state(self, rnnstate, input_feed, coverage):
         """ Update decoder state """
         if not isinstance(rnnstate, tuple):
@@ -300,16 +307,6 @@ class InputFeedRNNDecoder(RNNDecoderBase):
           E --> H
           G --> H
     """
-    def init_state(self, src, memory_bank, encoder_final, with_cache=False):
-        """ Init decoder state with last state of the encoder """
-        super(InputFeedRNNDecoder, self).init_state(src, memory_bank, encoder_final)
-
-        # Init the input feed.
-        batch_size = self.state["hidden"][0].size(1)
-        h_size = (batch_size, self.hidden_size)
-        self.state["input_feed"] = \
-            self.state["hidden"][0].data.new(*h_size).zero_().unsqueeze(0)
-        self.state["coverage"] = None
 
     def _run_forward_pass(self, tgt, memory_bank, memory_lengths=None):
         """

--- a/onmt/decoders/decoder.py
+++ b/onmt/decoders/decoder.py
@@ -172,7 +172,7 @@ class RNNDecoderBase(nn.Module):
             self.state["hidden"] = tuple([_fix_enc_hidden(enc_hid)
                                           for enc_hid in encoder_final])
         else:  # GRU
-            self.state["hidden"] = tuple(_fix_enc_hidden(encoder_final),)
+            self.state["hidden"] = (encoder_final, )
 
         # Init the input feed.
         batch_size = self.state["hidden"][0].size(1)
@@ -318,7 +318,6 @@ class InputFeedRNNDecoder(RNNDecoderBase):
         input_feed = self.state["input_feed"].squeeze(0)
         input_feed_batch, _ = input_feed.size()
         _, tgt_batch, _ = tgt.size()
-        print(tgt_batch, input_feed.size())
         aeq(tgt_batch, input_feed_batch)
         # END Additional args check.
 

--- a/onmt/decoders/decoder.py
+++ b/onmt/decoders/decoder.py
@@ -302,7 +302,7 @@ class InputFeedRNNDecoder(RNNDecoderBase):
     """
     def init_state(self, src, memory_bank, encoder_final, with_cache=False):
         """ Init decoder state with last state of the encoder """
-        super().init_state(self, src, memory_bank, encoder_final)
+        super(InputFeedRNNDecoder, self).init_state(src, memory_bank, encoder_final)
 
         # Init the input feed.
         batch_size = self.state["hidden"][0].size(1)

--- a/onmt/decoders/decoder.py
+++ b/onmt/decoders/decoder.py
@@ -122,13 +122,6 @@ class RNNDecoderBase(nn.Module):
         else:  # GRU
             self.state["hidden"] = (_fix_enc_hidden(encoder_final), )
 
-        # Init the input feed.
-        batch_size = self.state["hidden"][0].size(1)
-        h_size = (batch_size, self.hidden_size)
-        self.state["input_feed"] = \
-            self.state["hidden"][0].data.new(*h_size).zero_().unsqueeze(0)
-        self.state["coverage"] = None
-
     def update_state(self, rnnstate, input_feed, coverage):
         """ Update decoder state """
         if not isinstance(rnnstate, tuple):
@@ -307,6 +300,16 @@ class InputFeedRNNDecoder(RNNDecoderBase):
           E --> H
           G --> H
     """
+    def init_state(self, src, memory_bank, encoder_final, with_cache=False):
+        """ Init decoder state with last state of the encoder """
+        super().init_state(self, src, memory_bank, encoder_final, with_cache=False)
+
+        # Init the input feed.
+        batch_size = self.state["hidden"][0].size(1)
+        h_size = (batch_size, self.hidden_size)
+        self.state["input_feed"] = \
+            self.state["hidden"][0].data.new(*h_size).zero_().unsqueeze(0)
+        self.state["coverage"] = None
 
     def _run_forward_pass(self, tgt, memory_bank, memory_lengths=None):
         """

--- a/onmt/decoders/decoder.py
+++ b/onmt/decoders/decoder.py
@@ -302,7 +302,7 @@ class InputFeedRNNDecoder(RNNDecoderBase):
     """
     def init_state(self, src, memory_bank, encoder_final, with_cache=False):
         """ Init decoder state with last state of the encoder """
-        super().init_state(self, src, memory_bank, encoder_final, with_cache=False)
+        super().init_state(self, src, memory_bank, encoder_final)
 
         # Init the input feed.
         batch_size = self.state["hidden"][0].size(1)

--- a/onmt/decoders/ensemble.py
+++ b/onmt/decoders/ensemble.py
@@ -9,13 +9,12 @@ All models in the ensemble must share a target vocabulary.
 import torch
 import torch.nn as nn
 
-from onmt.decoders.decoder import DecoderState
 from onmt.encoders.encoder import EncoderBase
 from onmt.models import NMTModel
 import onmt.model_builder
 
 
-class EnsembleDecoderState(DecoderState):
+class EnsembleDecoderState(object):
     """ Dummy DecoderState that wraps a tuple of real DecoderStates """
     def __init__(self, model_decoder_states):
         self.model_decoder_states = tuple(model_decoder_states)

--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -49,12 +49,12 @@ class TransformerDecoderLayer(nn.Module):
         # it gets TransformerDecoderLayer's cuda behavior automatically.
         self.register_buffer('mask', mask)
 
-    def forward(self, inputs, attn_context, src_pad_mask, tgt_pad_mask,
+    def forward(self, inputs, memory_bank, src_pad_mask, tgt_pad_mask,
                 previous_input=None, layer_cache=None, step=None):
         """
         Args:
             inputs (`FloatTensor`): `[batch_size x 1 x model_dim]`
-            attn_context (`FloatTensor`): `[batch_size x src_len x model_dim]`
+            memory_bank (`FloatTensor`): `[batch_size x src_len x model_dim]`
             src_pad_mask (`LongTensor`): `[batch_size x 1 x src_len]`
             tgt_pad_mask (`LongTensor`): `[batch_size x 1 x 1]`
 
@@ -88,7 +88,7 @@ class TransformerDecoderLayer(nn.Module):
         query = self.drop(query) + inputs
 
         query_norm = self.layer_norm_2(query)
-        mid, attn = self.context_attn(attn_context, attn_context, query_norm,
+        mid, attn = self.context_attn(memory_bank, memory_bank, query_norm,
                                       mask=src_pad_mask,
                                       layer_cache=layer_cache,
                                       type="context")
@@ -172,12 +172,50 @@ class TransformerDecoder(nn.Module):
             self._copy = True
         self.layer_norm = onmt.modules.LayerNorm(d_model)
 
+    def init_state(self, src, memory_bank, enc_hidden, with_cache=False):
+        """ Init decoder state """
+        self.state["src"] = src
+        self.state["previous_input"] = None
+        self.state["previous_layer_inputs"] = None
+        self.state["cache"] = None
+
+        if with_cache:
+            self._init_cache(memory_bank, self.num_layers,
+                             self.self_attn_type)
+
     def update_state(self, new_input, previous_layer_inputs):
 
         self.state["previous_input"] = new_input
         self.state["previous_layer_inputs"] = previous_layer_inputs
 
-    def forward(self, tgt, attn_context, memory_lengths=None,
+    def map_state(self, fn):
+        def _recursive_map(struct, batch_dim=0):
+            for k, v in struct.items():
+                if v is not None:
+                    if isinstance(v, dict):
+                        _recursive_map(v)
+                    else:
+                        struct[k] = fn(v, batch_dim)
+
+        self.state["src"] = fn(self.state["src"], 1)
+        if self.state["previous_input"] is not None:
+            self.state["previous_input"] = fn(self.state["previous_input"], 1)
+        if self.state["previous_layer_inputs"] is not None:
+            self.state["previous_layer_inputs"] = \
+                fn(self.state["previous_layer_inputs"], 1)
+        if self.state["cache"] is not None:
+            _recursive_map(self.state["cache"])
+
+    def detach_state(self):
+        if self.state["previous_input"] is not None:
+            self.state["previous_input"] = \
+                self.state["previous_input"].detach()
+        if self.state["previous_layer_inputs"] is not None:
+            self.state["previous_layer_inputs"] = \
+                self.state["previous_layer_inputs"].detach()
+        self.state["src"] = self.state["src"].detach()
+
+    def forward(self, tgt, memory_bank, memory_lengths=None,
                 step=None, cache=None):
         """
         See :obj:`onmt.modules.RNNDecoderBase.forward()`
@@ -199,7 +237,7 @@ class TransformerDecoder(nn.Module):
         assert emb.dim() == 3  # len x batch x embedding_dim
 
         output = emb.transpose(0, 1).contiguous()
-        src_attn_context = attn_context.transpose(0, 1).contiguous()
+        src_memory_bank = memory_bank.transpose(0, 1).contiguous()
 
         padding_idx = self.embeddings.word_padding_idx
         src_pad_mask = src_words.data.eq(padding_idx).unsqueeze(1) \
@@ -217,7 +255,7 @@ class TransformerDecoder(nn.Module):
                     prev_layer_input = self.state["previous_input"][i]
             output, attn, all_input \
                 = self.transformer_layers[i](
-                    output, src_attn_context,
+                    output, src_memory_bank,
                     src_pad_mask, tgt_pad_mask,
                     previous_input=prev_layer_input,
                     layer_cache=self.state["cache"]["layer_{}".format(i)]
@@ -245,10 +283,10 @@ class TransformerDecoder(nn.Module):
         # TODO change the way attns is returned dict => list or tuple (onnx)
         return dec_outs, attns
 
-    def _init_cache(self, attn_context, num_layers, self_attn_type):
+    def _init_cache(self, memory_bank, num_layers, self_attn_type):
         self.state["cache"] = {}
-        batch_size = attn_context.size(1)
-        depth = attn_context.size(-1)
+        batch_size = memory_bank.size(1)
+        depth = memory_bank.size(-1)
 
         for l in range(num_layers):
             layer_cache = {
@@ -264,42 +302,3 @@ class TransformerDecoder(nn.Module):
                 layer_cache["self_keys"] = None
                 layer_cache["self_values"] = None
             self.state["cache"]["layer_{}".format(l)] = layer_cache
-
-    def init_decoder_state(self, src, attn_context, enc_hidden,
-                           with_cache=False):
-        """ Init decoder state """
-        self.state["src"] = src
-        self.state["previous_input"] = None
-        self.state["previous_layer_inputs"] = None
-        self.state["cache"] = None
-
-        if with_cache:
-            self._init_cache(attn_context, self.num_layers,
-                             self.self_attn_type)
-
-    def map_batch_fn(self, fn):
-        def _recursive_map(struct, batch_dim=0):
-            for k, v in struct.items():
-                if v is not None:
-                    if isinstance(v, dict):
-                        _recursive_map(v)
-                    else:
-                        struct[k] = fn(v, batch_dim)
-
-        self.state["src"] = fn(self.state["src"], 1)
-        if self.state["previous_input"] is not None:
-            self.state["previous_input"] = fn(self.state["previous_input"], 1)
-        if self.state["previous_layer_inputs"] is not None:
-            self.state["previous_layer_inputs"] = \
-                fn(self.state["previous_layer_inputs"], 1)
-        if self.state["cache"] is not None:
-            _recursive_map(self.state["cache"])
-
-    def detach(self):
-        if self.state["previous_input"] is not None:
-            self.state["previous_input"] = \
-                self.state["previous_input"].detach()
-        if self.state["previous_layer_inputs"] is not None:
-            self.state["previous_layer_inputs"] = \
-                self.state["previous_layer_inputs"].detach()
-        self.state["src"] = self.state["src"].detach()

--- a/onmt/models/model.py
+++ b/onmt/models/model.py
@@ -31,20 +31,18 @@ class NMTModel(nn.Module):
             tgt (:obj:`LongTensor`):
                  a target sequence of size `[tgt_len x batch]`.
             lengths(:obj:`LongTensor`): the src lengths, pre-padding `[batch]`.
-            dec_state (:obj:`DecoderState`, optional): initial decoder state
+
         Returns:
             (:obj:`FloatTensor`, `dict`, :obj:`onmt.Models.DecoderState`):
 
                  * decoder output `[tgt_len x batch x hidden]`
                  * dictionary attention dists of `[tgt_len x batch x src_len]`
-                 * final decoder state
         """
         tgt = tgt[:-1]  # exclude last target from inputs
 
-        enc_final, memory_bank, lengths = self.encoder(src, lengths)
-        self.decoder.init_decoder_state(src, memory_bank, enc_final)
-        decoder_outputs, attns = \
-            self.decoder(tgt, memory_bank,
-                         memory_lengths=lengths)
+        enc_out, attn_context, lengths = self.encoder(src, lengths)
+        self.decoder.init_decoder_state(src, attn_context, enc_out)
+        dec_out, attns = self.decoder(tgt, attn_context,
+                                      memory_lengths=lengths)
 
-        return decoder_outputs, attns
+        return dec_out, attns

--- a/onmt/models/model.py
+++ b/onmt/models/model.py
@@ -18,7 +18,7 @@ class NMTModel(nn.Module):
         self.encoder = encoder
         self.decoder = decoder
 
-    def forward(self, src, tgt, lengths, dec_state=None):
+    def forward(self, src, tgt, lengths):
         """Forward propagate a `src` and `tgt` pair for training.
         Possible initialized with a beginning decoder state.
 
@@ -42,12 +42,9 @@ class NMTModel(nn.Module):
         tgt = tgt[:-1]  # exclude last target from inputs
 
         enc_final, memory_bank, lengths = self.encoder(src, lengths)
-        enc_state = \
-            self.decoder.init_decoder_state(src, memory_bank, enc_final)
-        decoder_outputs, dec_state, attns = \
+        self.decoder.init_decoder_state(src, memory_bank, enc_final)
+        decoder_outputs, attns = \
             self.decoder(tgt, memory_bank,
-                         enc_state if dec_state is None
-                         else dec_state,
                          memory_lengths=lengths)
 
-        return decoder_outputs, attns, dec_state
+        return decoder_outputs, attns

--- a/onmt/models/model.py
+++ b/onmt/models/model.py
@@ -40,9 +40,9 @@ class NMTModel(nn.Module):
         """
         tgt = tgt[:-1]  # exclude last target from inputs
 
-        enc_out, attn_context, lengths = self.encoder(src, lengths)
-        self.decoder.init_decoder_state(src, attn_context, enc_out)
-        dec_out, attns = self.decoder(tgt, attn_context,
+        enc_state, memory_bank, lengths = self.encoder(src, lengths)
+        self.decoder.init_state(src, memory_bank, enc_state)
+        dec_out, attns = self.decoder(tgt, memory_bank,
                                       memory_lengths=lengths)
 
         return dec_out, attns

--- a/onmt/tests/test_models.py
+++ b/onmt/tests/test_models.py
@@ -141,9 +141,7 @@ class TestModel(unittest.TestCase):
 
         test_src, test_tgt, test_length = self.get_batch(source_l=source_l,
                                                          bsize=bsize)
-        outputs, attn = model(test_src,
-                                 test_tgt,
-                                 test_length)
+        outputs, attn = model(test_src, test_tgt, test_length)
         outputsize = torch.zeros(source_l - 1, bsize, opt.dec_rnn_size)
         # Make sure that output has the correct size and type
         self.assertEqual(outputs.size(), outputsize.size())
@@ -180,9 +178,7 @@ class TestModel(unittest.TestCase):
             h=h, w=w,
             bsize=bsize,
             tgt_l=tgt_l)
-        outputs, attn = model(test_src,
-                                 test_tgt,
-                                 test_length)
+        outputs, attn = model(test_src, test_tgt, test_length)
         outputsize = torch.zeros(tgt_l - 1, bsize, opt.dec_rnn_size)
         # Make sure that output has the correct size and type
         self.assertEqual(outputs.size(), outputsize.size())
@@ -220,9 +216,7 @@ class TestModel(unittest.TestCase):
             sample_rate=opt.sample_rate,
             window_size=opt.window_size,
             t=t, tgt_l=tgt_l)
-        outputs, attn = model(test_src,
-                                 test_tgt,
-                                 test_length)
+        outputs, attn = model(test_src, test_tgt, test_length)
         outputsize = torch.zeros(tgt_l - 1, bsize, opt.dec_rnn_size)
         # Make sure that output has the correct size and type
         self.assertEqual(outputs.size(), outputsize.size())

--- a/onmt/tests/test_models.py
+++ b/onmt/tests/test_models.py
@@ -141,7 +141,7 @@ class TestModel(unittest.TestCase):
 
         test_src, test_tgt, test_length = self.get_batch(source_l=source_l,
                                                          bsize=bsize)
-        outputs, attn, _ = model(test_src,
+        outputs, attn = model(test_src,
                                  test_tgt,
                                  test_length)
         outputsize = torch.zeros(source_l - 1, bsize, opt.dec_rnn_size)
@@ -180,7 +180,7 @@ class TestModel(unittest.TestCase):
             h=h, w=w,
             bsize=bsize,
             tgt_l=tgt_l)
-        outputs, attn, _ = model(test_src,
+        outputs, attn = model(test_src,
                                  test_tgt,
                                  test_length)
         outputsize = torch.zeros(tgt_l - 1, bsize, opt.dec_rnn_size)
@@ -220,7 +220,7 @@ class TestModel(unittest.TestCase):
             sample_rate=opt.sample_rate,
             window_size=opt.window_size,
             t=t, tgt_l=tgt_l)
-        outputs, attn, _ = model(test_src,
+        outputs, attn = model(test_src,
                                  test_tgt,
                                  test_length)
         outputsize = torch.zeros(tgt_l - 1, bsize, opt.dec_rnn_size)

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -262,7 +262,7 @@ class Trainer(object):
             else:
                 trunc_size = target_size
 
-            dec_state = None
+            # dec_state = None
             src = inputters.make_features(batch, 'src', self.data_type)
             if self.data_type == 'text':
                 _, src_lengths = batch.src
@@ -281,8 +281,8 @@ class Trainer(object):
                 # 2. F-prop all but generator.
                 if self.grad_accum_count == 1:
                     self.model.zero_grad()
-                outputs, attns, dec_state = \
-                    self.model(src, tgt, src_lengths, dec_state)
+                outputs, attns = \
+                    self.model(src, tgt, src_lengths)
 
                 # 3. Compute loss in shards for memory efficiency.
                 batch_stats = self.train_loss.sharded_compute_loss(
@@ -303,8 +303,8 @@ class Trainer(object):
                     self.optim.step()
 
                 # If truncated, don't backprop fully.
-                if dec_state is not None:
-                    dec_state.detach()
+                #if dec_state is not None:
+                #    dec_state.detach()
 
         # in case of multi step gradient accumulation,
         # update only after accum batches

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -303,7 +303,8 @@ class Trainer(object):
                     self.optim.step()
 
                 # If truncated, don't backprop fully.
-                #if dec_state is not None:
+                # TODO
+                # if dec_state is not None:
                 #    dec_state.detach()
 
         # in case of multi step gradient accumulation,

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -303,9 +303,11 @@ class Trainer(object):
                     self.optim.step()
 
                 # If truncated, don't backprop fully.
-                # TODO
+                # TO CHECK
                 # if dec_state is not None:
                 #    dec_state.detach()
+                if self.model.decoder.state is not None:
+                    self.model.decoder.detach()
 
         # in case of multi step gradient accumulation,
         # update only after accum batches

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -235,7 +235,7 @@ class Trainer(object):
             tgt = inputters.make_features(batch, 'tgt')
 
             # F-prop through the model.
-            outputs, attns, _ = self.model(src, tgt, src_lengths)
+            outputs, attns = self.model(src, tgt, src_lengths)
 
             # Compute loss.
             batch_stats = self.valid_loss.monolithic_compute_loss(

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -307,7 +307,7 @@ class Trainer(object):
                 # if dec_state is not None:
                 #    dec_state.detach()
                 if self.model.decoder.state is not None:
-                    self.model.decoder.detach()
+                    self.model.decoder.detach_state()
 
         # in case of multi step gradient accumulation,
         # update only after accum batches

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -576,8 +576,6 @@ class Translator(object):
         self.model.decoder.init_decoder_state(
             src, memory_bank, enc_states)
 
-
-
         # (2) Repeat src objects `beam_size` times.
         src_map = rvar(batch.src_map.data) \
             if data_type == 'text' and self.copy_attn else None


### PR DESCRIPTION
This is necessary for future Onnx export.

This "simplifies" the way we maintain the decoder state within the Decoder itself.