### PR TITLE
Add option for averaging raw probabilities in ensembles

### DIFF
--- a/onmt/decoders/ensemble.py
+++ b/onmt/decoders/ensemble.py
@@ -96,14 +96,10 @@ class EnsembleGenerator(nn.Module):
         by averaging distributions from models in the ensemble.
         All models in the ensemble must share a target vocabulary.
         """
-        if attn is not None:
-            distributions = [model_generator(hidden[i], attn, src_map)
-                             for i, model_generator
-                             in enumerate(self.model_generators)]
-        else:
-            distributions = [model_generator(hidden[i])
-                             for i, model_generator
-                             in enumerate(self.model_generators)]
+        distributions = torch.stack(
+                [mg(h) if attn is None else mg(h, attn, src_map)
+                 for h, mg in zip(hidden, self.model_generators)]
+            )
         if self._raw_probs:
             return torch.log(torch.exp(distributions).mean(0))
         else:

--- a/onmt/decoders/ensemble.py
+++ b/onmt/decoders/ensemble.py
@@ -159,6 +159,5 @@ def load_test_model(opt, dummy_opt):
         models.append(model)
         if shared_model_opt is None:
             shared_model_opt = model_opt
-    print(opt.avg_raw_probs)
     ensemble_model = EnsembleModel(models, opt.avg_raw_probs)
     return shared_fields, ensemble_model, shared_model_opt

--- a/onmt/decoders/ensemble.py
+++ b/onmt/decoders/ensemble.py
@@ -104,9 +104,10 @@ class EnsembleGenerator(nn.Module):
     Dummy Generator that delegates to individual real Generators,
     and then averages the resulting target distributions.
     """
-    def __init__(self, model_generators):
-        self.model_generators = tuple(model_generators)
+    def __init__(self, model_generators, raw_probs=False):
         super(EnsembleGenerator, self).__init__()
+        self.model_generators = nn.ModuleList(model_generators)
+        self._raw_probs = raw_probs
 
     def forward(self, hidden):
         """
@@ -114,19 +115,27 @@ class EnsembleGenerator(nn.Module):
         by averaging distributions from models in the ensemble.
         All models in the ensemble must share a target vocabulary.
         """
-        distributions = [model_generator(hidden[i])
-                         for i, model_generator
-                         in enumerate(self.model_generators)]
-        return torch.stack(distributions).mean(0)
+        hidden = torch.stack(hidden.model_outputs)
+        # this is the essential behavior of the Elementwise module, but
+        # its code is still fairly specific to embeddings and needs to
+        # be rewritten to work right
+        distributions = torch.stack(
+            [mg(h) for h, mg in zip(hidden, self.model_generators)]
+        )
+        if self._raw_probs:
+            return torch.log(torch.exp(distributions).mean(0))
+        else:
+            return distributions.mean(0)
 
 
 class EnsembleModel(NMTModel):
     """ Dummy NMTModel wrapping individual real NMTModels """
-    def __init__(self, models):
+    def __init__(self, models, raw_probs=False):
         encoder = EnsembleEncoder(model.encoder for model in models)
         decoder = EnsembleDecoder(model.decoder for model in models)
         super(EnsembleModel, self).__init__(encoder, decoder)
-        self.generator = EnsembleGenerator(model.generator for model in models)
+        self.generator = EnsembleGenerator(
+            [model.generator for model in models], raw_probs)
         self.models = nn.ModuleList(models)
 
 
@@ -150,5 +159,6 @@ def load_test_model(opt, dummy_opt):
         models.append(model)
         if shared_model_opt is None:
             shared_model_opt = model_opt
-    ensemble_model = EnsembleModel(models)
+    print(opt.avg_raw_probs)
+    ensemble_model = EnsembleModel(models, opt.avg_raw_probs)
     return shared_fields, ensemble_model, shared_model_opt

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -452,6 +452,13 @@ def translate_opts(parser):
                        help='Path to model .pt file(s). '
                             'Multiple models can be specified, '
                             'for ensemble decoding.')
+    group.add_argument('-avg_raw_probs', action='store_true',
+                       help="""If this is set, during ensembling scores from
+                       different models will be combined by averaging their
+                       raw probabilities and then taking the log. Otherwise,
+                       the log probabilities will be averaged directly.
+                       Necessary for models whose output layers can assign
+                       zero probability.""")
 
     group = parser.add_argument_group('Data')
     group.add_argument('-data_type', default="text",

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -729,8 +729,6 @@ class Translator(object):
 
     def _score_target(self, batch, memory_bank, src_lengths):
         tgt_in = inputters.make_features(batch, 'tgt')[:-1]
-        tt = torch.cuda if self.cuda else torch
-        gold_scores = tt.FloatTensor(batch.batch_size).fill_(0)
         dec_out, _ = self.model.decoder(
             tgt_in, memory_bank, memory_lengths=src_lengths)
 

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -26,13 +26,9 @@ def build_translator(opt, report_score=True, logger=None, out_file=None):
     opts.model_opts(dummy_parser)
     dummy_opt = dummy_parser.parse_known_args([])[0]
 
-    if len(opt.models) > 1:
-        # use ensemble decoding if more than one model is specified
-        fields, model, model_opt = \
-            onmt.decoders.ensemble.load_test_model(opt, dummy_opt.__dict__)
-    else:
-        fields, model, model_opt = \
-            onmt.model_builder.load_test_model(opt, dummy_opt.__dict__)
+    load_test_model = onmt.decoders.ensemble.load_test_model \
+        if len(opt.models) > 1 else onmt.decoders.ensemble.load_test_model
+    fields, model, model_opt = load_test_model(opt, dummy_opt.__dict__)
 
     scorer = onmt.translate.GNMTGlobalScorer(opt.alpha,
                                              opt.beta,

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -27,7 +27,7 @@ def build_translator(opt, report_score=True, logger=None, out_file=None):
     dummy_opt = dummy_parser.parse_known_args([])[0]
 
     load_test_model = onmt.decoders.ensemble.load_test_model \
-        if len(opt.models) > 1 else onmt.decoders.ensemble.load_test_model
+        if len(opt.models) > 1 else onmt.model_builder.load_test_model
     fields, model, model_opt = load_test_model(opt, dummy_opt.__dict__)
 
     scorer = onmt.translate.GNMTGlobalScorer(opt.alpha,


### PR DESCRIPTION
This pull request adds a new option for computing scores for ensembled models. Previously, the only option was to average the log probabilities assigned by each model in the ensemble. This strategy is incompatible with models that output probability distributions that are not strictly positive because because the log of a zero probability is negative infinity, which breaks the averaging.

As an alternative, I added the command line option `-avg_raw_prob`, which will instead average the raw probabilities. Future work could explore other ensembling strategies such as majority voting.