### PR TITLE
Improve numerical stability of sparsemax

### DIFF
--- a/docs/source/options/train.md
+++ b/docs/source/options/train.md
@@ -115,9 +115,9 @@ Size of hidden transformer feed-forward
 * **-copy_attn []** 
 Train copy attention layer.
 
-* **-generator_function [log_softmax]** 
+* **-generator_function [softmax]** 
 Which function to use for generating probabilities over the target vocabulary
-(choices: log_softmax, sparsemax)
+(choices: softmax, sparsemax)
 
 * **-copy_attn_force []** 
 When available, train to copy.

--- a/onmt/modules/sparse_activations.py
+++ b/onmt/modules/sparse_activations.py
@@ -1,6 +1,8 @@
 """
 An implementation of sparsemax (Martins & Astudillo, 2016). See
 https://arxiv.org/pdf/1602.02068 for detailed description.
+
+By Ben Peters and Vlad Niculae
 """
 
 import torch
@@ -8,48 +10,65 @@ from torch.autograd import Function
 import torch.nn as nn
 
 
-def threshold_and_support(z, dim=0):
-    """
-    z: any dimension
-    dim: dimension along which to apply the sparsemax
-    """
-    sorted_z, _ = torch.sort(z, descending=True, dim=dim)
-    z_sum = sorted_z.cumsum(dim) - 1  # sort of a misnomer
-    k = torch.arange(1, sorted_z.size(dim) + 1, device=z.device).float().view(
-        torch.Size([-1] + [1] * (z.dim() - 1))
-    ).transpose(0, dim)
-    support = k * sorted_z > z_sum
+def _make_ix_like(X, dim=0):
+    d = X.size(dim)
+    rho = torch.arange(1, d + 1, device=X.device, dtype=X.dtype)
+    view = [1] * X.dim()
+    view[0] = -1
+    return rho.view(view).transpose(0, dim)
 
-    k_z_indices = support.sum(dim=dim).unsqueeze(dim)
-    k_z = k_z_indices.float()
-    tau_z = z_sum.gather(dim, k_z_indices - 1) / k_z
-    return tau_z, k_z
+
+def _threshold_and_support(X, dim=0):
+    """
+    Sparsemax building block: compute the threshold
+    Parameters:
+        X: any dimension
+        dim: dimension along which to apply the sparsemax
+    Returns:
+        the threshold value
+    """
+    X_srt, _ = torch.sort(X, descending=True, dim=dim)
+    X_cumsum = X_srt.cumsum(dim) - 1
+    rhos = _make_ix_like(X, dim)
+    support = rhos * X_srt > X_cumsum
+
+    support_size = support.sum(dim=dim).unsqueeze(dim)
+    tau = X_cumsum.gather(dim, support_size - 1)
+    tau /= support_size.to(X.dtype)
+    return tau, support_size
 
 
 class SparsemaxFunction(Function):
 
     @staticmethod
-    def forward(ctx, input, dim=0):
+    def forward(ctx, X, dim=0):
         """
-        input (FloatTensor): any shape
-        returns (FloatTensor): same shape with sparsemax computed on given dim
+        sparsemax: normalizing sparse transform (a la softmax)
+        Parameters:
+            X (Tensor): any shape
+            dim: dimension along which to apply sparsemax
+        Returns:
+            Y (Tensor): same shape as X
         """
         ctx.dim = dim
-        tau_z, k_z = threshold_and_support(input, dim=dim)
-        output = torch.clamp(input - tau_z, min=0)
-        ctx.save_for_backward(k_z, output)
-        return output
+        max_val, _ = X.max(dim=dim, keepdim=True)
+        X = X - max_val  # same numerical stability trick as for softmax
+        tau, support_size = _threshold_and_support(X, dim=dim)
+        Y = torch.clamp(X - tau, min=0)
+        ctx.save_for_backward(support_size, Y)
+        return Y
 
     @staticmethod
-    def backward(ctx, grad_output):
-        k_z, output = ctx.saved_tensors
+    def backward(ctx, dY):
+        support_size, Y = ctx.saved_tensors
         dim = ctx.dim
-        grad_input = grad_output.clone()
-        grad_input[output == 0] = 0
+        dX = dY.clone()
+        dX[Y == 0] = 0
 
-        v_hat = (grad_input.sum(dim=dim) / k_z.squeeze()).unsqueeze(dim)
-        grad_input = torch.where(output != 0, grad_input - v_hat, grad_input)
-        return grad_input, None
+        v_hat = dX.sum(dim=dim) / support_size.to(Y.dtype).squeeze()
+        v_hat = v_hat.unsqueeze(dim)
+        dX = torch.where(Y != 0, dX - v_hat, dX)
+        return dX, None
 
 
 sparsemax = SparsemaxFunction.apply

--- a/onmt/modules/sparse_losses.py
+++ b/onmt/modules/sparse_losses.py
@@ -1,7 +1,7 @@
 import torch
 import torch.nn as nn
 from torch.autograd import Function
-from onmt.modules.sparse_activations import threshold_and_support
+from onmt.modules.sparse_activations import _threshold_and_support
 from onmt.utils.misc import aeq
 
 
@@ -18,7 +18,7 @@ class SparsemaxLossFunction(Function):
         aeq(input_batch, target_batch)
 
         z_k = input.gather(1, target.unsqueeze(1)).squeeze()
-        tau_z, support_size = threshold_and_support(input, dim=1)
+        tau_z, support_size = _threshold_and_support(input, dim=1)
         support = input > tau_z
         x = torch.where(
             support, input**2 - tau_z**2,

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -131,11 +131,11 @@ def model_opts(parser):
     # Generator and loss options.
     group.add_argument('-copy_attn', action="store_true",
                        help='Train copy attention layer.')
-    group.add_argument('-generator_function', default="log_softmax",
-                       choices=["log_softmax", "sparsemax"],
+    group.add_argument('-generator_function', default="softmax",
+                       choices=["softmax", "sparsemax"],
                        help="""Which function to use for generating
                        probabilities over the target vocabulary (choices:
-                       log_softmax, sparsemax)""")
+                       softmax, sparsemax)""")
     group.add_argument('-copy_attn_force', action="store_true",
                        help='When available, train to copy.')
     group.add_argument('-reuse_copy_attn', action="store_true",


### PR DESCRIPTION
This pull request makes two changes:

1.  It incorporates Vlad Niculae's suggestions for improving the numerical stability of sparsemax.
2. It renames the default `-generator_function` option from `log_softmax` to `softmax`. It was inconsistent that the two options were called sparsemax and log softmax, given that both functions are passed through a log.

 