### PR TITLE
Remove unnecessary future division imports

### DIFF
--- a/onmt/decoders/decoder.py
+++ b/onmt/decoders/decoder.py
@@ -1,6 +1,5 @@
 """ Base Class and function for Decoders """
 
-from __future__ import division
 import torch
 import torch.nn as nn
 

--- a/onmt/encoders/encoder.py
+++ b/onmt/encoders/encoder.py
@@ -1,7 +1,5 @@
 """Base class for encoders and generic multi encoders."""
 
-from __future__ import division
-
 import torch.nn as nn
 
 from onmt.utils.misc import aeq

--- a/onmt/encoders/mean_encoder.py
+++ b/onmt/encoders/mean_encoder.py
@@ -1,6 +1,4 @@
 """Define a minimal encoder."""
-from __future__ import division
-
 from onmt.encoders.encoder import EncoderBase
 
 

--- a/onmt/encoders/rnn_encoder.py
+++ b/onmt/encoders/rnn_encoder.py
@@ -1,6 +1,4 @@
 """Define RNN-based encoders."""
-from __future__ import division
-
 import torch.nn as nn
 import torch.nn.functional as F
 

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -2,8 +2,6 @@
 """
     Training on a single process
 """
-from __future__ import division
-
 import argparse
 import os
 import random

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -9,8 +9,6 @@
           users of this library) for the strategy things we do.
 """
 
-from __future__ import division
-
 import onmt.inputters as inputters
 import onmt.utils
 

--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -1,6 +1,5 @@
 """ Translation main class """
-from __future__ import division, unicode_literals
-from __future__ import print_function
+from __future__ import unicode_literals, print_function
 
 import torch
 import onmt.inputters as inputters

--- a/onmt/utils/rnn_factory.py
+++ b/onmt/utils/rnn_factory.py
@@ -1,8 +1,6 @@
 """
  RNN tools
 """
-from __future__ import division
-
 import torch.nn as nn
 import onmt.models
 

--- a/tools/extract_embeddings.py
+++ b/tools/extract_embeddings.py
@@ -1,4 +1,3 @@
-from __future__ import division
 import torch
 import argparse
 import onmt

--- a/train.py
+++ b/train.py
@@ -2,7 +2,6 @@
 """
     Main training workflow
 """
-from __future__ import division
 import argparse
 import os
 import signal

--- a/translate.py
+++ b/translate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import division, unicode_literals
+from __future__ import unicode_literals
 import argparse
 
 from onmt.utils.logging import init_logger


### PR DESCRIPTION
This small PR removes `from __future__ import division` lines from scripts in which no integer division could plausibly occur. Unlike standard imports, future imports do not trigger flake8 when they are unused.