### PR TITLE
Use legacy Pytorch LayerNorm

### DIFF
--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -40,8 +40,8 @@ class TransformerDecoderLayer(nn.Module):
         self.context_attn = onmt.modules.MultiHeadedAttention(
             heads, d_model, dropout=dropout)
         self.feed_forward = PositionwiseFeedForward(d_model, d_ff, dropout)
-        self.layer_norm_1 = onmt.modules.LayerNorm(d_model)
-        self.layer_norm_2 = onmt.modules.LayerNorm(d_model)
+        self.layer_norm_1 = nn.LayerNorm(d_model, eps=1e-6)
+        self.layer_norm_2 = nn.LayerNorm(d_model, eps=1e-6)
         self.dropout = dropout
         self.drop = nn.Dropout(dropout)
         mask = self._get_attn_subsequent_mask(MAX_SIZE)
@@ -170,7 +170,7 @@ class TransformerDecoder(nn.Module):
             self.copy_attn = onmt.modules.GlobalAttention(
                 d_model, attn_type=attn_type)
             self._copy = True
-        self.layer_norm = onmt.modules.LayerNorm(d_model)
+        self.layer_norm = nn.LayerNorm(d_model, eps=1e-6)
 
     def init_state(self, src, memory_bank, enc_hidden, with_cache=False):
         """ Init decoder state """

--- a/onmt/encoders/transformer.py
+++ b/onmt/encoders/transformer.py
@@ -29,7 +29,7 @@ class TransformerEncoderLayer(nn.Module):
         self.self_attn = onmt.modules.MultiHeadedAttention(
             heads, d_model, dropout=dropout)
         self.feed_forward = PositionwiseFeedForward(d_model, d_ff, dropout)
-        self.layer_norm = onmt.modules.LayerNorm(d_model)
+        self.layer_norm = nn.LayerNorm(d_model, eps=1e-6)
         self.dropout = nn.Dropout(dropout)
 
     def forward(self, inputs, mask):
@@ -93,7 +93,7 @@ class TransformerEncoder(EncoderBase):
         self.transformer = nn.ModuleList(
             [TransformerEncoderLayer(d_model, heads, d_ff, dropout)
              for _ in range(num_layers)])
-        self.layer_norm = onmt.modules.LayerNorm(d_model)
+        self.layer_norm = nn.LayerNorm(d_model, eps=1e-6)
 
     def forward(self, src, lengths=None):
         """ See :obj:`EncoderBase.forward()`"""

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -2,7 +2,7 @@
 This file is for models creation, which consults options
 and creates each encoder and decoder accordingly.
 """
-
+import re
 import torch
 import torch.nn as nn
 from torch.nn.init import xavier_uniform_
@@ -236,6 +236,15 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None):
 
     # Load the model states from checkpoint or initialize them.
     if checkpoint is not None:
+        # This preserves backward-compat for models using customed layernorm
+        fix_bias = lambda s: re.sub(
+          r'(.*)\.layer_norm((_\d+)?)\.b_2', r'\1.layer_norm\2.bias', s)
+        fix_weight = lambda s: re.sub(
+          r'(.*)\.layer_norm((_\d+)?)\.a_2', r'\1.layer_norm\2.weight', s)
+        fix_key = lambda k: fix_weight(fix_bias(k))
+        # end of patch for backward compatibility
+
+        checkpoint['model'] = {fix_key(k): v for (k, v) in checkpoint['model'].items()}
         model.load_state_dict(checkpoint['model'], strict=False)
         generator.load_state_dict(checkpoint['generator'], strict=False)
     else:

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -237,14 +237,17 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None):
     # Load the model states from checkpoint or initialize them.
     if checkpoint is not None:
         # This preserves backward-compat for models using customed layernorm
-        fix_bias = lambda s: re.sub(
-          r'(.*)\.layer_norm((_\d+)?)\.b_2', r'\1.layer_norm\2.bias', s)
-        fix_weight = lambda s: re.sub(
-          r'(.*)\.layer_norm((_\d+)?)\.a_2', r'\1.layer_norm\2.weight', s)
-        fix_key = lambda k: fix_weight(fix_bias(k))
+        def fix_key(s):
+            s = re.sub(r'(.*)\.layer_norm((_\d+)?)\.b_2',
+                       r'\1.layer_norm\2.bias', s)
+            s = re.sub(r'(.*)\.layer_norm((_\d+)?)\.a_2',
+                       r'\1.layer_norm\2.weight', s)
+            return s
+
+        checkpoint['model'] = \
+            {fix_key(k): v for (k, v) in checkpoint['model'].items()}
         # end of patch for backward compatibility
 
-        checkpoint['model'] = {fix_key(k): v for (k, v) in checkpoint['model'].items()}
         model.load_state_dict(checkpoint['model'], strict=False)
         generator.load_state_dict(checkpoint['generator'], strict=False)
     else:

--- a/onmt/modules/__init__.py
+++ b/onmt/modules/__init__.py
@@ -1,5 +1,5 @@
 """  Attention and normalization modules  """
-from onmt.modules.util_class import LayerNorm, Elementwise
+from onmt.modules.util_class import Elementwise
 from onmt.modules.gate import context_gate_factory, ContextGate
 from onmt.modules.global_attention import GlobalAttention
 from onmt.modules.conv_multi_step_attention import ConvMultiStepAttention
@@ -9,7 +9,7 @@ from onmt.modules.embeddings import Embeddings, PositionalEncoding
 from onmt.modules.weight_norm import WeightNormConv2d
 from onmt.modules.average_attn import AverageAttention
 
-__all__ = ["LayerNorm", "Elementwise", "context_gate_factory", "ContextGate",
+__all__ = ["Elementwise", "context_gate_factory", "ContextGate",
            "GlobalAttention", "ConvMultiStepAttention", "CopyGenerator",
            "CopyGeneratorLossCompute", "MultiHeadedAttention", "Embeddings",
            "PositionalEncoding", "WeightNormConv2d", "AverageAttention"]

--- a/onmt/modules/position_ffn.py
+++ b/onmt/modules/position_ffn.py
@@ -21,7 +21,7 @@ class PositionwiseFeedForward(nn.Module):
         super(PositionwiseFeedForward, self).__init__()
         self.w_1 = nn.Linear(d_model, d_ff)
         self.w_2 = nn.Linear(d_ff, d_model)
-        self.layer_norm = onmt.modules.LayerNorm(d_model)
+        self.layer_norm = nn.LayerNorm(d_model, eps=1e-6)
         self.dropout_1 = nn.Dropout(dropout)
         self.relu = nn.ReLU()
         self.dropout_2 = nn.Dropout(dropout)

--- a/onmt/modules/position_ffn.py
+++ b/onmt/modules/position_ffn.py
@@ -4,8 +4,6 @@ Position feed-forward network from "Attention is All You Need"
 
 import torch.nn as nn
 
-import onmt
-
 
 class PositionwiseFeedForward(nn.Module):
     """ A two-layer Feed-Forward-Network with residual layer norm.

--- a/onmt/modules/util_class.py
+++ b/onmt/modules/util_class.py
@@ -2,6 +2,7 @@
 import torch
 import torch.nn as nn
 
+
 # At the moment this class is only used by embeddings.Embeddings look-up tables
 class Elementwise(nn.ModuleList):
     """

--- a/onmt/modules/util_class.py
+++ b/onmt/modules/util_class.py
@@ -2,24 +2,6 @@
 import torch
 import torch.nn as nn
 
-
-class LayerNorm(nn.Module):
-    """
-        Layer Normalization class
-    """
-
-    def __init__(self, features, eps=1e-6):
-        super(LayerNorm, self).__init__()
-        self.a_2 = nn.Parameter(torch.ones(features))
-        self.b_2 = nn.Parameter(torch.zeros(features))
-        self.eps = eps
-
-    def forward(self, x):
-        mean = x.mean(-1, keepdim=True)
-        std = x.std(-1, keepdim=True)
-        return self.a_2 * (x - mean) / (std + self.eps) + self.b_2
-
-
 # At the moment this class is only used by embeddings.Embeddings look-up tables
 class Elementwise(nn.ModuleList):
     """


### PR DESCRIPTION
The goal is to use the generic LayerNorm Class from Pytorch instead of the current adhoc class.

To maintain backward compatibility with existing model, we need to rename the state_dict:
a_2 => weight
b_2 => bias
(thanks @guillaumekln @pltrdy for pointing the changes)