### PR TITLE
Make loss code more uniform across model types

### DIFF
--- a/onmt/modules/__init__.py
+++ b/onmt/modules/__init__.py
@@ -3,7 +3,8 @@ from onmt.modules.util_class import LayerNorm, Elementwise
 from onmt.modules.gate import context_gate_factory, ContextGate
 from onmt.modules.global_attention import GlobalAttention
 from onmt.modules.conv_multi_step_attention import ConvMultiStepAttention
-from onmt.modules.copy_generator import CopyGenerator, CopyGeneratorLossCompute
+from onmt.modules.copy_generator import CopyGenerator, CopyGeneratorLoss, \
+    CopyGeneratorLossCompute
 from onmt.modules.multi_headed_attn import MultiHeadedAttention
 from onmt.modules.embeddings import Embeddings, PositionalEncoding
 from onmt.modules.weight_norm import WeightNormConv2d
@@ -11,5 +12,6 @@ from onmt.modules.average_attn import AverageAttention
 
 __all__ = ["LayerNorm", "Elementwise", "context_gate_factory", "ContextGate",
            "GlobalAttention", "ConvMultiStepAttention", "CopyGenerator",
-           "CopyGeneratorLossCompute", "MultiHeadedAttention", "Embeddings",
-           "PositionalEncoding", "WeightNormConv2d", "AverageAttention"]
+           "CopyGeneratorLoss", "CopyGeneratorLossCompute",
+           "MultiHeadedAttention", "Embeddings", "PositionalEncoding",
+           "WeightNormConv2d", "AverageAttention"]

--- a/onmt/modules/copy_generator.py
+++ b/onmt/modules/copy_generator.py
@@ -1,7 +1,6 @@
 """ Generator module """
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 import onmt.inputters as inputters
 from onmt.utils.misc import aeq
@@ -90,10 +89,10 @@ class CopyGenerator(nn.Module):
         # Original probabilities.
         logits = self.linear(hidden)
         logits[:, self.tgt_dict.stoi[inputters.PAD_WORD]] = -float('inf')
-        prob = F.softmax(logits, 1)
+        prob = torch.softmax(logits, 1)
 
         # Probability of copying p(z=1) batch.
-        p_copy = F.sigmoid(self.linear_copy(hidden))
+        p_copy = torch.sigmoid(self.linear_copy(hidden))
         # Probibility of not copying: p_{word}(w) * (1 - p(z))
         out_prob = torch.mul(prob, 1 - p_copy.expand_as(prob))
         mul_attn = torch.mul(attn, p_copy.expand_as(attn))

--- a/onmt/modules/copy_generator.py
+++ b/onmt/modules/copy_generator.py
@@ -9,8 +9,9 @@ from onmt.utils.loss import LossComputeBase
 
 
 class CopyGenerator(nn.Module):
-    """Generator module that additionally considers copying
-    words directly from the source.
+    """An implementation of pointer-generator networks (See et al., 2017)
+    (https://arxiv.org/abs/1704.04368), which consider copying words
+    directly from the source sequence.
 
     The main idea is that we have an extended "dynamic dictionary".
     It contains `|tgt_dict|` words plus an arbitrary number of

--- a/onmt/modules/sparse_losses.py
+++ b/onmt/modules/sparse_losses.py
@@ -55,11 +55,11 @@ class SparsemaxLoss(nn.Module):
     """
 
     def __init__(self, weight=None, ignore_index=-100,
-                 reduce=True, size_average=True):
+                 reduction='elementwise_mean'):
+        assert reduction in ['elementwise_mean', 'sum', 'none']
+        self.reduction = reduction
         self.weight = weight
         self.ignore_index = ignore_index
-        self.reduce = reduce
-        self.size_average = size_average
         super(SparsemaxLoss, self).__init__()
 
     def forward(self, input, target):
@@ -70,8 +70,8 @@ class SparsemaxLoss(nn.Module):
             loss.masked_fill_(ignored_positions, 0.0)
         else:
             size = float(target.size(0))
-        if self.reduce:
+        if self.reduction == 'sum':
             loss = loss.sum()
-            if self.size_average:
-                loss = loss / size
+        elif self.reduction == 'elementwise_mean':
+            loss = loss.sum() / size
         return loss

--- a/onmt/utils/loss.py
+++ b/onmt/utils/loss.py
@@ -12,6 +12,7 @@ import torch.nn.functional as F
 import onmt
 import onmt.inputters as inputters
 from onmt.modules.sparse_losses import SparsemaxLoss
+from onmt.modules.sparse_activations import LogSparsemax
 
 
 def build_loss_compute(model, tgt_vocab, opt, train=True):
@@ -27,9 +28,24 @@ def build_loss_compute(model, tgt_vocab, opt, train=True):
             model.generator, tgt_vocab, opt.copy_attn_force,
             opt.copy_loss_by_seqlength)
     else:
-        compute = NMTLossCompute(
-            model.generator, tgt_vocab,
-            label_smoothing=opt.label_smoothing if train else 0.0)
+        padding_idx = tgt_vocab.stoi[inputters.PAD_WORD]
+        if opt.label_smoothing > 0 and train:
+            criterion = LabelSmoothingLoss(
+                opt.label_smoothing, len(tgt_vocab), ignore_index=padding_idx
+            )
+        elif isinstance(model.generator[1], LogSparsemax):
+            criterion = SparsemaxLoss(
+                ignore_index=padding_idx, reduction='sum'
+            )
+        else:
+            criterion = nn.NLLLoss(ignore_index=padding_idx, reduction='sum')
+        # if the loss function operates on vectors of raw logits instead of
+        # probabilities, only the first part of the generator needs to be
+        # passed to the NMTLossCompute. At the moment, the only supported
+        # loss function of this kind is the sparsemax loss.
+        use_raw_logits = isinstance(criterion, SparsemaxLoss)
+        loss_gen = model.generator[0] if use_raw_logits else model.generator
+        compute = NMTLossCompute(criterion, loss_gen)
     compute.to(device)
 
     return compute
@@ -55,11 +71,14 @@ class LossComputeBase(nn.Module):
         normalzation (str): normalize by "sents" or "tokens"
     """
 
-    def __init__(self, generator, tgt_vocab):
+    def __init__(self, criterion, generator):
         super(LossComputeBase, self).__init__()
+        self.criterion = criterion
         self.generator = generator
-        self.tgt_vocab = tgt_vocab
-        self.padding_idx = tgt_vocab.stoi[inputters.PAD_WORD]
+
+    @property
+    def padding_idx(self):
+        return self.criterion.ignore_index
 
     def _make_shard_state(self, batch, output, range_, attns=None):
         """
@@ -159,10 +178,7 @@ class LossComputeBase(nn.Module):
         """
         pred = scores.max(1)[1]
         non_padding = target.ne(self.padding_idx)
-        num_correct = pred.eq(target) \
-                          .masked_select(non_padding) \
-                          .sum() \
-                          .item()
+        num_correct = pred.eq(target).masked_select(non_padding).sum().item()
         num_non_padding = non_padding.sum().item()
         return onmt.utils.Statistics(loss.item(), num_non_padding, num_correct)
 
@@ -181,12 +197,12 @@ class LabelSmoothingLoss(nn.Module):
     """
     def __init__(self, label_smoothing, tgt_vocab_size, ignore_index=-100):
         assert 0.0 < label_smoothing <= 1.0
-        self.padding_idx = ignore_index
+        self.ignore_index = ignore_index
         super(LabelSmoothingLoss, self).__init__()
 
         smoothing_value = label_smoothing / (tgt_vocab_size - 2)
         one_hot = torch.full((tgt_vocab_size,), smoothing_value)
-        one_hot[self.padding_idx] = 0
+        one_hot[self.ignore_index] = 0
         self.register_buffer('one_hot', one_hot.unsqueeze(0))
 
         self.confidence = 1.0 - label_smoothing
@@ -198,7 +214,7 @@ class LabelSmoothingLoss(nn.Module):
         """
         model_prob = self.one_hot.repeat(target.size(0), 1)
         model_prob.scatter_(1, target.unsqueeze(1), self.confidence)
-        model_prob.masked_fill_((target == self.padding_idx).unsqueeze(1), 0)
+        model_prob.masked_fill_((target == self.ignore_index).unsqueeze(1), 0)
 
         return F.kl_div(output, model_prob, reduction='sum')
 
@@ -208,22 +224,8 @@ class NMTLossCompute(LossComputeBase):
     Standard NMT Loss Computation.
     """
 
-    def __init__(self, generator, tgt_vocab, normalization="sents",
-                 label_smoothing=0.0):
-        super(NMTLossCompute, self).__init__(generator, tgt_vocab)
-        self.sparse = not isinstance(generator[1], nn.LogSoftmax)
-        if label_smoothing > 0:
-            self.criterion = LabelSmoothingLoss(
-                label_smoothing, len(tgt_vocab), ignore_index=self.padding_idx
-            )
-        elif self.sparse:
-            self.criterion = SparsemaxLoss(
-                ignore_index=self.padding_idx, reduction='sum'
-            )
-        else:
-            self.criterion = nn.NLLLoss(
-                ignore_index=self.padding_idx, reduction='sum'
-            )
+    def __init__(self, criterion, generator, normalization="sents"):
+        super(NMTLossCompute, self).__init__(criterion, generator)
 
     def _make_shard_state(self, batch, output, range_, attns=None):
         return {
@@ -233,13 +235,8 @@ class NMTLossCompute(LossComputeBase):
 
     def _compute_loss(self, batch, output, target):
         bottled_output = self._bottle(output)
-        if self.sparse:
-            # for sparsemax loss, the loss function operates on the raw output
-            # vector, not a probability vector. Hence it's only necessary to
-            # apply the first part of the generator here.
-            scores = self.generator[0](bottled_output)
-        else:
-            scores = self.generator(bottled_output)
+
+        scores = self.generator(bottled_output)
         gtruth = target.view(-1)
 
         loss = self.criterion(scores, gtruth)
@@ -249,7 +246,6 @@ class NMTLossCompute(LossComputeBase):
 
 
 def filter_shard_state(state, shard_size=None):
-    """ ? """
     for k, v in state.items():
         if shard_size is None:
             yield k, v

--- a/onmt/utils/loss.py
+++ b/onmt/utils/loss.py
@@ -218,7 +218,7 @@ class NMTLossCompute(LossComputeBase):
             )
         elif self.sparse:
             self.criterion = SparsemaxLoss(
-                ignore_index=self.padding_idx, size_average=False
+                ignore_index=self.padding_idx, reduction='sum'
             )
         else:
             self.criterion = nn.NLLLoss(


### PR DESCRIPTION
This pull request makes a number of small changes intended to make the behavior of the loss code easier to understand and extend.

1. `SparsemaxLoss` now takes a `reduction` parameter similar to that used by `nn.NLLLoss` and `nn.CrossEntropyLoss`.
2. The `CopyGeneratorCriterion` class, which did not subclass `nn.Module`, is replaced by `CopyGeneratorLoss`, which does. The code for computing the loss has been made simpler, although this is still a work in progress. In particular, it would be nice if the `CopyGeneratorLoss` had a similar reduction parameter to other loss modules. I do not like that the loss computation for copy models is divided between two places, the criterion module and the `_compute_loss` method of `CopyGeneratorLossCompute`. For other module types, the loss computation happens entirely within the criterion and that seems like the best pattern to follow.
3. Loss function modules (`nn.NLLLoss`, `LabelSmoothingLoss`, `SparsemaxLoss`, and `CopyGeneratorLoss`) are now the first parameter of `LossCompute`'s `__init__()`. The goal of this is to make it easier to just plug in a new loss function similar to the ones defined in pytorch. This is more intuitive and user-friendly than requiring them to write a subclass of `LossCompute`. I hope that further refactoring will make it possible to remove `CopyGeneratorLossCompute` as well.
4. The unk index is now a parameter of the criterion module, analogous to the treatment of the pad index (aka `ignore_index`).
5. Various comments are updated.



