### PR TITLE
[WIP] remove need of src lengths in encoders

### DIFF
--- a/onmt/encoders/cnn_encoder.py
+++ b/onmt/encoders/cnn_encoder.py
@@ -25,13 +25,10 @@ class CNNEncoder(EncoderBase):
         self.cnn = StackedCNN(num_layers, hidden_size,
                               cnn_kernel_width, dropout)
 
-    def forward(self, input, lengths=None, hidden=None):
+    def forward(self, input):
         """ See :obj:`onmt.modules.EncoderBase.forward()`"""
-        self._check_args(input, lengths, hidden)
 
         emb = self.embeddings(input)
-        # s_len, batch, emb_dim = emb.size()
-
         emb = emb.transpose(0, 1).contiguous()
         emb_reshape = emb.view(emb.size(0) * emb.size(1), -1)
         emb_remap = self.linear(emb_reshape)
@@ -40,4 +37,4 @@ class CNNEncoder(EncoderBase):
         out = self.cnn(emb_remap)
 
         return emb_remap.squeeze(3).transpose(0, 1).contiguous(), \
-            out.squeeze(3).transpose(0, 1).contiguous(), lengths
+            out.squeeze(3).transpose(0, 1).contiguous()

--- a/onmt/encoders/encoder.py
+++ b/onmt/encoders/encoder.py
@@ -4,8 +4,6 @@ from __future__ import division
 
 import torch.nn as nn
 
-from onmt.utils.misc import aeq
-
 
 class EncoderBase(nn.Module):
     """
@@ -32,18 +30,11 @@ class EncoderBase(nn.Module):
           E-->G
     """
 
-    def _check_args(self, src, lengths=None, hidden=None):
-        _, n_batch, _ = src.size()
-        if lengths is not None:
-            n_batch_, = lengths.size()
-            aeq(n_batch, n_batch_)
-
-    def forward(self, src, lengths=None):
+    def forward(self, src):
         """
         Args:
             src (:obj:`LongTensor`):
                padded sequences of sparse indices `[src_len x batch x nfeat]`
-            lengths (:obj:`LongTensor`): length of each sequence `[batch]`
 
 
         Returns:

--- a/onmt/encoders/image_encoder.py
+++ b/onmt/encoders/image_encoder.py
@@ -2,9 +2,10 @@
 import torch.nn as nn
 import torch.nn.functional as F
 import torch
+from onmt.encoders.encoder import EncoderBase
 
 
-class ImageEncoder(nn.Module):
+class ImageEncoder(EncoderBase):
     """
     A simple encoder convolutional -> recurrent neural network for
     image src.
@@ -51,7 +52,7 @@ class ImageEncoder(nn.Module):
         """ Pass in needed options only when modify function definition."""
         pass
 
-    def forward(self, src, lengths=None):
+    def forward(self, src):
         "See :obj:`onmt.encoders.encoder.EncoderBase.forward()`"
 
         batch_size = src.size(0)
@@ -106,4 +107,4 @@ class ImageEncoder(nn.Module):
             all_outputs.append(outputs)
         out = torch.cat(all_outputs, 0)
 
-        return hidden_t, out, lengths
+        return hidden_t, out

--- a/onmt/encoders/mean_encoder.py
+++ b/onmt/encoders/mean_encoder.py
@@ -17,13 +17,12 @@ class MeanEncoder(EncoderBase):
         self.num_layers = num_layers
         self.embeddings = embeddings
 
-    def forward(self, src, lengths=None):
+    def forward(self, src):
         "See :obj:`EncoderBase.forward()`"
-        self._check_args(src, lengths)
 
         emb = self.embeddings(src)
         _, batch, emb_dim = emb.size()
         mean = emb.mean(0).expand(self.num_layers, batch, emb_dim)
         memory_bank = emb
         encoder_final = (mean, mean)
-        return encoder_final, memory_bank, lengths
+        return encoder_final, memory_bank

--- a/onmt/encoders/rnn_encoder.py
+++ b/onmt/encoders/rnn_encoder.py
@@ -50,13 +50,12 @@ class RNNEncoder(EncoderBase):
                                     hidden_size,
                                     num_layers)
 
-    def forward(self, src, lengths=None):
+    def forward(self, src):
         "See :obj:`EncoderBase.forward()`"
-        self._check_args(src, lengths)
 
         emb = self.embeddings(src)
-        # s_len, batch, emb_dim = emb.size()
-
+        padding_idx = self.embeddings.word_padding_idx
+        lengths = src.ne(padding_idx).sum(0)
         packed_emb = emb
         if lengths is not None and not self.no_pack_padded_seq:
             # Lengths data is wrapped inside a Tensor.
@@ -70,7 +69,7 @@ class RNNEncoder(EncoderBase):
 
         if self.use_bridge:
             encoder_final = self._bridge(encoder_final)
-        return encoder_final, memory_bank, lengths
+        return encoder_final, memory_bank
 
     def _initialize_bridge(self, rnn_type,
                            hidden_size,

--- a/onmt/encoders/transformer.py
+++ b/onmt/encoders/transformer.py
@@ -95,21 +95,19 @@ class TransformerEncoder(EncoderBase):
              for _ in range(num_layers)])
         self.layer_norm = nn.LayerNorm(d_model, eps=1e-6)
 
-    def forward(self, src, lengths=None):
+    def forward(self, src):
         """ See :obj:`EncoderBase.forward()`"""
-        self._check_args(src, lengths)
-
         emb = self.embeddings(src)
 
         out = emb.transpose(0, 1).contiguous()
         words = src[:, :, 0].transpose(0, 1)
         w_batch, w_len = words.size()
         padding_idx = self.embeddings.word_padding_idx
-        mask = words.data.eq(padding_idx).unsqueeze(1) \
+        mask = words.eq(padding_idx).unsqueeze(1) \
             .expand(w_batch, w_len, w_len)
         # Run the forward pass of every layer of the tranformer.
         for i in range(self.num_layers):
             out = self.transformer[i](out, mask)
         out = self.layer_norm(out)
 
-        return emb, out.transpose(0, 1).contiguous(), lengths
+        return emb, out.transpose(0, 1).contiguous()

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -216,7 +216,7 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None):
 
     # Build NMTModel(= encoder + decoder).
     device = torch.device("cuda" if gpu else "cpu")
-    model = onmt.models.NMTModel(encoder, decoder)
+    model = onmt.models.NMTModel(encoder, decoder, model_opt.model_type)
 
     # Build Generator.
     if not model_opt.copy_attn:

--- a/onmt/models/model.py
+++ b/onmt/models/model.py
@@ -13,10 +13,11 @@ class NMTModel(nn.Module):
       multi<gpu (bool): setup for multigpu support
     """
 
-    def __init__(self, encoder, decoder):
+    def __init__(self, encoder, decoder, model_type):
         super(NMTModel, self).__init__()
         self.encoder = encoder
         self.decoder = decoder
+        self.model_type = model_type
 
     def forward(self, src, tgt, lengths):
         """Forward propagate a `src` and `tgt` pair for training.
@@ -39,8 +40,9 @@ class NMTModel(nn.Module):
                  * dictionary attention dists of `[tgt_len x batch x src_len]`
         """
         tgt = tgt[:-1]  # exclude last target from inputs
-
-        enc_state, memory_bank, lengths = self.encoder(src, lengths)
+        enc_state, memory_bank = self.encoder(src)
+        if self.model_type == 'audio':
+            lengths = self.encoder.pooled_lengths
         self.decoder.init_state(src, memory_bank, enc_state)
         dec_out, attns = self.decoder(tgt, memory_bank,
                                       memory_lengths=lengths)

--- a/onmt/tests/test_models.py
+++ b/onmt/tests/test_models.py
@@ -137,7 +137,7 @@ class TestModel(unittest.TestCase):
                                       for_encoder=False)
         dec = build_decoder(opt, embeddings)
 
-        model = onmt.models.model.NMTModel(enc, dec)
+        model = onmt.models.model.NMTModel(enc, dec, 'text')
 
         test_src, test_tgt, test_length = self.get_batch(source_l=source_l,
                                                          bsize=bsize)
@@ -172,7 +172,7 @@ class TestModel(unittest.TestCase):
                                       for_encoder=False)
         dec = build_decoder(opt, embeddings)
 
-        model = onmt.models.model.NMTModel(enc, dec)
+        model = onmt.models.model.NMTModel(enc, dec, 'image')
 
         test_src, test_tgt, test_length = self.get_batch_image(
             h=h, w=w,
@@ -209,7 +209,7 @@ class TestModel(unittest.TestCase):
                                       for_encoder=False)
         dec = build_decoder(opt, embeddings)
 
-        model = onmt.models.model.NMTModel(enc, dec)
+        model = onmt.models.model.NMTModel(enc, dec, 'audio')
 
         test_src, test_tgt, test_length = self.get_batch_audio(
             bsize=bsize,

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -303,7 +303,7 @@ class Translator(object):
             src_lengths = batch.src_lengths
         enc_states, memory_bank = self.model.encoder(src)
         if data_type == 'audio':
-            src_lengths = self.encoder.pooled_lengths
+            src_lengths = self.model.encoder.pooled_lengths
 
         if src_lengths is None:
             assert not isinstance(memory_bank, tuple), \

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -301,8 +301,10 @@ class Translator(object):
             _, src_lengths = batch.src
         elif data_type == 'audio':
             src_lengths = batch.src_lengths
-        enc_states, memory_bank, src_lengths = self.model.encoder(
-            src, src_lengths)
+        enc_states, memory_bank = self.model.encoder(src)
+        if data_type == 'audio':
+            src_lengths = self.encoder.pooled_lengths
+
         if src_lengths is None:
             assert not isinstance(memory_bank, tuple), \
                 'Ensemble decoding only supported for text data'


### PR DESCRIPTION
The initial goal of this pull request was to make all encoders uniform and depend on the EncoderBase class.
Since only AudioEncoder was actually returning a modified "lengths" I just added it in the class itself.

However, I just discovered a major discrepancy between Text encoders (rnn, transf) and Audio/image encoders.

The input src of text encoder is [src_len x batch_size x nfeats] as per the documentation of the EncoderBase Class. For Image and Audio, the input has dimensions and start with batch_size making them different and such not really depending on the EncoderBase class.

Any suggestion or insight of what path to follow ?
@da03 @guillaumekln @bpopeters @srush 
thanks.
Vincent