### PR TITLE
Set file logging level with a new  option

### DIFF
--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -251,6 +251,10 @@ def preprocess_opts(parser):
               help="Report status every this many sentences")
     group.add('--log_file', '-log_file', type=str, default="",
               help="Output logs to a file under this path.")
+    group.add('--log_file_level', '-log_file_level', type=str,
+              action=StoreLoggingLevelAction,
+              choices=StoreLoggingLevelAction.CHOICES,
+              default="0")
 
     # Options most relevant to speech
     group = parser.add_argument_group('Speech')
@@ -446,6 +450,10 @@ def train_opts(parser):
               help="Print stats at this interval.")
     group.add('--log_file', '-log_file', type=str, default="",
               help="Output logs to a file under this path.")
+    group.add('--log_file_level', '-log_file_level', type=str,
+              action=StoreLoggingLevelAction,
+              choices=StoreLoggingLevelAction.CHOICES,
+              default="0")
     group.add('--exp_host', '-exp_host', type=str, default="",
               help="Send logs to this crayon server.")
     group.add('--exp', '-exp', type=str, default="",
@@ -567,6 +575,10 @@ def translate_opts(parser):
               help='Print scores and predictions for each sentence')
     group.add('--log_file', '-log_file', type=str, default="",
               help="Output logs to a file under this path.")
+    group.add('--log_file_level', '-log_file_level', type=str,
+              action=StoreLoggingLevelAction,
+              choices=StoreLoggingLevelAction.CHOICES,
+              default="0")
     group.add('--attn_debug', '-attn_debug', action="store_true",
               help='Print best attn for each word')
     group.add('--dump_beam', '-dump_beam', type=str, default="",
@@ -666,6 +678,30 @@ class MarkdownHelpAction(configargparse.Action):
         parser.formatter_class = MarkdownHelpFormatter
         parser.print_help()
         parser.exit()
+
+
+class StoreLoggingLevelAction(configargparse.Action):
+    """ Convert string to logging level """
+    import logging
+    LEVELS = {
+        "CRITICAL": logging.CRITICAL,
+        "ERROR": logging.ERROR,
+        "WARNING": logging.WARNING,
+        "INFO": logging.INFO,
+        "DEBUG": logging.DEBUG,
+        "NOTSET": logging.NOTSET
+    }
+
+    CHOICES = list(LEVELS.keys()) + [str(_) for _ in LEVELS.values()]
+
+    def __init__(self, option_strings, dest, help=None, **kwargs):
+        super(StoreLoggingLevelAction, self).__init__(
+            option_strings, dest, help=help, **kwargs)
+
+    def __call__(self, parser, namespace, value, option_string=None):
+        # Get the key 'value' in the dict, or just use 'value'
+        level = StoreLoggingLevelAction.LEVELS.get(value, value)
+        setattr(namespace, self.dest, level)
 
 
 class DeprecateAction(configargparse.Action):

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -186,7 +186,8 @@ class ServerModel:
             log_file = os.path.join(model_root, self.opt.log_file)
         else:
             log_file = None
-        self.logger = init_logger(log_file=log_file)
+        self.logger = init_logger(log_file=log_file,
+                                  log_file_level=self.opt.log_file_level)
 
         self.loading_lock = threading.Event()
         self.loading_lock.set()

--- a/onmt/utils/logging.py
+++ b/onmt/utils/logging.py
@@ -6,7 +6,7 @@ import logging
 logger = logging.getLogger()
 
 
-def init_logger(log_file=None):
+def init_logger(log_file=None, log_file_level=logging.NOTSET):
     log_format = logging.Formatter("[%(asctime)s %(levelname)s] %(message)s")
     logger = logging.getLogger()
     logger.setLevel(logging.INFO)
@@ -17,7 +17,7 @@ def init_logger(log_file=None):
 
     if log_file and log_file != '':
         file_handler = logging.FileHandler(log_file)
-        file_handler.setLevel(logging.ERROR)
+        file_handler.setLevel(log_file_level)
         file_handler.setFormatter(log_format)
         logger.addHandler(file_handler)
 


### PR DESCRIPTION
PR: https://github.com/OpenNMT/OpenNMT-py/pull/1062 changed the default behavior (i.e. logging everything to file when `-log_file` is set).

This revert the pre-1062 default behavior and introduce a flag `-file_log_level` in order to set it. 
Both level and numerical values are accepted:

|Level	|  Numeric value|
|---|---|
|CRITICAL |	50 |
|ERROR |	40|
WARNING|	30
INFO|	20
DEBUG|	10
NOTSET	|0

