### PR TITLE
Fix attention option when using fast beam search 

### DIFF
--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -188,7 +188,7 @@ class Translator(object):
         all_predictions = []
 
         for batch in data_iter:
-            batch_data = self.translate_batch(batch, data, fast=self.fast)
+            batch_data = self.translate_batch(batch, data, attn_debug, fast=self.fast)
             translations = builder.from_batch(batch_data)
 
             for trans in translations:
@@ -268,7 +268,7 @@ class Translator(object):
                       codecs.open(self.dump_beam, 'w', 'utf-8'))
         return all_scores, all_predictions
 
-    def translate_batch(self, batch, data, fast=False):
+    def translate_batch(self, batch, data, attn_debug, fast=False):
         """
         Translate a batch of sentences.
 
@@ -289,7 +289,8 @@ class Translator(object):
                     data,
                     self.max_length,
                     min_length=self.min_length,
-                    n_best=self.n_best)
+                    n_best=self.n_best,
+                    return_attention=attn_debug or self.replace_unk)
             else:
                 return self._translate_batch(batch, data)
 
@@ -366,7 +367,7 @@ class Translator(object):
                               max_length,
                               min_length=0,
                               n_best=1,
-                              return_attention=True):
+                              return_attention=False):
         # TODO: faster code path for beam_size == 1.
 
         # TODO: support these blacklisted features.

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -289,8 +289,7 @@ class Translator(object):
                     data,
                     self.max_length,
                     min_length=self.min_length,
-                    n_best=self.n_best,
-                    return_attention=self.replace_unk)
+                    n_best=self.n_best)
             else:
                 return self._translate_batch(batch, data)
 
@@ -367,7 +366,7 @@ class Translator(object):
                               max_length,
                               min_length=0,
                               n_best=1,
-                              return_attention=False):
+                              return_attention=True):
         # TODO: faster code path for beam_size == 1.
 
         # TODO: support these blacklisted features.

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -188,7 +188,8 @@ class Translator(object):
         all_predictions = []
 
         for batch in data_iter:
-            batch_data = self.translate_batch(batch, data, attn_debug, fast=self.fast)
+            batch_data = self.translate_batch(batch, data, attn_debug,
+                                              fast=self.fast)
             translations = builder.from_batch(batch_data)
 
             for trans in translations:


### PR DESCRIPTION
This PR fixes `-attn_debug` option for `-fast` mode. It seems that `-attn_debug -fast` is conditioned with `-replace_unk`, which is unnecessary in my understanding.

Specifically, `def translate_batch` from `onmt/translate/translator.py` calls `def _fast_translate_batch` with `return_attention=self.replace_unk`. Therefore, enabling `-attn_debug -fast` without using `-replace_unk` ends up returning no attention, which raises an error at the `if attn_debug` block.

I suspect that original intention here was making `-replace_unk` dependent of `-attn_debug`, but `-attn_debug` itself should be a standalone option. How do you think @guillaumekln ?

(btw, thanks for refining the previous PR!)