### PR TITLE
Only cache projections in Transformer state

### DIFF
--- a/onmt/decoders/cnn_decoder.py
+++ b/onmt/decoders/cnn_decoder.py
@@ -56,7 +56,7 @@ class CNNDecoder(nn.Module):
                 hidden_size, attn_type=attn_type)
             self._copy = True
 
-    def init_state(self, _, memory_bank, enc_hidden, with_cache=False):
+    def init_state(self, _, memory_bank, enc_hidden):
         """
         Init decoder state.
         """

--- a/onmt/decoders/decoder.py
+++ b/onmt/decoders/decoder.py
@@ -105,7 +105,7 @@ class RNNDecoderBase(nn.Module):
             self._copy = True
         self._reuse_copy_attn = reuse_copy_attn
 
-    def init_state(self, src, memory_bank, encoder_final, with_cache=False):
+    def init_state(self, src, memory_bank, encoder_final):
         """ Init decoder state with last state of the encoder """
         def _fix_enc_hidden(hidden):
             # The encoder hidden is  (layers*directions) x batch x dim.

--- a/onmt/decoders/ensemble.py
+++ b/onmt/decoders/ensemble.py
@@ -69,11 +69,10 @@ class EnsembleDecoder(nn.Module):
             result[key] = torch.stack([attn[key] for attn in attns]).mean(0)
         return result
 
-    def init_state(self, src, memory_bank, enc_hidden, with_cache=False):
+    def init_state(self, src, memory_bank, enc_hidden):
         """ See :obj:`RNNDecoderBase.init_state()` """
         for i, model_decoder in enumerate(self.model_decoders):
-            model_decoder.init_state(src, memory_bank[i],
-                                     enc_hidden[i], with_cache)
+            model_decoder.init_state(src, memory_bank[i], enc_hidden[i])
 
     def map_state(self, fn):
         for model_decoder in self.model_decoders:

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -386,8 +386,7 @@ class Translator(object):
         # Encoder forward.
         src, enc_states, memory_bank, src_lengths = self._run_encoder(
             batch, data.data_type)
-        self.model.decoder.init_state(
-            src, memory_bank, enc_states, with_cache=True)
+        self.model.decoder.init_state(src, memory_bank, enc_states)
 
         results = {}
         results["predictions"] = [[] for _ in range(batch_size)]  # noqa: F812
@@ -398,8 +397,7 @@ class Translator(object):
             results["gold_score"] = self._score_target(
                 batch, memory_bank, src_lengths, data, batch.src_map
                 if data.data_type == 'text' and self.copy_attn else None)
-            self.model.decoder.init_state(
-                src, memory_bank, enc_states, with_cache=True)
+            self.model.decoder.init_state(src, memory_bank, enc_states)
         else:
             results["gold_score"] = [0] * batch_size
 
@@ -605,8 +603,7 @@ class Translator(object):
             results["gold_score"] = self._score_target(
                 batch, memory_bank, src_lengths, data, batch.src_map
                 if data_type == 'text' and self.copy_attn else None)
-            self.model.decoder.init_state(
-                src, memory_bank, enc_states, with_cache=True)
+            self.model.decoder.init_state(src, memory_bank, enc_states)
         else:
             results["gold_score"] = [0] * batch_size
 


### PR DESCRIPTION
Both translation paths now set `with_cache=True` (non fast beam search had to wait for https://github.com/OpenNMT/OpenNMT-py/commit/9fef5b223067fc92eb4dae34caf5d4d8ac2683e3 which added batched gathering of the decoder state), so let's cleanup the Transformer state to reflect that. 