### PR TITLE
reduce valid batch size in summarization tutorial

### DIFF
--- a/docs/source/Summarization.md
+++ b/docs/source/Summarization.md
@@ -100,6 +100,7 @@ python train.py -save_model models/cnndm \
                 -max_grad_norm 2 \
                 -dropout 0. \
                 -batch_size 16 \
+                -valid_batch_size 16 \
                 -optim adagrad \
                 -learning_rate 0.15 \
                 -adagrad_accumulator_init 0.1 \


### PR DESCRIPTION
After running into the same issue as https://github.com/OpenNMT/OpenNMT-py/issues/476 when computing the validation scores, reducing the validation batch size just solved the problem.