### PR TITLE
Simplify get_fields

### DIFF
--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -9,10 +9,8 @@ import io
 from tqdm import tqdm
 
 import torch
-import torchtext
 
-from onmt.inputters.dataset_base import DatasetBase, PAD_WORD, BOS_WORD, \
-    EOS_WORD
+from onmt.inputters.dataset_base import DatasetBase
 
 
 class AudioDataset(DatasetBase):
@@ -190,57 +188,6 @@ class AudioDataset(DatasetBase):
                 index += 1
 
                 yield example_dict
-
-    @staticmethod
-    def get_fields(n_src_features, n_tgt_features):
-        """
-        Args:
-            n_src_features: the number of source features to
-                create `torchtext.data.Field` for.
-            n_tgt_features: the number of target features to
-                create `torchtext.data.Field` for.
-
-        Returns:
-            A dictionary whose keys are strings and whose values
-            are the corresponding Field objects.
-        """
-        fields = {}
-
-        def make_audio(data, vocab):
-            """ batch audio data """
-            nfft = data[0].size(0)
-            t = max([t.size(1) for t in data])
-            sounds = torch.zeros(len(data), 1, nfft, t)
-            for i, spect in enumerate(data):
-                sounds[i, :, :, 0:spect.size(1)] = spect
-            return sounds
-
-        fields["src"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.float,
-            postprocessing=make_audio, sequential=False)
-
-        fields["src_lengths"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.long,
-            sequential=False)
-
-        for j in range(n_src_features):
-            fields["src_feat_" + str(j)] = \
-                torchtext.data.Field(pad_token=PAD_WORD)
-
-        fields["tgt"] = torchtext.data.Field(
-            init_token=BOS_WORD, eos_token=EOS_WORD,
-            pad_token=PAD_WORD)
-
-        for j in range(n_tgt_features):
-            fields["tgt_feat_" + str(j)] = \
-                torchtext.data.Field(init_token=BOS_WORD, eos_token=EOS_WORD,
-                                     pad_token=PAD_WORD)
-
-        fields["indices"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.long,
-            sequential=False)
-
-        return fields
 
     @staticmethod
     def get_num_features(corpus_file, side):

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -10,8 +10,7 @@ import sys
 import torch
 import torchtext
 
-from onmt.inputters.dataset_base import (DatasetBase, UNK_WORD,
-                                         PAD_WORD, BOS_WORD, EOS_WORD)
+from onmt.inputters.dataset_base import DatasetBase, UNK_WORD, PAD_WORD
 from onmt.utils.misc import aeq
 
 
@@ -202,70 +201,6 @@ class TextDataset(DatasetBase):
         with codecs.open(path, "r", "utf-8") as corpus_file:
             for line in corpus_file:
                 yield line
-
-    @staticmethod
-    def get_fields(n_src_features, n_tgt_features):
-        """
-        Args:
-            n_src_features (int): the number of source features to
-                create `torchtext.data.Field` for.
-            n_tgt_features (int): the number of target features to
-                create `torchtext.data.Field` for.
-
-        Returns:
-            A dictionary whose keys are strings and whose values
-            are the corresponding Field objects.
-        """
-        fields = {}
-
-        fields["src"] = torchtext.data.Field(
-            pad_token=PAD_WORD,
-            include_lengths=True)
-
-        for j in range(n_src_features):
-            fields["src_feat_" + str(j)] = \
-                torchtext.data.Field(pad_token=PAD_WORD)
-
-        fields["tgt"] = torchtext.data.Field(
-            init_token=BOS_WORD, eos_token=EOS_WORD,
-            pad_token=PAD_WORD)
-
-        for j in range(n_tgt_features):
-            fields["tgt_feat_" + str(j)] = \
-                torchtext.data.Field(init_token=BOS_WORD, eos_token=EOS_WORD,
-                                     pad_token=PAD_WORD)
-
-        def make_src(data, vocab):
-            """ ? """
-            src_size = max([t.size(0) for t in data])
-            src_vocab_size = max([t.max() for t in data]) + 1
-            alignment = torch.zeros(src_size, len(data), src_vocab_size)
-            for i, sent in enumerate(data):
-                for j, t in enumerate(sent):
-                    alignment[j, i, t] = 1
-            return alignment
-
-        fields["src_map"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.float,
-            postprocessing=make_src, sequential=False)
-
-        def make_tgt(data, vocab):
-            """ ? """
-            tgt_size = max([t.size(0) for t in data])
-            alignment = torch.zeros(tgt_size, len(data)).long()
-            for i, sent in enumerate(data):
-                alignment[:sent.size(0), i] = sent
-            return alignment
-
-        fields["alignment"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.long,
-            postprocessing=make_tgt, sequential=False)
-
-        fields["indices"] = torchtext.data.Field(
-            use_vocab=False, dtype=torch.long,
-            sequential=False)
-
-        return fields
 
     @staticmethod
     def get_num_features(corpus_file, side):


### PR DESCRIPTION
A current interest of mine is making the I/O code clearer and more flexible so that it's easier to specify new data sources, methods of tokenizing, and so on. It also doesn't look very much like the more idiomatic examples of torchtext you can find in various places, and I think it would be great if we could change that.

To that end, this pull request removes the `get_fields` static methods from various `*Dataset` classes and puts it in the `get_fields` function in `inputters.py`. For one thing, there was a lot of reduplicated code between them. For another thing, in general torchtext practice, the fields are a parameter of a dataset instance. They should be pretty modular, so it's easy to for example replace one kind of source field with a different one that tokenizes in a different way. Our current dataset classes depart from that philosophy by having a static method on each class that produces the particular kinds of fields the class is supposed to take. This is less modular.