### PR TITLE
Remove unnecessary feature-related code, share more between datasets

### DIFF
--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -53,10 +53,9 @@ class AudioDataset(DatasetBase):
         super(AudioDataset, self).__init__(examples, fields, filter_pred)
 
     @staticmethod
-    def make_audio_examples_nfeats_tpl(path, audio_dir,
-                                       sample_rate, window_size,
-                                       window_stride, window,
-                                       normalize_audio, truncate=None):
+    def make_audio_examples(path, audio_dir, sample_rate, window_size,
+                            window_stride, window, normalize_audio,
+                            truncate=None):
         """
         Args:
             path (str): location of a src file containing audio paths.
@@ -77,7 +76,7 @@ class AudioDataset(DatasetBase):
             window_size, window_stride, window,
             normalize_audio, truncate)
 
-        return examples_iter, 0
+        return examples_iter
 
     @staticmethod
     def extract_features(audio_path, sample_rate, truncate, window_size,

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -69,7 +69,7 @@ class AudioDataset(DatasetBase):
             truncate (int): maximum audio length (0 or None for unlimited).
 
         Returns:
-            (example_dict iterator, num_feats) tuple
+            example_dict iterator
         """
         examples_iter = AudioDataset.read_audio_file(
             path, audio_dir, "src", sample_rate,
@@ -157,27 +157,6 @@ class AudioDataset(DatasetBase):
 
                 yield {side: spect, side + '_path': line.strip(),
                        side + '_lengths': spect.size(1), 'indices': i}
-
-    @staticmethod
-    def get_num_features(corpus_file, side):
-        """
-        For audio corpus, source side is in form of audio, thus
-        no feature; while target side is in form of text, thus
-        we can extract its text features.
-
-        Args:
-            corpus_file (str): file path to get the features.
-            side (str): 'src' or 'tgt'.
-
-        Returns:
-            number of features on `side`.
-        """
-        if side == 'src':
-            return 0
-        with codecs.open(corpus_file, "r", "utf-8") as cf:
-            f_line = cf.readline().strip().split()
-            _, _, num_feats = AudioDataset.extract_text_features(f_line)
-            return num_feats
 
 
 class ShardedAudioCorpusIterator(object):

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -7,10 +7,10 @@ from tqdm import tqdm
 
 import torch
 
-from onmt.inputters.dataset_base import DatasetBase
+from onmt.inputters.dataset_base import AudioVisualDataset
 
 
-class AudioDataset(DatasetBase):
+class AudioDataset(AudioVisualDataset):
     """ Dataset for data_type=='audio'
 
         Build `Example` objects, `Field` objects, and filter_pred function
@@ -26,31 +26,12 @@ class AudioDataset(DatasetBase):
             use_filter_pred (bool): use a custom filter predicate to filter
                 out examples?
     """
+    data_type = 'audio'  # get rid of this class attribute asap
+
     @staticmethod
     def sort_key(ex):
         """ Sort using duration time of the sound spectrogram. """
         return ex.src.size(1)
-
-    def __init__(self, fields, src_examples_iter, tgt_examples_iter,
-                 filter_pred=None):
-        self.data_type = 'audio'
-
-        if tgt_examples_iter is not None:
-            examples_iter = (self._join_dicts(src, tgt) for src, tgt in
-                             zip(src_examples_iter, tgt_examples_iter))
-        else:
-            examples_iter = src_examples_iter
-
-        # Peek at the first to see which fields are used.
-        ex, examples_iter = self._peek(examples_iter)
-        keys = ex.keys()
-
-        fields = [(k, fields[k]) if k in fields else (k, None) for k in keys]
-        example_values = ([ex[k] for k in keys] for ex in examples_iter)
-        examples = [self._construct_example_fromlist(ex_values, fields)
-                    for ex_values in example_values]
-
-        super(AudioDataset, self).__init__(examples, fields, filter_pred)
 
     @staticmethod
     def make_audio_examples(path, audio_dir, sample_rate, window_size,

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -11,21 +11,6 @@ from onmt.inputters.dataset_base import AudioVisualDataset
 
 
 class AudioDataset(AudioVisualDataset):
-    """ Dataset for data_type=='audio'
-
-        Build `Example` objects, `Field` objects, and filter_pred function
-        from audio corpus.
-
-        Args:
-            fields (dict): a dictionary of `torchtext.data.Field`.
-            src_examples_iter (dict iter): preprocessed source example
-                dictionary iterator.
-            tgt_examples_iter (dict iter): preprocessed target example
-                dictionary iterator.
-            tgt_seq_length (int): maximum target sequence length.
-            use_filter_pred (bool): use a custom filter predicate to filter
-                out examples?
-    """
     data_type = 'audio'  # get rid of this class attribute asap
 
     @staticmethod

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -34,8 +34,6 @@ class AudioDataset(DatasetBase):
     def __init__(self, fields, src_examples_iter, tgt_examples_iter,
                  filter_pred=None):
         self.data_type = 'audio'
-        self.n_src_feats = 0
-        self.n_tgt_feats = 0
 
         if tgt_examples_iter is not None:
             examples_iter = (self._join_dicts(src, tgt) for src, tgt in

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -7,8 +7,6 @@ from itertools import chain
 import torch
 import torchtext
 
-import onmt
-
 PAD_WORD = '<blank>'
 UNK_WORD = '<unk>'
 UNK = 0
@@ -44,17 +42,6 @@ class DatasetBase(torchtext.data.Dataset):
         if remove_fields:
             self.fields = []
         torch.save(self, path)
-
-    def load_fields(self, vocab_dict):
-        """ Load fields from vocab.pt, and set the `fields` attribute.
-
-        Args:
-            vocab_dict (dict): a dict of loaded vocab from vocab.pt file.
-        """
-        fields = onmt.inputters.inputter.load_fields_from_vocab(
-            vocab_dict.items(), self.data_type)
-        self.fields = dict([(k, f) for (k, f) in fields.items()
-                            if k in self.examples[0].__dict__])
 
     @staticmethod
     def extract_text_features(tokens):

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -115,3 +115,25 @@ class DatasetBase(torchtext.data.Dataset):
             else:
                 setattr(ex, name, val)
         return ex
+
+
+# this is just temporary until the TextDatabase can be unified with the others
+class AudioVisualDataset(DatasetBase):
+    def __init__(self, fields, src_examples_iter, tgt_examples_iter,
+                 filter_pred=None):
+        if tgt_examples_iter is not None:
+            examples_iter = (self._join_dicts(src, tgt) for src, tgt in
+                             zip(src_examples_iter, tgt_examples_iter))
+        else:
+            examples_iter = src_examples_iter
+
+        # Peek at the first to see which fields are used.
+        ex, examples_iter = self._peek(examples_iter)
+        keys = ex.keys()
+
+        fields = [(k, fields[k]) if k in fields else (k, None) for k in keys]
+        example_values = ([ex[k] for k in keys] for ex in examples_iter)
+        examples = [self._construct_example_fromlist(ex_values, fields)
+                    for ex_values in example_values]
+
+        super(DatasetBase, self).__init__(examples, fields, filter_pred)

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -119,6 +119,15 @@ class DatasetBase(torchtext.data.Dataset):
 
 # this is just temporary until the TextDatabase can be unified with the others
 class AudioVisualDataset(DatasetBase):
+    """
+    Args:
+            fields (dict): a dictionary of `torchtext.data.Field`.
+            src_examples_iter (dict iter): preprocessed source example
+                dictionary iterator.
+            tgt_examples_iter (dict iter): preprocessed target example
+                dictionary iterator.
+            tgt_seq_length (int): maximum target sequence length.
+    """
     def __init__(self, fields, src_examples_iter, tgt_examples_iter,
                  filter_pred=None):
         if tgt_examples_iter is not None:

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -1,7 +1,5 @@
 # coding: utf-8
-"""
-    Base dataset class and constants
-"""
+
 from itertools import chain
 
 import torch

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -29,12 +29,8 @@ class ImageDataset(DatasetBase):
         return ex.src.size(2), ex.src.size(1)
 
     def __init__(self, fields, src_examples_iter, tgt_examples_iter,
-                 num_src_feats=0, num_tgt_feats=0,
                  filter_pred=None, image_channel_size=3):
         self.data_type = 'img'
-
-        self.n_src_feats = num_src_feats
-        self.n_tgt_feats = num_tgt_feats
 
         self.image_channel_size = image_channel_size
         if tgt_examples_iter is not None:

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -62,7 +62,7 @@ class ImageDataset(DatasetBase):
             src_dir (str): location of source images
 
         Returns:
-            (example_dict iterator, num_feats) tuple
+            example_dict iterator
         """
         if img_iter is None and img_path is None:
             raise ValueError("Either img_iter or img_path must be non-None")
@@ -128,24 +128,3 @@ class ImageDataset(DatasetBase):
                     img = transforms.ToTensor()(Image.open(img_path))
 
                 yield img, filename
-
-    @staticmethod
-    def get_num_features(corpus_file, side):
-        """
-        For image corpus, source side is in form of image, thus
-        no feature; while target side is in form of text, thus
-        we can extract its text features.
-
-        Args:
-            corpus_file (str): file path to get the features.
-            side (str): 'src' or 'tgt'.
-
-        Returns:
-            number of features on `side`.
-        """
-        if side == 'src':
-            return 0
-        with codecs.open(corpus_file, "r", "utf-8") as cf:
-            f_line = cf.readline().strip().split()
-            _, _, num_feats = ImageDataset.extract_text_features(f_line)
-            return num_feats

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -51,8 +51,7 @@ class ImageDataset(DatasetBase):
         super(ImageDataset, self).__init__(examples, fields, filter_pred)
 
     @staticmethod
-    def make_image_examples_nfeats_tpl(img_iter, img_path, img_dir,
-                                       image_channel_size=3):
+    def make_image_examples(img_iter, img_path, img_dir, image_channel_size=3):
         """
         Note: one of img_iter and img_path must be not None
         Args:
@@ -74,7 +73,7 @@ class ImageDataset(DatasetBase):
 
         examples_iter = ImageDataset.make_examples(img_iter, img_dir, 'src')
 
-        return examples_iter, 0
+        return examples_iter
 
     @staticmethod
     def make_examples(img_iter, src_dir, side, truncate=None):

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -7,22 +7,6 @@ from onmt.inputters.dataset_base import AudioVisualDataset
 
 
 class ImageDataset(AudioVisualDataset):
-    """
-    Build `Example` objects, `Field` objects, and filter_pred function
-    from image corpus.
-
-    Args:
-        fields (dict): a dictionary of `torchtext.data.Field`.
-        src_examples_iter (dict iter): preprocessed source example
-            dictionary iterator.
-        tgt_examples_iter (dict iter): preprocessed target example
-            dictionary iterator.
-        num_src_feats (int): number of source side features.
-        num_tgt_feats (int): number of target side features.
-        tgt_seq_length (int): maximum target sequence length.
-        use_filter_pred (bool): use a custom filter predicate to filter
-            out examples?
-    """
     data_type = 'img'  # get rid of this class attribute asap
 
     @staticmethod

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -3,10 +3,10 @@
 import codecs
 import os
 
-from onmt.inputters.dataset_base import DatasetBase
+from onmt.inputters.dataset_base import AudioVisualDataset
 
 
-class ImageDataset(DatasetBase):
+class ImageDataset(AudioVisualDataset):
     """
     Build `Example` objects, `Field` objects, and filter_pred function
     from image corpus.
@@ -23,32 +23,12 @@ class ImageDataset(DatasetBase):
         use_filter_pred (bool): use a custom filter predicate to filter
             out examples?
     """
+    data_type = 'img'  # get rid of this class attribute asap
+
     @staticmethod
     def sort_key(ex):
         """ Sort using the size of the image: (width, height)."""
         return ex.src.size(2), ex.src.size(1)
-
-    def __init__(self, fields, src_examples_iter, tgt_examples_iter,
-                 filter_pred=None, image_channel_size=3):
-        self.data_type = 'img'
-
-        self.image_channel_size = image_channel_size
-        if tgt_examples_iter is not None:
-            examples_iter = (self._join_dicts(src, tgt) for src, tgt in
-                             zip(src_examples_iter, tgt_examples_iter))
-        else:
-            examples_iter = src_examples_iter
-
-        # Peek at the first to see which fields are used.
-        ex, examples_iter = self._peek(examples_iter)
-        keys = ex.keys()
-
-        fields = [(k, fields[k]) if k in fields else (k, None) for k in keys]
-        example_values = ([ex[k] for k in keys] for ex in examples_iter)
-        examples = [self._construct_example_fromlist(ex_values, fields)
-                    for ex_values in example_values]
-
-        super(ImageDataset, self).__init__(examples, fields, filter_pred)
 
     @staticmethod
     def make_image_examples(img_iter, img_path, img_dir, image_channel_size=3):

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -339,15 +339,12 @@ def build_dataset(fields, data_type, src_data_iter=None, src_path=None,
         dataset = TextDataset(
             fields, src_examples_iter, tgt_examples_iter,
             dynamic_dict=dynamic_dict, filter_pred=filter_pred)
-    elif data_type == 'img':
-        dataset = ImageDataset(
+    else:
+        dataset_cls = ImageDataset if data_type == 'img' else AudioDataset
+        dataset = dataset_cls(
             fields, src_examples_iter, tgt_examples_iter,
-            filter_pred=filter_pred, image_channel_size=image_channel_size)
-    elif data_type == 'audio':
-        dataset = AudioDataset(
-            fields, src_examples_iter, tgt_examples_iter,
-            filter_pred=filter_pred)
-
+            filter_pred=filter_pred
+        )
     return dataset
 
 

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -303,52 +303,29 @@ def build_dataset(fields, data_type, src_data_iter=None, src_path=None,
     number of features.
     """
 
-    def _make_examples_nfeats_tpl(data_type, src_data_iter, src_path, src_dir,
-                                  src_seq_length_trunc, sample_rate,
-                                  window_size, window_stride,
-                                  window, normalize_audio,
-                                  image_channel_size=3):
-        """
-        Process the corpus into (example_dict iterator, num_feats) tuple
-        on source side for different 'data_type'.
-        """
+    if data_type == 'text':
+        src_examples_iter = TextDataset.make_text_examples(
+            src_data_iter, src_path, src_seq_length_trunc, "src"
+        )
+    elif data_type == 'img':
+        src_examples_iter = ImageDataset.make_image_examples(
+            src_data_iter, src_path, src_dir, image_channel_size)
 
-        if data_type == 'text':
-            src_examples_iter, num_src_feats = \
-                TextDataset.make_text_examples_nfeats_tpl(
-                    src_data_iter, src_path, src_seq_length_trunc, "src")
-
-        elif data_type == 'img':
-            src_examples_iter, num_src_feats = \
-                ImageDataset.make_image_examples_nfeats_tpl(
-                    src_data_iter, src_path, src_dir, image_channel_size)
-
-        elif data_type == 'audio':
-            if src_data_iter:
-                raise ValueError("""Data iterator for AudioDataset isn't
-                                    implemented""")
-
-            if src_path is None:
-                raise ValueError("AudioDataset requires a non None path")
-            src_examples_iter, num_src_feats = \
-                AudioDataset.make_audio_examples_nfeats_tpl(
-                    src_path, src_dir, sample_rate,
-                    window_size, window_stride, window,
-                    normalize_audio)
-
-        return src_examples_iter, num_src_feats
-
-    src_examples_iter, num_src_feats = \
-        _make_examples_nfeats_tpl(data_type, src_data_iter, src_path, src_dir,
-                                  src_seq_length_trunc, sample_rate,
-                                  window_size, window_stride,
-                                  window, normalize_audio,
-                                  image_channel_size=image_channel_size)
+    elif data_type == 'audio':
+        if src_data_iter:
+            raise ValueError("""Data iterator for AudioDataset isn't
+                                implemented""")
+        if src_path is None:
+            raise ValueError("AudioDataset requires a non None path")
+        src_examples_iter = AudioDataset.make_audio_examples(
+            src_path, src_dir, sample_rate, window_size, window_stride,
+            window, normalize_audio
+        )
 
     # For all data types, the tgt side corpus is in form of text.
-    tgt_examples_iter, num_tgt_feats = \
-        TextDataset.make_text_examples_nfeats_tpl(
-            tgt_data_iter, tgt_path, tgt_seq_length_trunc, "tgt")
+    tgt_examples_iter = TextDataset.make_text_examples(
+        tgt_data_iter, tgt_path, tgt_seq_length_trunc, "tgt"
+    )
 
     # I'm not certain about the practical utility of the second part
     if use_filter_pred and tgt_examples_iter is not None:

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -185,27 +185,26 @@ def merge_vocabs(vocabs, vocab_size=None, min_frequency=1):
                                  min_freq=min_frequency)
 
 
-def get_num_features(data_type, corpus_file, side):
+def get_num_features(src_data_type, corpus_file, side):
     """
     Args:
-        data_type (str): type of the source input.
-            Options are [text|img|audio].
+        src_data_type (str): ['text'|'img'|'audio']
         corpus_file (str): file path to get the features.
-        side (str): for source or for target.
+        side (str): src or tgt
 
     Returns:
         number of features on `side`.
     """
     assert side in ["src", "tgt"]
-
-    if data_type == 'text':
-        return TextDataset.get_num_features(corpus_file, side)
-    elif data_type == 'img':
-        return ImageDataset.get_num_features(corpus_file, side)
-    elif data_type == 'audio':
-        return AudioDataset.get_num_features(corpus_file, side)
+    assert src_data_type in ['text', 'img', 'audio'], \
+        "Data type not implemented"
+    if side == 'src' and src_data_type != 'text':
+        return 0  # no features for non-text
     else:
-        raise ValueError("Data type not implemented")
+        with codecs.open(corpus_file, "r", "utf-8") as f:
+            line = f.readline().strip().split()
+            _, _, n_feats = TextDataset.extract_text_features(line)
+            return n_feats
 
 
 def make_features(batch, side, data_type='text'):

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -108,7 +108,7 @@ class TextDataset(DatasetBase):
             side (str): "src" or "tgt".
 
         Returns:
-            (example_dict iterator, num_feats) tuple.
+            example_dict iterator
         """
         # this will probably be removed soon
         assert side in ['src', 'tgt']
@@ -139,7 +139,7 @@ class TextDataset(DatasetBase):
             if truncate:
                 line = line[:truncate]
 
-            words, feats, n_feats = TextDataset.extract_text_features(line)
+            words, feats, _ = TextDataset.extract_text_features(line)
 
             example_dict = {side: words, "indices": i}
             if feats:
@@ -153,27 +153,6 @@ class TextDataset(DatasetBase):
         with codecs.open(path, "r", "utf-8") as corpus_file:
             for line in corpus_file:
                 yield line
-
-    @staticmethod
-    def get_num_features(corpus_file, side):
-        """
-        Peek one line and get number of features of it.
-        (All lines must have same number of features).
-        For text corpus, both sides are in text form, thus
-        it works the same.
-
-        Args:
-            corpus_file (str): file path to get the features.
-            side (str): 'src' or 'tgt'.
-
-        Returns:
-            number of features on `side`.
-        """
-        with codecs.open(corpus_file, "r", "utf-8") as cf:
-            f_line = cf.readline().strip().split()
-            _, _, num_feats = TextDataset.extract_text_features(f_line)
-
-        return num_feats
 
     def _dynamic_dict(self, examples_iter):
         for example in examples_iter:

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -24,9 +24,7 @@ class TextDataset(DatasetBase):
             dictionary iterator.
         tgt_examples_iter (dict iter): preprocessed target example
             dictionary iterator.
-        num_src_feats (int): number of source side features.
-        num_tgt_feats (int): number of target side features.
-        dynamic_dict (bool): create dynamic dictionaries?
+        dynamic_dict (bool)
     """
     data_type = 'text'  # get rid of this class attribute asap
 

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -36,16 +36,12 @@ class TextDataset(DatasetBase):
         return len(ex.src)
 
     def __init__(self, fields, src_examples_iter, tgt_examples_iter,
-                 num_src_feats=0, num_tgt_feats=0,
                  dynamic_dict=True, filter_pred=None):
         self.data_type = 'text'
 
         # self.src_vocabs: mutated in dynamic_dict, used in
         # collapse_copy_scores and in Translator.py
         self.src_vocabs = []
-
-        self.n_src_feats = num_src_feats
-        self.n_tgt_feats = num_tgt_feats
 
         # Each element of an example is a dictionary whose keys represents
         # at minimum the src tokens and their indices and potentially also

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -28,6 +28,8 @@ class TextDataset(DatasetBase):
         num_tgt_feats (int): number of target side features.
         dynamic_dict (bool): create dynamic dictionaries?
     """
+    data_type = 'text'  # get rid of this class attribute asap
+
     @staticmethod
     def sort_key(ex):
         if hasattr(ex, "tgt"):
@@ -36,8 +38,6 @@ class TextDataset(DatasetBase):
 
     def __init__(self, fields, src_examples_iter, tgt_examples_iter,
                  dynamic_dict=True, filter_pred=None):
-        self.data_type = 'text'
-
         # self.src_vocabs: mutated in dynamic_dict, used in
         # collapse_copy_scores and in Translator.py
         self.src_vocabs = []


### PR DESCRIPTION
This PR removes a great deal of code related to numbers of source and target features from datasets. A dataset does not actually need to know how many features the examples it contains have.

It also shares more code between various DatasetBase subclasses, somewhat lessening the copy-pasting problem I alluded to earlier.

I also changed a few small stylistic things where I saw fit.