### PR TITLE
Do not filter validation data by default

### DIFF
--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -197,23 +197,22 @@ def collect_features(fields, side="src"):
     return feats
 
 
-# min_len is misnamed
 def filter_example(ex, use_src_len=True, use_tgt_len=True,
-                   min_src_len=0, max_src_len=float('inf'),
-                   min_tgt_len=0, max_tgt_len=float('inf')):
+                   min_src_len=1, max_src_len=float('inf'),
+                   min_tgt_len=1, max_tgt_len=float('inf')):
     """
     A generalized function for filtering examples based on the length of their
     src or tgt values. Rather than being used by itself as the filter_pred
     argument to a dataset, it should be partially evaluated with everything
     specified except the value of the example.
     """
-    return (not use_src_len or min_src_len < len(ex.src) <= max_src_len) and \
-        (not use_tgt_len or min_tgt_len < len(ex.tgt) <= max_tgt_len)
+    return (not use_src_len or min_src_len <= len(ex.src) <= max_src_len) and \
+        (not use_tgt_len or min_tgt_len <= len(ex.tgt) <= max_tgt_len)
 
 
 def build_dataset(fields, data_type, src_data_iter=None, src_path=None,
                   src_dir=None, tgt_data_iter=None, tgt_path=None,
-                  src_seq_len=0, tgt_seq_len=0,
+                  src_seq_len=50, tgt_seq_len=50,
                   src_seq_length_trunc=0, tgt_seq_length_trunc=0,
                   dynamic_dict=True, sample_rate=0,
                   window_size=0, window_stride=0, window=None,

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -238,6 +238,8 @@ def preprocess_opts(parser):
               type=int, default=0,
               help="Truncate target sequence length.")
     group.add('--lower', '-lower', action='store_true', help='lowercase data')
+    group.add('--filter_valid', '-filter_valid', action='store_true',
+              help='Filter validation data by src and/or tgt length')
 
     # Data processing options
     group = parser.add_argument_group('Random')

--- a/preprocess.py
+++ b/preprocess.py
@@ -109,7 +109,7 @@ def build_save_dataset(corpus_type, fields, opt):
             window_stride=opt.window_stride,
             window=opt.window,
             image_channel_size=opt.image_channel_size,
-            use_filter_pred=corpus_type == 'train'
+            use_filter_pred=corpus_type == 'train' or opt.filter_valid
         )
 
         data_path = "{:s}.{:s}.{:d}.pt".format(opt.save_data, corpus_type, i)

--- a/preprocess.py
+++ b/preprocess.py
@@ -108,7 +108,8 @@ def build_save_dataset(corpus_type, fields, opt):
             window_size=opt.window_size,
             window_stride=opt.window_stride,
             window=opt.window,
-            image_channel_size=opt.image_channel_size
+            image_channel_size=opt.image_channel_size,
+            use_filter_pred=corpus_type == 'train'
         )
 
         data_path = "{:s}.{:s}.{:d}.pt".format(opt.save_data, corpus_type, i)


### PR DESCRIPTION
These changes related to the behavior when preprocessing the validation data. Previously, the validation data would be filtered by length and there was no way to change this option. This PR makes it so that by default the validation data is _not_ filtered unless preprocess.py is called with `-filter_valid`, in which case the validation is filtered with the same parameters as the train set.

The PR also very slightly changes the meanings of certain parameters of `filter_example` which were misnomers, and gives `build_dataset`'s filtering-related parameters more sensible defaults.