### PR TITLE
Exit early if src/tgt files do not exist

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -161,6 +161,12 @@ def main():
         "-shuffle is not implemented. Please shuffle \
         your data before pre-processing."
 
+    assert os.path.isfile(opt.train_src) and os.path.isfile(opt.train_tgt), \
+        "Please check path of your train src and tgt files!"
+
+    assert os.path.isfile(opt.valid_src) and os.path.isfile(opt.valid_tgt), \
+        "Please check path of your valid src and tgt files!"
+
     init_logger(opt.log_file)
     logger.info("Extracting features...")
 


### PR DESCRIPTION
Handful of times I've preprocessed train files correctly only to realize at a later point that my path to valid files were wrong, do file exists check early on! Minor nit 