### PR TITLE
fix for Not restoring state correctly during truncated bptt #1164

### DIFF
--- a/onmt/models/model.py
+++ b/onmt/models/model.py
@@ -18,7 +18,7 @@ class NMTModel(nn.Module):
         self.encoder = encoder
         self.decoder = decoder
 
-    def forward(self, src, tgt, lengths, dec_state=None):
+    def forward(self, src, tgt, lengths, bptt=False):
         """Forward propagate a `src` and `tgt` pair for training.
         Possible initialized with a beginning decoder state.
 
@@ -31,6 +31,9 @@ class NMTModel(nn.Module):
             tgt (:obj:`LongTensor`):
                  a target sequence of size `[tgt_len x batch]`.
             lengths(:obj:`LongTensor`): the src lengths, pre-padding `[batch]`.
+            bptt (:obj:`Boolean`):
+                a flag indicating if truncated bptt is set. If reset then
+                init_state
 
         Returns:
             (:obj:`FloatTensor`, `dict`, :obj:`onmt.Models.DecoderState`):
@@ -41,10 +44,8 @@ class NMTModel(nn.Module):
         tgt = tgt[:-1]  # exclude last target from inputs
 
         enc_state, memory_bank, lengths = self.encoder(src, lengths)
-        if dec_state is None:
+        if bptt is False:
             self.decoder.init_state(src, memory_bank, enc_state)
-        else:
-            self.decoder.state = dec_state
         dec_out, attns = self.decoder(tgt, memory_bank,
                                       memory_lengths=lengths)
         return dec_out, attns

--- a/onmt/models/model.py
+++ b/onmt/models/model.py
@@ -47,4 +47,4 @@ class NMTModel(nn.Module):
             self.decoder.state = dec_state
         dec_out, attns = self.decoder(tgt, memory_bank,
                                       memory_lengths=lengths)
-        return dec_out, attns, self.decoder.state
+        return dec_out, attns

--- a/onmt/models/model.py
+++ b/onmt/models/model.py
@@ -18,7 +18,7 @@ class NMTModel(nn.Module):
         self.encoder = encoder
         self.decoder = decoder
 
-    def forward(self, src, tgt, lengths):
+    def forward(self, src, tgt, lengths, dec_state=None):
         """Forward propagate a `src` and `tgt` pair for training.
         Possible initialized with a beginning decoder state.
 
@@ -41,8 +41,10 @@ class NMTModel(nn.Module):
         tgt = tgt[:-1]  # exclude last target from inputs
 
         enc_state, memory_bank, lengths = self.encoder(src, lengths)
-        self.decoder.init_state(src, memory_bank, enc_state)
+        if dec_state is None:
+            self.decoder.init_state(src, memory_bank, enc_state)
+        else:
+            self.decoder.state = dec_state
         dec_out, attns = self.decoder(tgt, memory_bank,
                                       memory_lengths=lengths)
-
-        return dec_out, attns
+        return dec_out, attns, self.decoder.state

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -278,8 +278,9 @@ class Trainer(object):
                 # 2. F-prop all but generator.
                 if self.grad_accum_count == 1:
                     self.model.zero_grad()
-                outputs, attns, dec_state = \
+                outputs, attns = \
                     self.model(src, tgt, src_lengths, dec_state=dec_state)
+                dec_state = self.model.decoder.state
 
                 # 3. Compute loss in shards for memory efficiency.
                 batch_stats = self.train_loss.sharded_compute_loss(

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -259,7 +259,7 @@ class Trainer(object):
             else:
                 trunc_size = target_size
 
-            dec_state = None
+            bptt = False
             src = inputters.make_features(batch, 'src', self.data_type)
             if self.data_type == 'text':
                 _, src_lengths = batch.src
@@ -279,8 +279,8 @@ class Trainer(object):
                 if self.grad_accum_count == 1:
                     self.model.zero_grad()
                 outputs, attns = \
-                    self.model(src, tgt, src_lengths, dec_state=dec_state)
-                dec_state = self.model.decoder.state
+                    self.model(src, tgt, src_lengths, bptt=bptt)
+                bptt = True
 
                 # 3. Compute loss in shards for memory efficiency.
                 batch_stats = self.train_loss.sharded_compute_loss(

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -259,7 +259,7 @@ class Trainer(object):
             else:
                 trunc_size = target_size
 
-            # dec_state = None
+            dec_state = None
             src = inputters.make_features(batch, 'src', self.data_type)
             if self.data_type == 'text':
                 _, src_lengths = batch.src
@@ -278,8 +278,8 @@ class Trainer(object):
                 # 2. F-prop all but generator.
                 if self.grad_accum_count == 1:
                     self.model.zero_grad()
-                outputs, attns = \
-                    self.model(src, tgt, src_lengths)
+                outputs, attns, dec_state = \
+                    self.model(src, tgt, src_lengths, dec_state=dec_state)
 
                 # 3. Compute loss in shards for memory efficiency.
                 batch_stats = self.train_loss.sharded_compute_loss(


### PR DESCRIPTION
Making behavior consistent with earlier behavior for truncated bptt like in [v0.1](https://github.com/OpenNMT/OpenNMT-py/tree/v0.1). The state of decoder is saved and restored in the next bptt instance.