### PR TITLE
Fix #1172

### DIFF
--- a/tools/embeddings_to_torch.py
+++ b/tools/embeddings_to_torch.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 from __future__ import division
 import six
 import sys


### PR DESCRIPTION
This PR should fix the issue when using `embeddings_to_torch.py` with a new-style vocab. I have not tested it rigorously myself, but it is very similar to the changes to vocab loading elsewhere in the codebase.

Looking at this script, many other improvements are possible. The file reading is not idiomatic python and also quite redundant (needlessly repeating almost exactly the same loop twice for no good reason). Also, is there any reason for this script to require both source and target embedding files? I can imagine only wanting to use one (if, for example, I had pretrained source word vectors and a character-level decoder or vice versa).