### PR TITLE
Fix 1168 and 1170

### DIFF
--- a/onmt/inputters/__init__.py
+++ b/onmt/inputters/__init__.py
@@ -4,7 +4,7 @@ Inputters implement the logic of transforming raw data to vectorized inputs,
 e.g., from a line of text to a sequence of embeddings.
 """
 from onmt.inputters.inputter import make_features, \
-    load_fields_from_vocab, get_fields, OrderedIterator, \
+    load_old_vocab, get_fields, OrderedIterator, \
     build_dataset, build_vocab, old_style_vocab
 from onmt.inputters.dataset_base import DatasetBase
 from onmt.inputters.text_dataset import TextDataset
@@ -13,7 +13,7 @@ from onmt.inputters.audio_dataset import AudioDataset
 
 
 __all__ = ['DatasetBase', 'make_features',
-           'load_fields_from_vocab', 'get_fields',
+           'load_old_vocab', 'get_fields',
            'build_dataset', 'old_style_vocab',
            'build_vocab', 'OrderedIterator',
            'TextDataset', 'ImageDataset', 'AudioDataset']

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -173,19 +173,20 @@ def get_fields(
     return fields
 
 
-def load_fields_from_vocab(vocab, data_type="text"):
+def load_old_vocab(vocab, data_type="text", dynamic_dict=False):
     """
-    vocab: a list of (field name, torchtext.vocab.Vocab) pairs
+    vocab: a list of (field name, torchtext.vocab.Vocab) pairs. This is the
+           format formerly saved in *.vocab.pt files.
     data_type: text, img, or audio
     returns: a dictionary whose keys are the field names and whose values
-             are field objects with the vocab set to the corresponding vocab
-             object from the input.
+             are lists of (name, Field) pairs
     """
     vocab = dict(vocab)
     n_src_features = sum('src_feat_' in k for k in vocab)
     n_tgt_features = sum('tgt_feat_' in k for k in vocab)
-    fields = get_fields(data_type, n_src_features, n_tgt_features)
-
+    fields = get_fields(
+        data_type, n_src_features, n_tgt_features, dynamic_dict=dynamic_dict
+    )
     for k, vals in fields.items():
         for n, f in vals:
             if n in vocab:

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -149,13 +149,14 @@ def load_test_model(opt, dummy_opt, model_path=None):
     checkpoint = torch.load(model_path,
                             map_location=lambda storage, loc: storage)
 
+    model_opt = checkpoint['opt']
     vocab = checkpoint['vocab']
     if inputters.old_style_vocab(vocab):
-        fields = inputters.load_old_vocab(vocab, opt.data_type)
+        fields = inputters.load_old_vocab(
+            vocab, opt.data_type, dynamic_dict=model_opt.copy_attn
+        )
     else:
         fields = vocab
-
-    model_opt = checkpoint['opt']
 
     for arg in dummy_opt:
         if arg not in model_opt:

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -151,7 +151,7 @@ def load_test_model(opt, dummy_opt, model_path=None):
 
     vocab = checkpoint['vocab']
     if inputters.old_style_vocab(vocab):
-        fields = inputters.load_fields_from_vocab(vocab, opt.data_type)
+        fields = inputters.load_old_vocab(vocab, opt.data_type)
     else:
         fields = vocab
 

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -14,7 +14,7 @@ import torch
 import onmt.opts as opts
 
 from onmt.inputters.inputter import build_dataset_iter, \
-    load_fields_from_vocab, old_style_vocab
+    load_old_vocab, old_style_vocab
 from onmt.model_builder import build_model
 from onmt.utils.optimizers import build_optim
 from onmt.utils.misc import set_random_seed
@@ -109,9 +109,9 @@ def main(opt, device_id):
     data_type = first_dataset.data_type
 
     # check for code where vocab is saved instead of fields
-    # (in the future this will be done in a smarter way
+    # (in the future this will be done in a smarter way)
     if old_style_vocab(vocab):
-        fields = load_fields_from_vocab(vocab, data_type)
+        fields = load_old_vocab(vocab, data_type, dynamic_dict=opt.copy_attn)
     else:
         fields = vocab
 

--- a/tools/extract_embeddings.py
+++ b/tools/extract_embeddings.py
@@ -45,7 +45,7 @@ def main():
 
     vocab = checkpoint['vocab']
     if inputters.old_style_vocab(vocab):
-        fields = onmt.inputters.load_fields_from_vocab(vocab)
+        fields = onmt.inputters.load_old_vocab(vocab)
     else:
         fields = vocab
     src_dict = fields['src'][0][1].vocab


### PR DESCRIPTION
This pull request fixes two related bugs that occurred when attempting to load a dataset or model that uses copy attention and was preprocessed or trained before #1132 was merged. 

The issue was related to a difference in how fields are constructed. Before #1132, copy attention-specific data like `src_map` and `alignment` was created whenever fields were initialized, whether they were actually necessary or not. #1132 changed that default behavior, but failed to correctly indicate if the copy attention fields were necessary when loading fields from old-style vocab lists. The correct fields should be made now.