### PR TITLE
Allow -tensorboard_log_dir to be set in config file

### DIFF
--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -464,8 +464,8 @@ def train_opts(parser):
     group.add('--tensorboard', '-tensorboard', action="store_true",
               help="""Use tensorboardX for visualization during training.
                        Must have the library tensorboardX.""")
-    group.add_argument("-tensorboard_log_dir", type=str,
-                       default="runs/onmt",
+    group.add_argument("--tensorboard_log_dir", "-tensorboard_log_dir",
+                       type=str, default="runs/onmt",
                        help="""Log directory for Tensorboard.
                        This is also the name of the run.
                        """)


### PR DESCRIPTION
This PR makes it possible to specify the `tensorboard_log_dir` in a config file. Previously, this caused an error.