### PR TITLE
Do not reset LR scheduling step with -reset_optim keep_states

### DIFF
--- a/onmt/utils/optimizers.py
+++ b/onmt/utils/optimizers.py
@@ -230,7 +230,6 @@ class Optimizer(object):
             elif opt.reset_optim == 'keep_states':
                 # Reset options, keep optimizer.
                 optim_state_dict = ckpt_state_dict
-                del optim_state_dict['decay_step']
 
         optimizer = cls(
             build_torch_optimizer(model, optim_opt),


### PR DESCRIPTION
Note: it is still reset with `-reset_optim all`.