### PR TITLE
Enable big file translation (for massive back translation)

### DIFF
--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -511,7 +511,7 @@ def translate_opts(parser):
               help='Source directory for image or audio files')
     group.add('--tgt', '-tgt',
                        help='True target sequence (optional)')
-    group.add('--shard_size', '-shard_size', type=int, default=1000000,
+    group.add('--shard_size', '-shard_size', type=int, default=10000,
               help="""Divide src and tgt (if applicable) into
                        smaller multiple src and tgt files, then
                        build shards, each shard will have

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -511,6 +511,14 @@ def translate_opts(parser):
               help='Source directory for image or audio files')
     group.add('--tgt', '-tgt',
                        help='True target sequence (optional)')
+    group.add('--shard_size', '-shard_size', type=int, default=1000000,
+              help="""Divide src and tgt (if applicable) into
+                       smaller multiple src and tgt files, then
+                       build shards, each shard will have
+                       opt.shard_size samples except last shard.
+                       shard_size=0 means no segmentation
+                       shard_size>0 means segment dataset into multiple shards,
+                       each shard has shard_size samples""")
     group.add('--output', '-output', default='pred.txt',
               help="""Path to output the predictions (each line will
                        be the decoded sequence""")

--- a/onmt/utils/__init__.py
+++ b/onmt/utils/__init__.py
@@ -1,10 +1,10 @@
 """Module defining various utilities."""
-from onmt.utils.misc import aeq, use_gpu, set_random_seed
+from onmt.utils.misc import split_corpus, aeq, use_gpu, set_random_seed
 from onmt.utils.report_manager import ReportMgr, build_report_manager
 from onmt.utils.statistics import Statistics
 from onmt.utils.optimizers import MultipleOptimizer, \
     Optimizer, AdaFactor
 
-__all__ = ["aeq", "use_gpu", "set_random_seed", "ReportMgr",
+__all__ = ["split_corpus", "aeq", "use_gpu", "set_random_seed", "ReportMgr",
            "build_report_manager", "Statistics",
            "MultipleOptimizer", "Optimizer", "AdaFactor"]

--- a/onmt/utils/misc.py
+++ b/onmt/utils/misc.py
@@ -2,6 +2,17 @@
 
 import torch
 import random
+import codecs
+from itertools import islice
+
+
+def split_corpus(path, shard_size):
+    with codecs.open(path, "r", encoding="utf-8") as f:
+        while True:
+            shard = list(islice(f, shard_size))
+            if not shard:
+                break
+            yield shard
 
 
 def aeq(*args):

--- a/preprocess.py
+++ b/preprocess.py
@@ -3,17 +3,15 @@
 """
     Pre-process Data / features files and build vocabulary
 """
-
+import codecs
 import configargparse
 import glob
 import sys
 import gc
 import os
-import codecs
-from itertools import islice
 import torch
 from onmt.utils.logging import init_logger, logger
-
+from onmt.utils.misc import split_corpus
 import onmt.inputters as inputters
 import onmt.opts as opts
 
@@ -45,15 +43,6 @@ def parse_args():
     check_existing_pt_files(opt)
 
     return opt
-
-
-def split_corpus(path, shard_size):
-    with codecs.open(path, "r", encoding="utf-8") as f:
-        while True:
-            shard = list(islice(f, shard_size))
-            if not shard:
-                break
-            yield shard
 
 
 def build_save_dataset(corpus_type, fields, opt):

--- a/translate.py
+++ b/translate.py
@@ -3,21 +3,11 @@
 
 from __future__ import unicode_literals
 import configargparse
-import codecs
-from itertools import islice
 from onmt.utils.logging import init_logger
+from onmt.utils.misc import split_corpus
 from onmt.translate.translator import build_translator
 
 import onmt.opts as opts
-
-
-def split_corpus(path, shard_size):
-    with codecs.open(path, "r", encoding="utf-8") as f:
-        while True:
-            shard = list(islice(f, shard_size))
-            if not shard:
-                break
-            yield shard
 
 
 def main(opt):

--- a/translate.py
+++ b/translate.py
@@ -10,6 +10,7 @@ from onmt.translate.translator import build_translator
 
 import onmt.opts as opts
 
+
 def split_corpus(path, shard_size):
     with codecs.open(path, "r", encoding="utf-8") as f:
         while True:
@@ -18,23 +19,24 @@ def split_corpus(path, shard_size):
                 break
             yield shard
 
+
 def main(opt):
     translator = build_translator(opt, report_score=True)
     src_shards = split_corpus(opt.src, opt.shard_size)
     tgt_shards = split_corpus(opt.tgt, opt.shard_size) \
         if opt.tgt is not None else [None]*opt.shard_size
     shard_pairs = zip(src_shards, tgt_shards)
-    dataset_paths = []
 
     for i, (src_shard, tgt_shard) in enumerate(shard_pairs):
         logger.info("Translating shard %d." % i)
         translator.translate(
-	    src=src_shard,
-	    tgt=tgt_shard,
-	    src_dir=opt.src_dir,
-	    batch_size=opt.batch_size,
-	    attn_debug=opt.attn_debug
-	    )
+            src=src_shard,
+            tgt=tgt_shard,
+            src_dir=opt.src_dir,
+            batch_size=opt.batch_size,
+            attn_debug=opt.attn_debug
+            )
+
 
 if __name__ == "__main__":
     parser = configargparse.ArgumentParser(

--- a/translate.py
+++ b/translate.py
@@ -3,23 +3,38 @@
 
 from __future__ import unicode_literals
 import configargparse
-
+import codecs
+from itertools import islice
 from onmt.utils.logging import init_logger
 from onmt.translate.translator import build_translator
 
 import onmt.opts as opts
 
+def split_corpus(path, shard_size):
+    with codecs.open(path, "r", encoding="utf-8") as f:
+        while True:
+            shard = list(islice(f, shard_size))
+            if not shard:
+                break
+            yield shard
 
 def main(opt):
     translator = build_translator(opt, report_score=True)
-    translator.translate(
-        src=opt.src,
-        tgt=opt.tgt,
-        src_dir=opt.src_dir,
-        batch_size=opt.batch_size,
-        attn_debug=opt.attn_debug
-    )
+    src_shards = split_corpus(opt.src, opt.shard_size)
+    tgt_shards = split_corpus(opt.tgt, opt.shard_size) \
+        if opt.tgt is not None else [None]*opt.shard_size
+    shard_pairs = zip(src_shards, tgt_shards)
+    dataset_paths = []
 
+    for i, (src_shard, tgt_shard) in enumerate(shard_pairs):
+        logger.info("Translating shard %d." % i)
+        translator.translate(
+	    src=src_shard,
+	    tgt=tgt_shard,
+	    src_dir=opt.src_dir,
+	    batch_size=opt.batch_size,
+	    attn_debug=opt.attn_debug
+	    )
 
 if __name__ == "__main__":
     parser = configargparse.ArgumentParser(


### PR DESCRIPTION
without running out of memory.

This PR uses the same mechanism as in preprocess.py
The use case is "Massive back translation"
When you need to translate millions of segments, you will run out of memory.
This PR will cut in shard_size chunks and translate sequentially.