### PR TITLE
Move copy scores from text dataset to copy_generator.

### DIFF
--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import torch
-
 from onmt.inputters.dataset_base import DatasetBase
 
 
@@ -25,35 +23,6 @@ class TextDataset(DatasetBase):
         if hasattr(ex, "tgt"):
             return len(ex.src), len(ex.tgt)
         return len(ex.src)
-
-    @staticmethod
-    def collapse_copy_scores(scores, batch, tgt_vocab, src_vocabs,
-                             batch_dim=1, batch_offset=None):
-        """
-        Given scores from an expanded dictionary
-        corresponeding to a batch, sums together copies,
-        with a dictionary word when it is ambiguous.
-        """
-        offset = len(tgt_vocab)
-        for b in range(scores.size(batch_dim)):
-            blank = []
-            fill = []
-            batch_id = batch_offset[b] if batch_offset is not None else b
-            index = batch.indices.data[batch_id]
-            src_vocab = src_vocabs[index]
-            for i in range(1, len(src_vocab)):
-                sw = src_vocab.itos[i]
-                ti = tgt_vocab.stoi[sw]
-                if ti != 0:
-                    blank.append(offset + i)
-                    fill.append(ti)
-            if blank:
-                blank = torch.Tensor(blank).type_as(batch.indices.data)
-                fill = torch.Tensor(fill).type_as(batch.indices.data)
-                score = scores[:, b] if batch_dim == 1 else scores[b]
-                score.index_add_(1, fill, score.index_select(1, blank))
-                score.index_fill_(1, blank, 1e-10)
-        return scores
 
     @classmethod
     def make_examples(cls, sequences, side):

--- a/onmt/modules/copy_generator.py
+++ b/onmt/modules/copy_generator.py
@@ -1,9 +1,37 @@
 import torch
 import torch.nn as nn
 
-import onmt.inputters as inputters
 from onmt.utils.misc import aeq
 from onmt.utils.loss import LossComputeBase
+
+
+def collapse_copy_scores(scores, batch, tgt_vocab, src_vocabs,
+                         batch_dim=1, batch_offset=None):
+    """
+    Given scores from an expanded dictionary
+    corresponeding to a batch, sums together copies,
+    with a dictionary word when it is ambiguous.
+    """
+    offset = len(tgt_vocab)
+    for b in range(scores.size(batch_dim)):
+        blank = []
+        fill = []
+        batch_id = batch_offset[b] if batch_offset is not None else b
+        index = batch.indices.data[batch_id]
+        src_vocab = src_vocabs[index]
+        for i in range(1, len(src_vocab)):
+            sw = src_vocab.itos[i]
+            ti = tgt_vocab.stoi[sw]
+            if ti != 0:
+                blank.append(offset + i)
+                fill.append(ti)
+        if blank:
+            blank = torch.Tensor(blank).type_as(batch.indices.data)
+            fill = torch.Tensor(fill).type_as(batch.indices.data)
+            score = scores[:, b] if batch_dim == 1 else scores[b]
+            score.index_add_(1, fill, score.index_select(1, blank))
+            score.index_fill_(1, blank, 1e-10)
+    return scores
 
 
 class CopyGenerator(nn.Module):
@@ -181,7 +209,7 @@ class CopyGeneratorLossCompute(LossComputeBase):
 
         # this block does not depend on the loss value computed above
         # and is used only for stats
-        scores_data = inputters.TextDataset.collapse_copy_scores(
+        scores_data = collapse_copy_scores(
             self._unbottle(scores.clone(), batch.batch_size),
             batch, self.tgt_vocab, batch.dataset.src_vocabs)
         scores_data = self._bottle(scores_data)


### PR DESCRIPTION
It's not clear that ``collapse_copy_scores`` belongs in the dataset. It seems that it's part of the statistics stuff in ``copy_generator.py`` so I moved it there. That's the only code that uses it AFAIK.

This was originally in #1194 