### PR TITLE
Add missing vocab_size and min_frec in building vocabulary

### DIFF
--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -384,7 +384,7 @@ def build_vocab(train_dataset_files, fields, data_type, share_vocab,
         for name, field in fields["src"]:
             if name == "src":
                 _build_field_vocab(
-                    field, counters[name], max_size=src_vocab_size, 
+                    field, counters[name], max_size=src_vocab_size,
                     min_freq=src_words_min_frequency)
             else:
                 _build_field_vocab(field, counters[name])


### PR DESCRIPTION
The vocab_size(max_size) and min_freq in _build_field_vocab is missing in the current version. 