### PR TITLE
Update translator.py

### DIFF
--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -19,6 +19,7 @@ import onmt.decoders.ensemble
 from onmt.utils.misc import set_random_seed
 from onmt.modules.copy_generator import collapse_copy_scores
 
+
 def build_translator(opt, report_score=True, logger=None, out_file=None):
     if out_file is None:
         out_file = codecs.open(opt.output, 'w+', 'utf-8')

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -17,7 +17,7 @@ import onmt.inputters as inputters
 import onmt.opts as opts
 import onmt.decoders.ensemble
 from onmt.utils.misc import set_random_seed
-
+from onmt.modules.copy_generator import collapse_copy_scores
 
 def build_translator(opt, report_score=True, logger=None, out_file=None):
     if out_file is None:
@@ -514,7 +514,7 @@ class Translator(object):
                 scores = scores.view(batch.batch_size, -1, scores.size(-1))
             else:
                 scores = scores.view(-1, self.beam_size, scores.size(-1))
-            scores = data.collapse_copy_scores(
+            scores = collapse_copy_scores(
                 scores,
                 batch,
                 tgt_field.vocab,


### PR DESCRIPTION
collapse_copy_scores is a separate function in at top of this file: https://github.com/OpenNMT/OpenNMT-py/blob/master/onmt/modules/copy_generator.py#L8.

If I run this example: http://opennmt.net/OpenNMT-py/Summarization.html#inference, data has no attr collapse_copy_scores. This bug may due to an earlier merge (possibly d57fa68e6b0c2041642af40f76e1d5903c80a9b8).