### PR TITLE
Unify loss interface and do not force backpropagation

### DIFF
--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -376,7 +376,7 @@ def train_opts(parser):
               type=int, default=32,
               help="""Maximum batches of words in a sequence to run
                         the generator on in parallel. Higher is faster, but
-                        uses more memory.""")
+                        uses more memory. Set to 0 to disable.""")
     group.add('--train_steps', '-train_steps', type=int, default=100000,
               help='Number of training steps')
     group.add('--epochs', '-epochs', type=int, default=0,


### PR DESCRIPTION
The loss computation had the unwanted side effect of also running the backpropagation. It should not. This PR removes this side effect and makes the loss class expose a single general interface for training and evaluation.

The backward pass in now initiated in `trainer.py` with a simple `loss.backward()`. This will allow other loss manipulation, such as loss scaling for FP16 training. I tested that the loss is the same and memory usage similar in different training configurations: Transformer, RNN, RNN with copy_attn, RNN with TBPTT.

It also adds support of setting `-max_generator_batches 0` to not shard the loss computation (fastest).