### PR TITLE
Move batching and field logic from inputter to dsets

### DIFF
--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -156,7 +156,7 @@ class AudioSeqField(Field):
                              "(data batch, batch lengths).")
         if isinstance(arr, tuple):
             arr, lengths = arr
-            lengths = torch.tensor(lengths, dtype=self.dtype, device=device)
+            lengths = torch.tensor(lengths, dtype=torch.int, device=device)
 
         if self.postprocessing is not None:
             arr = self.postprocessing(arr, None)

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -120,21 +120,58 @@ class AudioDataset(DatasetBase):
                    side + '_lengths': spect.size(1), 'indices': i}
 
 
-def batch_audio(data, vocab):
-    """ batch audio data """
-    nfft = data[0].size(0)
-    t = max([t.size(1) for t in data])
-    sounds = torch.zeros(len(data), 1, nfft, t)
-    for i, spect in enumerate(data):
-        sounds[i, :, :, 0:spect.size(1)] = spect
-    return sounds
+class AudioSeqField(Field):
+    def __init__(self, preprocessing=None, postprocessing=None,
+                 include_lengths=False, batch_first=False, pad_index=0,
+                 is_target=False):
+        super(AudioSeqField, self).__init__(
+            sequential=True, use_vocab=False, init_token=None,
+            eos_token=None, fix_length=False, dtype=torch.float,
+            preprocessing=preprocessing, postprocessing=postprocessing,
+            lower=False, tokenize=None, include_lengths=include_lengths,
+            batch_first=batch_first, pad_token=pad_index, unk_token=None,
+            pad_first=False, truncate_first=False, stop_words=None,
+            is_target=is_target
+        )
+
+    def pad(self, minibatch):
+        assert not self.pad_first and not self.truncate_first \
+               and not self.fix_length and self.sequential
+        minibatch = list(minibatch)
+        lengths = [x.size(1) for x in minibatch]
+        max_len = max(lengths)
+        nfft = minibatch[0].size(0)
+        sounds = torch.full((len(minibatch), 1, nfft, max_len), self.pad_token)
+        for i, (spect, len_) in enumerate(zip(minibatch, lengths)):
+            sounds[i, :, :, 0:len_] = spect
+        if self.include_lengths:
+            return (sounds, lengths)
+        return sounds
+
+    def numericalize(self, arr, device=None):
+        assert self.use_vocab is False
+        if self.include_lengths and not isinstance(arr, tuple):
+            raise ValueError("Field has include_lengths set to True, but "
+                             "input data is not a tuple of "
+                             "(data batch, batch lengths).")
+        if isinstance(arr, tuple):
+            arr, lengths = arr
+            lengths = torch.tensor(lengths, dtype=self.dtype, device=device)
+
+        if self.postprocessing is not None:
+            arr = self.postprocessing(arr, None)
+
+        if self.sequential and not self.batch_first:
+            arr.permute(3, 0, 1, 2)
+        if self.sequential:
+            arr = arr.contiguous()
+
+        if self.include_lengths:
+            return arr, lengths
+        return arr
 
 
 def audio_fields(base_name, **kwargs):
-    audio = Field(
-        use_vocab=False, dtype=torch.float,
-        postprocessing=batch_audio, sequential=False)
+    audio = AudioSeqField(pad_index=0, batch_first=True, include_lengths=True)
 
-    length = Field(use_vocab=False, dtype=torch.long, sequential=False)
-
-    return [(base_name + "_lengths", length)], [(base_name, audio)]
+    return [(base_name, audio)]

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -116,8 +116,7 @@ class AudioDataset(DatasetBase):
                 window_stride, window, normalize_audio
             )
 
-            yield {side: spect, side + '_path': line.strip(),
-                   side + '_lengths': spect.size(1), 'indices': i}
+            yield {side: spect, side + '_path': line.strip(), 'indices': i}
 
 
 class AudioSeqField(Field):

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -3,6 +3,7 @@ import os
 from tqdm import tqdm
 
 import torch
+from torchtext.data import Field
 
 from onmt.inputters.dataset_base import DatasetBase
 
@@ -106,3 +107,23 @@ class AudioDataset(DatasetBase):
 
             yield {side: spect, side + '_path': line.strip(),
                    side + '_lengths': spect.size(1), 'indices': i}
+
+
+def batch_audio(data, vocab):
+    """ batch audio data """
+    nfft = data[0].size(0)
+    t = max([t.size(1) for t in data])
+    sounds = torch.zeros(len(data), 1, nfft, t)
+    for i, spect in enumerate(data):
+        sounds[i, :, :, 0:spect.size(1)] = spect
+    return sounds
+
+
+def audio_fields(base_name, **kwargs):
+    audio = Field(
+        use_vocab=False, dtype=torch.float,
+        postprocessing=batch_audio, sequential=False)
+
+    length = Field(use_vocab=False, dtype=torch.long, sequential=False)
+
+    return [(base_name + "_lengths", length)], [(base_name, audio)]

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -81,4 +81,4 @@ def image_fields(base_name, **kwargs):
     img = Field(
         use_vocab=False, dtype=torch.float,
         postprocessing=batch_img, sequential=False)
-    return [], [(base_name, img)]
+    return [(base_name, img)]

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -2,6 +2,9 @@
 
 import os
 
+import torch
+from torchtext.data import Field
+
 from onmt.inputters.dataset_base import DatasetBase
 
 
@@ -51,3 +54,20 @@ class ImageDataset(DatasetBase):
                         and img.size(2) <= truncate[1]):
                     continue
             yield {side: img, side + '_path': filename, 'indices': i}
+
+
+def batch_img(data, vocab):
+    c = data[0].size(0)
+    h = max([t.size(1) for t in data])
+    w = max([t.size(2) for t in data])
+    imgs = torch.zeros(len(data), c, h, w).fill_(1)
+    for i, img in enumerate(data):
+        imgs[i, :, 0:img.size(1), 0:img.size(2)] = img
+    return imgs
+
+
+def image_fields(base_name, **kwargs):
+    img = Field(
+        use_vocab=False, dtype=torch.float,
+        postprocessing=batch_img, sequential=False)
+    return [], [(base_name, img)]

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -18,6 +18,8 @@ from onmt.inputters.audio_dataset import AudioDataset, audio_fields
 from onmt.utils.logging import logger
 # backwards compatibility
 from onmt.inputters.text_dataset import _feature_tokenize  # noqa: F401
+from onmt.inputters.image_dataset import (  # noqa: F401
+    batch_img as make_img)
 
 import gc
 

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -51,17 +51,6 @@ def make_tgt(data, vocab):
     return alignment
 
 
-# mix this with partial
-def _feature_tokenize(
-        string, layer=0, tok_delim=None, feat_delim=None, truncate=None):
-    tokens = string.split(tok_delim)
-    if truncate is not None:
-        tokens = tokens[:truncate]
-    if feat_delim is not None:
-        tokens = [t.split(feat_delim)[layer] for t in tokens]
-    return tokens
-
-
 def get_fields(
     src_data_type,
     n_src_feats,

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -163,8 +163,7 @@ def make_features(batch, side):
         data = batch.__dict__[side]
         lengths = None
 
-    if not data.dim() == 4 and (
-            isinstance(batch.__dict__[side], tuple) or side == 'tgt'):
+    if batch.src_is_text or side == 'tgt':  # this is temporary, see #1196
         # cat together layers, producing a 3d output tensor for src text
         # and for tgt (which is assumed to be text)
         feat_start = side + "_feat_"
@@ -384,6 +383,12 @@ class OrderedIterator(torchtext.data.Iterator):
             for b in torchtext.data.batch(self.data(), self.batch_size,
                                           self.batch_size_fn):
                 self.batches.append(sorted(b, key=self.sort_key))
+
+    def __iter__(self):
+        # temporary fix: See #1196
+        for batch in super(OrderedIterator, self).__iter__():
+            batch.src_is_text = isinstance(self.dataset, TextDataset)
+            yield batch
 
 
 class DatasetLazyIter(object):

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -16,6 +16,8 @@ from onmt.inputters.text_dataset import TextDataset, text_fields
 from onmt.inputters.image_dataset import ImageDataset, image_fields
 from onmt.inputters.audio_dataset import AudioDataset, audio_fields
 from onmt.utils.logging import logger
+# backwards compatibility
+from onmt.inputters.text_dataset import _feature_tokenize  # noqa: F401
 
 import gc
 

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
+from functools import partial
 
 import torch
+from torchtext.data import Field
 
 from onmt.inputters.dataset_base import DatasetBase
 
@@ -72,3 +74,50 @@ class TextDataset(DatasetBase):
             sequences = cls._read_file(sequences)
         for i, seq in enumerate(sequences):
             yield {side: seq, "indices": i}
+
+
+# mix this with partial
+def _feature_tokenize(
+        string, layer=0, tok_delim=None, feat_delim=None, truncate=None):
+    tokens = string.split(tok_delim)
+    if truncate is not None:
+        tokens = tokens[:truncate]
+    if feat_delim is not None:
+        tokens = [t.split(feat_delim)[layer] for t in tokens]
+    return tokens
+
+
+def text_fields(base_name, **kwargs):
+    """Create text fields.
+    Args:
+        base_name (str)
+        n_feats (int)
+        include_lengths (bool)
+        pad (str, optional): Defaults to <blank>.
+        bos (str or NoneType, optional): Defaults to <s>
+        eos (str or NoneType, optional): Defaults to </s>
+        truncate (bool or NoneType, optional): Defaults to None.
+    """
+
+    n_feats = kwargs["n_feats"]
+    include_lengths = kwargs["include_lengths"]
+    pad = kwargs.get("pad", "<blank>")
+    bos = kwargs.get("bos", "<s>")
+    eos = kwargs.get("eos", "</s>")
+    truncate = kwargs.get("truncate", None)
+    fields_ = []
+    feat_delim = u"￨" if n_feats > 0 else None
+    for i in range(n_feats + 1):
+        name = base_name + "_feat_" + str(i - 1) if i > 0 else base_name
+        tokenize = partial(
+            _feature_tokenize,
+            layer=i,
+            truncate=truncate,
+            feat_delim=feat_delim)
+        use_len = i == 0 and include_lengths
+        feat = Field(
+            init_token=bos, eos_token=eos,
+            pad_token=pad, tokenize=tokenize,
+            include_lengths=use_len)
+        fields_.append((name, feat))
+    return [], fields_

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -90,4 +90,4 @@ def text_fields(base_name, **kwargs):
             pad_token=pad, tokenize=tokenize,
             include_lengths=use_len)
         fields_.append((name, feat))
-    return [], fields_
+    return fields_

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -812,7 +812,7 @@ class Translator(object):
             # Loop over the batch_size number of beam
             for j, b in enumerate(beam):
                 b.advance(out[j, :],
-                          beam_attn.data[j, :, :int(memory_lengths[j])])
+                          beam_attn.data[j, :, :memory_lengths[j]])
                 select_indices_array.append(
                     b.get_current_origin() + j * beam_size)
             select_indices = torch.cat(select_indices_array)

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -812,7 +812,7 @@ class Translator(object):
             # Loop over the batch_size number of beam
             for j, b in enumerate(beam):
                 b.advance(out[j, :],
-                          beam_attn.data[j, :, :memory_lengths[j]])
+                          beam_attn.data[j, :, :int(memory_lengths[j])])
                 select_indices_array.append(
                     b.get_current_origin() + j * beam_size)
             select_indices = torch.cat(select_indices_array)


### PR DESCRIPTION
Follow-up to #1196 per discussion on #1200 . I wasn't able to reopen 1196 since it's merged.

For text and img models, this restores backwards compatibility for checkpoints since #1132 . Audio models made between 1132 and now are not backwards compatible.

Backwards compatibility since 1132 was tested using the commands here: https://github.com/flauted/OpenNMT-py/issues/6 (check out master, preprocess, train and save, check out this, translate using the save).