### PR TITLE
Fix bug: error when training from checkpoint with fix_word_vecs

### DIFF
--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -41,6 +41,9 @@ def build_embeddings(opt, word_field, feat_fields, for_encoder=True):
     feat_pad_indices = [ff.vocab.stoi[ff.pad_token] for ff in feat_fields]
     num_feat_embeddings = [len(ff.vocab) for ff in feat_fields]
 
+    fix_word_vecs = opt.fix_word_vecs_enc if for_encoder \
+        else opt.fix_word_vecs_dec
+
     emb = Embeddings(
         word_vec_size=emb_dim,
         position_encoding=opt.position_encoding,
@@ -52,7 +55,8 @@ def build_embeddings(opt, word_field, feat_fields, for_encoder=True):
         feat_padding_idx=feat_pad_indices,
         word_vocab_size=num_word_embeddings,
         feat_vocab_sizes=num_feat_embeddings,
-        sparse=opt.optim == "sparseadam"
+        sparse=opt.optim == "sparseadam",
+        fix_word_vecs=fix_word_vecs
     )
     return emb
 
@@ -288,10 +292,10 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None):
 
         if hasattr(model.encoder, 'embeddings'):
             model.encoder.embeddings.load_pretrained_vectors(
-                model_opt.pre_word_vecs_enc, model_opt.fix_word_vecs_enc)
+                model_opt.pre_word_vecs_enc)
         if hasattr(model.decoder, 'embeddings'):
             model.decoder.embeddings.load_pretrained_vectors(
-                model_opt.pre_word_vecs_dec, model_opt.fix_word_vecs_dec)
+                model_opt.pre_word_vecs_dec)
 
     model.generator = generator
     model.to(device)

--- a/onmt/modules/embeddings.py
+++ b/onmt/modules/embeddings.py
@@ -156,7 +156,7 @@ class Embeddings(nn.Module):
         if self.position_encoding:
             pe = PositionalEncoding(dropout, self.embedding_size)
             self.make_embedding.add_module('pe', pe)
-        
+
         if fix_word_vecs:
             self.word_lut.weight.requires_grad = False
 

--- a/onmt/modules/embeddings.py
+++ b/onmt/modules/embeddings.py
@@ -95,7 +95,8 @@ class Embeddings(nn.Module):
                  feat_padding_idx=[],
                  feat_vocab_sizes=[],
                  dropout=0,
-                 sparse=False):
+                 sparse=False,
+                 fix_word_vecs=False):
 
         if feat_padding_idx is None:
             feat_padding_idx = []
@@ -155,6 +156,9 @@ class Embeddings(nn.Module):
         if self.position_encoding:
             pe = PositionalEncoding(dropout, self.embedding_size)
             self.make_embedding.add_module('pe', pe)
+        
+        if fix_word_vecs:
+            self.word_lut.weight.requires_grad = False
 
     @property
     def word_lut(self):
@@ -166,7 +170,7 @@ class Embeddings(nn.Module):
         """ embedding look-up table """
         return self.make_embedding[0]
 
-    def load_pretrained_vectors(self, emb_file, fixed):
+    def load_pretrained_vectors(self, emb_file):
         """Load in pretrained embeddings.
 
         Args:
@@ -183,8 +187,6 @@ class Embeddings(nn.Module):
                     .copy_(pretrained[:, :self.word_vec_size])
             else:
                 self.word_lut.weight.data.copy_(pretrained)
-            if fixed:
-                self.word_lut.weight.requires_grad = False
 
     def forward(self, source, step=None):
         """


### PR DESCRIPTION
In #950 , problem arises when training from checkpoint with fix_word_vecs. 
Reason: when loading checkpoint, the fix_word_vecs is ignored in https://github.com/OpenNMT/OpenNMT-py/blob/9c6e32a7e9b4c8a66af5c1b196bb0dc9886ef6ec/onmt/model_builder.py#L291 
So i move the fix_words_vec setting to embedding initialization.

Another way is to add specific check after load checkpoint:
```
    if model_opt.fix_word_vecs_enc:
        model.encoder.embeddings.word_lut.weight.requires_grad = False
    if model_opt.fix_word_vecs_dec:
        model.decoder.embeddings.word_lut.weight.requires_grad = False
```