### PR TITLE
Fix source word logging

### DIFF
--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -250,6 +250,8 @@ class Trainer(object):
                 trunc_size = target_size
 
             src, src_lengths = inputters.make_features(batch, 'src')
+            if src_lengths is not None:
+                report_stats.n_src_words += src_lengths.sum().item()
 
             # this method unsqueezes its input
             tgt_outer, _ = inputters.make_features(batch, 'tgt')


### PR DESCRIPTION
#1184 accidentally removed the line of code that updates the number of source words seen, which means that the statistics has been recording 0 target words per second. This PR restores that line.

Since there is no longer a check for `data_type` inside the trainer, I made `report_stats` update the number of source words if `src_lengths is not None`. This may have an unintended effect because audio models also have a non-none src_lengths. This may cause unnecessary source word logging when training a speech-to-text model, but I'm not sure if that is a problem.