### PR TITLE
Fix behavior with shard_size == 0

### DIFF
--- a/onmt/utils/misc.py
+++ b/onmt/utils/misc.py
@@ -8,11 +8,14 @@ from itertools import islice
 
 def split_corpus(path, shard_size):
     with codecs.open(path, "r", encoding="utf-8") as f:
-        while True:
-            shard = list(islice(f, shard_size))
-            if not shard:
-                break
-            yield shard
+        if shard_size <= 0:
+            yield f.readlines()
+        else:
+            while True:
+                shard = list(islice(f, shard_size))
+                if not shard:
+                    break
+                yield shard
 
 
 def aeq(*args):


### PR DESCRIPTION
This pull request fixes a bug in the behavior when shard_size is set to 0. The intended behavior, which this PR implements, is that data should not be sharded. What happened before was that the data never even got read at all.