### PR TITLE
Clean decoder code, remove unnecessary attributes

### DIFF
--- a/onmt/decoders/cnn_decoder.py
+++ b/onmt/decoders/cnn_decoder.py
@@ -23,8 +23,6 @@ class CNNDecoder(nn.Module):
                  copy_attn, cnn_kernel_width, dropout, embeddings):
         super(CNNDecoder, self).__init__()
 
-        # Basic attributes.
-        self.decoder_type = 'cnn'
         self.num_layers = num_layers
         self.hidden_size = hidden_size
         self.cnn_kernel_width = cnn_kernel_width
@@ -49,7 +47,7 @@ class CNNDecoder(nn.Module):
                 onmt.modules.ConvMultiStepAttention(self.hidden_size))
 
         # CNNDecoder has its own attention mechanism.
-        # Set up a separated copy attention layer, if needed.
+        # Set up a separate copy attention layer if needed.
         self._copy = False
         if copy_attn:
             self.copy_attn = onmt.modules.GlobalAttention(
@@ -79,7 +77,6 @@ class CNNDecoder(nn.Module):
         if self.state["previous_input"] is not None:
             tgt = torch.cat([self.state["previous_input"], tgt], 0)
 
-        # Initialize return variables.
         dec_outs = []
         attns = {"std": []}
         assert not self._copy, "Copy mechanism not yet tested in conv2conv"
@@ -95,15 +92,13 @@ class CNNDecoder(nn.Module):
         # The combination of output of CNNEncoder and source embeddings.
         src_memory_bank_c = self.state["src"].transpose(0, 1).contiguous()
 
-        # Run the forward pass of the CNNDecoder.
         emb_reshape = tgt_emb.contiguous().view(
             tgt_emb.size(0) * tgt_emb.size(1), -1)
         linear_out = self.linear(emb_reshape)
         x = linear_out.view(tgt_emb.size(0), tgt_emb.size(1), -1)
         x = shape_transform(x)
 
-        pad = torch.zeros(x.size(0), x.size(1),
-                          self.cnn_kernel_width - 1, 1)
+        pad = torch.zeros(x.size(0), x.size(1), self.cnn_kernel_width - 1, 1)
 
         pad = pad.type_as(x)
         base_target_emb = x

--- a/onmt/decoders/decoder.py
+++ b/onmt/decoders/decoder.py
@@ -1,11 +1,11 @@
-""" Base Class and function for Decoders """
-
 import torch
 import torch.nn as nn
 
-import onmt.models.stacked_rnn
-from onmt.utils.misc import aeq
+from onmt.models.stacked_rnn import StackedLSTM, StackedGRU
+from onmt.modules import context_gate_factory, GlobalAttention
 from onmt.utils.rnn_factory import rnn_factory
+
+from onmt.utils.misc import aeq
 
 
 class RNNDecoderBase(nn.Module):
@@ -81,27 +81,26 @@ class RNNDecoderBase(nn.Module):
         # Set up the context gate.
         self.context_gate = None
         if context_gate is not None:
-            self.context_gate = onmt.modules.context_gate_factory(
+            self.context_gate = context_gate_factory(
                 context_gate, self._input_size,
                 hidden_size, hidden_size, hidden_size
             )
 
         # Set up the standard attention.
         self._coverage = coverage_attn
-        self.attn = onmt.modules.GlobalAttention(
+        self.attn = GlobalAttention(
             hidden_size, coverage=coverage_attn,
             attn_type=attn_type, attn_func=attn_func
         )
 
-        # Set up a separated copy attention layer, if needed.
-        self._copy = False
         if copy_attn and not reuse_copy_attn:
-            self.copy_attn = onmt.modules.GlobalAttention(
+            self.copy_attn = GlobalAttention(
                 hidden_size, attn_type=attn_type, attn_func=attn_func
             )
-        if copy_attn:
-            self._copy = True
-        self._reuse_copy_attn = reuse_copy_attn
+        else:
+            self.copy_attn = None
+
+        self._reuse_copy_attn = reuse_copy_attn and copy_attn
 
     def init_state(self, src, memory_bank, encoder_final):
         """ Init decoder state with last state of the encoder """
@@ -114,8 +113,8 @@ class RNNDecoderBase(nn.Module):
             return hidden
 
         if isinstance(encoder_final, tuple):  # LSTM
-            self.state["hidden"] = tuple([_fix_enc_hidden(enc_hid)
-                                          for enc_hid in encoder_final])
+            self.state["hidden"] = tuple(_fix_enc_hidden(enc_hid)
+                                         for enc_hid in encoder_final)
         else:  # GRU
             self.state["hidden"] = (_fix_enc_hidden(encoder_final), )
 
@@ -127,13 +126,11 @@ class RNNDecoderBase(nn.Module):
         self.state["coverage"] = None
 
     def map_state(self, fn):
-        self.state["hidden"] = tuple(map(lambda x: fn(x, 1),
-                                         self.state["hidden"]))
+        self.state["hidden"] = tuple(fn(h, 1) for h in self.state["hidden"])
         self.state["input_feed"] = fn(self.state["input_feed"], 1)
 
     def detach_state(self):
-        self.state["hidden"] = tuple([_.detach()
-                                     for _ in self.state["hidden"]])
+        self.state["hidden"] = tuple(h.detach() for h in self.state["hidden"])
         self.state["input_feed"] = self.state["input_feed"].detach()
 
     def forward(self, tgt, memory_bank, memory_lengths=None, step=None):
@@ -152,7 +149,6 @@ class RNNDecoderBase(nn.Module):
                 * attns: distribution over src at each tgt
                         `[tgt_len x batch x src_len]`.
         """
-        # Run the forward pass of the RNN.
         dec_state, dec_outs, attns = self._run_forward_pass(
             tgt, memory_bank, memory_lengths=memory_lengths)
 
@@ -216,13 +212,12 @@ class StdRNNDecoder(RNNDecoderBase):
                             type of attention Tensor array of every time
                             step from the decoder.
         """
-        assert not self._copy  # TODO, no support yet.
+        assert self.copy_attn is None  # TODO, no support yet.
         assert not self._coverage  # TODO, no support yet.
 
         attns = {}
         emb = self.embeddings(tgt)
 
-        # Run the forward pass of the RNN.
         if isinstance(self.rnn, nn.GRU):
             rnn_output, dec_state = self.rnn(emb, self.state["hidden"][0])
         else:
@@ -249,8 +244,7 @@ class StdRNNDecoder(RNNDecoderBase):
                 rnn_output.view(-1, rnn_output.size(2)),
                 dec_outs.view(-1, dec_outs.size(2))
             )
-            dec_outs = \
-                dec_outs.view(tgt_len, tgt_batch, self.hidden_size)
+            dec_outs = dec_outs.view(tgt_len, tgt_batch, self.hidden_size)
 
         dec_outs = self.dropout(dec_outs)
         return dec_state, dec_outs, attns
@@ -303,10 +297,9 @@ class InputFeedRNNDecoder(RNNDecoderBase):
         aeq(tgt_batch, input_feed_batch)
         # END Additional args check.
 
-        # Initialize local and return variables.
         dec_outs = []
         attns = {"std": []}
-        if self._copy:
+        if self.copy_attn is not None or self._reuse_copy_attn:
             attns["copy"] = []
         if self._coverage:
             attns["coverage"] = []
@@ -320,9 +313,8 @@ class InputFeedRNNDecoder(RNNDecoderBase):
 
         # Input feed concatenates hidden state with
         # input at every time step.
-        for _, emb_t in enumerate(emb.split(1)):
-            emb_t = emb_t.squeeze(0)
-            decoder_input = torch.cat([emb_t, input_feed], 1)
+        for emb_t in emb.split(1):
+            decoder_input = torch.cat([emb_t.squeeze(0), input_feed], 1)
             rnn_output, dec_state = self.rnn(decoder_input, dec_state)
             decoder_output, p_attn = self.attn(
                 rnn_output,
@@ -342,30 +334,24 @@ class InputFeedRNNDecoder(RNNDecoderBase):
 
             # Update the coverage attention.
             if self._coverage:
-                coverage = coverage + p_attn \
-                    if coverage is not None else p_attn
+                coverage = p_attn if coverage is None else p_attn + coverage
                 attns["coverage"] += [coverage]
 
-            # Run the forward pass of the copy attention layer.
-            if self._copy and not self._reuse_copy_attn:
-                _, copy_attn = self.copy_attn(decoder_output,
-                                              memory_bank.transpose(0, 1))
+            if self.copy_attn is not None:
+                _, copy_attn = self.copy_attn(
+                    decoder_output, memory_bank.transpose(0, 1))
                 attns["copy"] += [copy_attn]
-            elif self._copy:
+            elif self._reuse_copy_attn:
                 attns["copy"] = attns["std"]
 
         return dec_state, dec_outs, attns
 
     def _build_rnn(self, rnn_type, input_size,
                    hidden_size, num_layers, dropout):
-        assert not rnn_type == "SRU", "SRU doesn't support input feed! " \
+        assert rnn_type != "SRU", "SRU doesn't support input feed! " \
             "Please set -input_feed 0!"
-        if rnn_type == "LSTM":
-            stacked_cell = onmt.models.stacked_rnn.StackedLSTM
-        else:
-            stacked_cell = onmt.models.stacked_rnn.StackedGRU
-        return stacked_cell(num_layers, input_size,
-                            hidden_size, dropout)
+        stacked_cell = StackedLSTM if rnn_type == "LSTM" else StackedGRU
+        return stacked_cell(num_layers, input_size, hidden_size, dropout)
 
     @property
     def _input_size(self):

--- a/onmt/decoders/decoder.py
+++ b/onmt/decoders/decoder.py
@@ -62,8 +62,6 @@ class RNNDecoderBase(nn.Module):
                  reuse_copy_attn=False):
         super(RNNDecoderBase, self).__init__()
 
-        # Basic attributes.
-        self.decoder_type = 'rnn'
         self.bidirectional_encoder = bidirectional_encoder
         self.num_layers = num_layers
         self.hidden_size = hidden_size
@@ -134,13 +132,11 @@ class RNNDecoderBase(nn.Module):
         self.state["input_feed"] = fn(self.state["input_feed"], 1)
 
     def detach_state(self):
-        """ Need to document this """
         self.state["hidden"] = tuple([_.detach()
                                      for _ in self.state["hidden"]])
         self.state["input_feed"] = self.state["input_feed"].detach()
 
-    def forward(self, tgt, memory_bank, memory_lengths=None,
-                step=None):
+    def forward(self, tgt, memory_bank, memory_lengths=None, step=None):
         """
         Args:
             tgt (`LongTensor`): sequences of padded tokens
@@ -223,7 +219,6 @@ class StdRNNDecoder(RNNDecoderBase):
         assert not self._copy  # TODO, no support yet.
         assert not self._coverage  # TODO, no support yet.
 
-        # Initialize local and return variables.
         attns = {}
         emb = self.embeddings(tgt)
 
@@ -238,7 +233,6 @@ class StdRNNDecoder(RNNDecoderBase):
         output_len, output_batch, _ = rnn_output.size()
         aeq(tgt_len, output_len)
         aeq(tgt_batch, output_batch)
-        # END
 
         # Calculate the attention.
         dec_outs, p_attn = self.attn(
@@ -267,9 +261,6 @@ class StdRNNDecoder(RNNDecoderBase):
 
     @property
     def _input_size(self):
-        """
-        Private helper returning the number of expected features.
-        """
         return self.embeddings.embedding_size
 
 
@@ -362,7 +353,7 @@ class InputFeedRNNDecoder(RNNDecoderBase):
                 attns["copy"] += [copy_attn]
             elif self._copy:
                 attns["copy"] = attns["std"]
-        # Return result.
+
         return dec_state, dec_outs, attns
 
     def _build_rnn(self, rnn_type, input_size,

--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -145,8 +145,6 @@ class TransformerDecoder(nn.Module):
                  copy_attn, self_attn_type, dropout, embeddings):
         super(TransformerDecoder, self).__init__()
 
-        # Basic attributes.
-        self.decoder_type = 'transformer'
         self.num_layers = num_layers
         self.embeddings = embeddings
         self.self_attn_type = self_attn_type
@@ -161,7 +159,7 @@ class TransformerDecoder(nn.Module):
              for _ in range(num_layers)])
 
         # TransformerDecoder has its own attention mechanism.
-        # Set up a separated copy attention layer, if needed.
+        # Set up a separate copy attention layer if needed.
         self._copy = False
         if copy_attn:
             self.copy_attn = onmt.modules.GlobalAttention(
@@ -203,13 +201,11 @@ class TransformerDecoder(nn.Module):
         src_batch, src_len = src_words.size()
         tgt_batch, tgt_len = tgt_words.size()
 
-        # Initialize return variables.
         dec_outs = []
         attns = {"std": []}
         if self._copy:
             attns["copy"] = []
 
-        # Run the forward pass of the TransformerDecoder.
         emb = self.embeddings(tgt, step=step)
         assert emb.dim() == 3  # len x batch x embedding_dim
 

--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn as nn
 import numpy as np
 
-import onmt
+from onmt.modules import MultiHeadedAttention, AverageAttention
 from onmt.modules.position_ffn import PositionwiseFeedForward
 
 MAX_SIZE = 5000
@@ -20,7 +20,7 @@ class TransformerDecoderLayer(nn.Module):
                        the first-layer of the PositionwiseFeedForward.
       heads (int): the number of heads for MultiHeadedAttention.
       d_ff (int): the second-layer of the PositionwiseFeedForward.
-      dropout (float): dropout probability(0-1.0).
+      dropout (float): dropout probability.
       self_attn_type (string): type of self-attention scaled-dot, average
     """
 
@@ -31,18 +31,16 @@ class TransformerDecoderLayer(nn.Module):
         self.self_attn_type = self_attn_type
 
         if self_attn_type == "scaled-dot":
-            self.self_attn = onmt.modules.MultiHeadedAttention(
+            self.self_attn = MultiHeadedAttention(
                 heads, d_model, dropout=dropout)
         elif self_attn_type == "average":
-            self.self_attn = onmt.modules.AverageAttention(
-                d_model, dropout=dropout)
+            self.self_attn = AverageAttention(d_model, dropout=dropout)
 
-        self.context_attn = onmt.modules.MultiHeadedAttention(
+        self.context_attn = MultiHeadedAttention(
             heads, d_model, dropout=dropout)
         self.feed_forward = PositionwiseFeedForward(d_model, d_ff, dropout)
         self.layer_norm_1 = nn.LayerNorm(d_model, eps=1e-6)
         self.layer_norm_2 = nn.LayerNorm(d_model, eps=1e-6)
-        self.dropout = dropout
         self.drop = nn.Dropout(dropout)
         mask = self._get_attn_subsequent_mask(MAX_SIZE)
         # Register self.mask as a buffer in TransformerDecoderLayer, so
@@ -145,7 +143,6 @@ class TransformerDecoder(nn.Module):
                  copy_attn, self_attn_type, dropout, embeddings):
         super(TransformerDecoder, self).__init__()
 
-        self.num_layers = num_layers
         self.embeddings = embeddings
         self.self_attn_type = self_attn_type
 
@@ -156,15 +153,11 @@ class TransformerDecoder(nn.Module):
         self.transformer_layers = nn.ModuleList(
             [TransformerDecoderLayer(d_model, heads, d_ff, dropout,
              self_attn_type=self_attn_type)
-             for _ in range(num_layers)])
+             for i in range(num_layers)])
 
         # TransformerDecoder has its own attention mechanism.
         # Set up a separate copy attention layer if needed.
-        self._copy = False
-        if copy_attn:
-            self.copy_attn = onmt.modules.GlobalAttention(
-                d_model, attn_type=attn_type)
-            self._copy = True
+        self._copy = copy_attn
         self.layer_norm = nn.LayerNorm(d_model, eps=1e-6)
 
     def init_state(self, src, memory_bank, enc_hidden):
@@ -193,18 +186,13 @@ class TransformerDecoder(nn.Module):
         See :obj:`onmt.modules.RNNDecoderBase.forward()`
         """
         if step == 0:
-            self._init_cache(memory_bank, self.num_layers, self.self_attn_type)
+            self._init_cache(memory_bank)
 
         src = self.state["src"]
         src_words = src[:, :, 0].transpose(0, 1)
         tgt_words = tgt[:, :, 0].transpose(0, 1)
         src_batch, src_len = src_words.size()
         tgt_batch, tgt_len = tgt_words.size()
-
-        dec_outs = []
-        attns = {"std": []}
-        if self._copy:
-            attns["copy"] = []
 
         emb = self.embeddings(tgt, step=step)
         assert emb.dim() == 3  # len x batch x embedding_dim
@@ -216,15 +204,15 @@ class TransformerDecoder(nn.Module):
         src_pad_mask = src_words.data.eq(pad_idx).unsqueeze(1)  # [B, 1, T_src]
         tgt_pad_mask = tgt_words.data.eq(pad_idx).unsqueeze(1)  # [B, 1, T_tgt]
 
-        for i in range(self.num_layers):
-            output, attn = self.transformer_layers[i](
+        for i, layer in enumerate(self.transformer_layers):
+            layer_cache = self.state["cache"]["layer_{}".format(i)] \
+                if step is not None else None
+            output, attn = layer(
                 output,
                 src_memory_bank,
                 src_pad_mask,
                 tgt_pad_mask,
-                layer_cache=(
-                    self.state["cache"]["layer_{}".format(i)]
-                    if step is not None else None),
+                layer_cache=layer_cache,
                 step=step)
 
         output = self.layer_norm(output)
@@ -233,29 +221,23 @@ class TransformerDecoder(nn.Module):
         dec_outs = output.transpose(0, 1).contiguous()
         attn = attn.transpose(0, 1).contiguous()
 
-        attns["std"] = attn
+        attns = {"std": attn}
         if self._copy:
             attns["copy"] = attn
 
         # TODO change the way attns is returned dict => list or tuple (onnx)
         return dec_outs, attns
 
-    def _init_cache(self, memory_bank, num_layers, self_attn_type):
+    def _init_cache(self, memory_bank):
         self.state["cache"] = {}
         batch_size = memory_bank.size(1)
         depth = memory_bank.size(-1)
 
-        for l in range(num_layers):
-            layer_cache = {
-                "memory_keys": None,
-                "memory_values": None
-            }
-            if self_attn_type == "scaled-dot":
-                layer_cache["self_keys"] = None
-                layer_cache["self_values"] = None
-            elif self_attn_type == "average":
+        for i in range(len(self.transformer_layers)):
+            layer_cache = {"memory_keys": None, "memory_values": None}
+            if self.self_attn_type == "average":
                 layer_cache["prev_g"] = torch.zeros((batch_size, 1, depth))
             else:
                 layer_cache["self_keys"] = None
                 layer_cache["self_values"] = None
-            self.state["cache"]["layer_{}".format(l)] = layer_cache
+            self.state["cache"]["layer_{}".format(i)] = layer_cache


### PR DESCRIPTION
This PR makes a number of small changes to RNN, CNN, and transformer decoders. All of them had a number of attributes that were either completely unused or could be refactored away.

I noticed something strange in the transformer decoder implementation, which is that setting `-copy_attn` will cause the decoder to have a `GlobalAttention` module for copy attention, but this module was never actually used. What actually happens when one uses copy attention is that the context attention is used for copying. I removed the `GlobalAttention` module from the class.