### PR TITLE
Release running_lock on exceptions

### DIFF
--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -26,7 +26,12 @@ def critical(func):
         if not server_model.running_lock.acquire(blocking=True, timeout=120):
             raise ServerModelError("Model %d running lock timeout"
                                    % server_model.model_id)
-        o = func(server_model, *args, **kwargs)
+        try:
+            o = func(server_model, *args, **kwargs)
+        except (Exception, RuntimeError):
+            server_model.running_lock.release()
+            raise
+
         server_model.running_lock.release()
         return o
     return wrapper


### PR DESCRIPTION
We found that model appears to be locked (i.e. running lock going to timeout).

This could be explained because current code does not release the lock if exception occurs. I modify the `critical` wrapper to release it anyway.