### PR TITLE
Reintroduce partial backward if max_generator_batches > 0

### DIFF
--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -276,7 +276,8 @@ class Trainer(object):
                     shard_size=self.shard_size,
                     trunc_start=j,
                     trunc_size=trunc_size)
-                loss.backward()
+                if loss is not None:
+                    loss.backward()
                 total_stats.update(batch_stats)
                 report_stats.update(batch_stats)
 


### PR DESCRIPTION
The removal changed the memory requirements of the training which could possibly break existing user configurations.

This also reintroduces the unwanted side-effect that the loss computation initiates the backward pass unless max_generator_batches is 0.