### PR TITLE
Let the trainer decide when to save checkpoints

### DIFF
--- a/onmt/models/model_saver.py
+++ b/onmt/models/model_saver.py
@@ -12,7 +12,6 @@ def build_model_saver(model_opt, opt, model, fields, optim):
                              model_opt,
                              fields,
                              optim,
-                             opt.save_checkpoint_steps,
                              opt.keep_checkpoint)
     return model_saver
 
@@ -26,28 +25,23 @@ class ModelSaverBase(object):
     """
 
     def __init__(self, base_path, model, model_opt, fields, optim,
-                 save_checkpoint_steps, keep_checkpoint=-1):
+                 keep_checkpoint=-1):
         self.base_path = base_path
         self.model = model
         self.model_opt = model_opt
         self.fields = fields
         self.optim = optim
         self.keep_checkpoint = keep_checkpoint
-        self.save_checkpoint_steps = save_checkpoint_steps
-
         if keep_checkpoint > 0:
             self.checkpoint_queue = deque([], maxlen=keep_checkpoint)
 
-    def maybe_save(self, step):
+    def save(self, step):
         """
         Main entry point for model saver
         It wraps the `_save` method with checks and apply `keep_checkpoint`
         related logic
         """
         if self.keep_checkpoint == 0:
-            return
-
-        if step % self.save_checkpoint_steps != 0:
             return
 
         chkpt, chkpt_name = self._save(step)
@@ -85,12 +79,6 @@ class ModelSaver(ModelSaverBase):
     """
         Simple model saver to filesystem
     """
-
-    def __init__(self, base_path, model, model_opt, fields, optim,
-                 save_checkpoint_steps, keep_checkpoint=0):
-        super(ModelSaver, self).__init__(
-            base_path, model, model_opt, fields, optim,
-            save_checkpoint_steps, keep_checkpoint)
 
     def _save(self, step):
         real_model = (self.model.module

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -151,6 +151,7 @@ def main(opt, device_id):
     trainer.train(
         train_iter,
         opt.train_steps,
+        save_checkpoint_steps=opt.save_checkpoint_steps,
         valid_iter=valid_iter,
         valid_steps=opt.valid_steps)
 


### PR DESCRIPTION
In particular, the trainer should always save a checkpoint on the last iteration. This PR also adds support for "-save_checkpoint_steps 0" to only save the last checkpoint.