### PR TITLE
Moving average of model parameters

### DIFF
--- a/onmt/models/model_saver.py
+++ b/onmt/models/model_saver.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 from collections import deque
 from onmt.utils.logging import logger
 
+from copy import deepcopy
 
 def build_model_saver(model_opt, opt, model, fields, optim):
     model_saver = ModelSaver(opt.save_model,
@@ -38,7 +39,7 @@ class ModelSaverBase(object):
         if keep_checkpoint > 0:
             self.checkpoint_queue = deque([], maxlen=keep_checkpoint)
 
-    def maybe_save(self, step):
+    def maybe_save(self, step, moving_average=None):
         """
         Main entry point for model saver
         It wraps the `_save` method with checks and apply `keep_checkpoint`
@@ -50,7 +51,17 @@ class ModelSaverBase(object):
         if step % self.save_checkpoint_steps != 0:
             return
 
-        chkpt, chkpt_name = self._save(step)
+        if moving_average:
+            save_model = deepcopy(self.model)
+            for avg, param in zip(moving_average, save_model.parameters()):
+                param.data.copy_(avg.data)
+        else:
+            save_model = self.model
+
+        chkpt, chkpt_name = self._save(step, save_model)
+
+        if moving_average:
+            del save_model
 
         if self.keep_checkpoint > 0:
             if len(self.checkpoint_queue) == self.checkpoint_queue.maxlen:
@@ -92,10 +103,10 @@ class ModelSaver(ModelSaverBase):
             base_path, model, model_opt, fields, optim,
             save_checkpoint_steps, keep_checkpoint)
 
-    def _save(self, step):
-        real_model = (self.model.module
-                      if isinstance(self.model, nn.DataParallel)
-                      else self.model)
+    def _save(self, step, model):
+        real_model = (model.module
+                      if isinstance(model, nn.DataParallel)
+                      else model)
         real_generator = (real_model.generator.module
                           if isinstance(real_model.generator, nn.DataParallel)
                           else real_model.generator)

--- a/onmt/models/model_saver.py
+++ b/onmt/models/model_saver.py
@@ -7,6 +7,7 @@ from onmt.utils.logging import logger
 
 from copy import deepcopy
 
+
 def build_model_saver(model_opt, opt, model, fields, optim):
     model_saver = ModelSaver(opt.save_model,
                              model,

--- a/onmt/models/model_saver.py
+++ b/onmt/models/model_saver.py
@@ -56,7 +56,7 @@ class ModelSaverBase(object):
 
         chkpt, chkpt_name = self._save(step, save_model)
         self.last_saved_step = step
-        
+
         if moving_average:
             del save_model
 

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -435,8 +435,11 @@ def train_opts(parser):
                        https://arxiv.org/abs/1512.00567""")
     group.add('--average_decay', '-average_decay', type=float, default=0,
               help="""Moving average decay.
-                      #TODO Cite Marian Here.
-                      Set to other than 0 (e.g. 1e-4) to activate.""")
+                      Set to other than 0 (e.g. 1e-4) to activate.
+                      Similar to Marian NMT implementation:
+                      http://www.aclweb.org/anthology/P18-4020
+                      For more detail on Exponential Moving Average:
+                      https://en.wikipedia.org/wiki/Moving_average""")
     group.add('--average_every', '-average_every', type=int, default=1,
               help="""Step for moving average.
                       Default is every update,

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -437,6 +437,10 @@ def train_opts(parser):
               help="""Moving average decay.
                       #TODO Cite Marian Here.
                       Set to other than 0 (e.g. 1e-4) to activate.""")
+    group.add('--average_every', '-average_every', type=int, default=1,
+              help="""Step for moving average.
+                      Default is every update,
+                      if -average_decay is set.""")
 
     # learning rate
     group = parser.add_argument_group('Optimization- Rate')

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -433,6 +433,11 @@ def train_opts(parser):
                        Set to zero to turn off label smoothing.
                        For more detailed information, see:
                        https://arxiv.org/abs/1512.00567""")
+    group.add('--average_decay', '-average_decay', type=float, default=0,
+              help="""Moving average decay.
+                      #TODO Cite Marian Here.
+                      Set to other than 0 (e.g. 1e-4) to activate.""")
+
     # learning rate
     group = parser.add_argument_group('Optimization- Rate')
     group.add('--learning_rate', '-learning_rate', type=float, default=1.0,

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -186,18 +186,16 @@ class Trainer(object):
                 report_stats)
 
             if self.average_decay > 0:
-                copy_params = [params.clone().detach()
-                               for params in self.model.parameters()]
-                for param in copy_params:
-                    param.requires_grad = False
                 if self.moving_average is None:
+                    copy_params = [params.detach()
+                                   for params in self.model.parameters()]
                     self.moving_average = copy_params
                 else:
                     for (i, avg), cpt in zip(enumerate(self.moving_average),
-                                             copy_params):
+                                             self.model.parameters()):
                         self.moving_average[i] = \
                             (1 - self.average_decay) * avg + \
-                            self.average_decay * cpt
+                            self.average_decay * cpt.detach()
 
             report_stats = self._maybe_report_training(
                 step, train_steps,

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -238,7 +238,7 @@ class Trainer(object):
                 break
 
         if self.model_saver is not None:
-            self.model_saver.save(step)
+            self.model_saver.save(step, moving_average=self.moving_average)
         return total_stats
 
     def validate(self, valid_iter, moving_average=None):

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -191,7 +191,8 @@ class Trainer(object):
                                    for params in self.model.parameters()]
                     self.moving_average = copy_params
                 else:
-                    average_decay = max(self.average_decay, 1 - (i + 1)/(i + 10))
+                    average_decay = max(self.average_decay,
+                                        1 - (i + 1)/(i + 10))
                     for (i, avg), cpt in zip(enumerate(self.moving_average),
                                              self.model.parameters()):
                         self.moving_average[i] = \
@@ -394,4 +395,4 @@ class Trainer(object):
         Save the model if a model saver is set
         """
         if self.model_saver is not None:
-            self.model_saver.maybe_save(step)
+            self.model_saver.maybe_save(step, moving_average=self.moving_average)

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -191,11 +191,12 @@ class Trainer(object):
                                    for params in self.model.parameters()]
                     self.moving_average = copy_params
                 else:
+                    average_decay = max(self.average_decay, 1 - (i + 1)/(i + 10))
                     for (i, avg), cpt in zip(enumerate(self.moving_average),
                                              self.model.parameters()):
                         self.moving_average[i] = \
-                            (1 - self.average_decay) * avg + \
-                            self.average_decay * cpt.detach()
+                            (1 - average_decay) * avg + \
+                            average_decay * cpt.detach()
 
             report_stats = self._maybe_report_training(
                 step, train_steps,
@@ -233,14 +234,14 @@ class Trainer(object):
         """
         if moving_average:
             valid_model = deepcopy(self.model)
-            for avg, param in zip(self.moving_average, valid_model.parameters()):
+            for avg, param in zip(self.moving_average,
+                                  valid_model.parameters()):
                 param.data = avg.data
         else:
             valid_model = self.model
 
         # Set model in validating mode.
         valid_model.eval()
-
 
         with torch.no_grad():
             stats = onmt.utils.Statistics()


### PR DESCRIPTION
This is in attempt in following the logic implemented in [Marian NMT](https://github.com/marian-nmt/marian) - http://www.aclweb.org/anthology/P18-4020.

- we keep the moving average parameters on the GPU (around 500~600MB for base models);
- leads to ~5% speed decrease if we average every step. 

Features:
- [x] save the moving average instead of last update;
- [x] validate with moving average parameters instead of last update;
- [x] adapt the `average_decay` instead of keeping it fixed;
- [x] add an option to `-average_every` N steps;