### PR TITLE
Training option to iterate on the dataset once

### DIFF
--- a/onmt/models/model_saver.py
+++ b/onmt/models/model_saver.py
@@ -31,6 +31,7 @@ class ModelSaverBase(object):
         self.model_opt = model_opt
         self.fields = fields
         self.optim = optim
+        self.last_saved_step = None
         self.keep_checkpoint = keep_checkpoint
         if keep_checkpoint > 0:
             self.checkpoint_queue = deque([], maxlen=keep_checkpoint)
@@ -41,10 +42,11 @@ class ModelSaverBase(object):
         It wraps the `_save` method with checks and apply `keep_checkpoint`
         related logic
         """
-        if self.keep_checkpoint == 0:
+        if self.keep_checkpoint == 0 or step == self.last_saved_step:
             return
 
         chkpt, chkpt_name = self._save(step)
+        self.last_saved_step = step
 
         if self.keep_checkpoint > 0:
             if len(self.checkpoint_queue) == self.checkpoint_queue.maxlen:

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -388,6 +388,8 @@ def train_opts(parser):
                         uses more memory. Set to 0 to disable.""")
     group.add('--train_steps', '-train_steps', type=int, default=100000,
               help='Number of training steps')
+    group.add('--single_pass', '-single_pass', action='store_true',
+              help="Make a single pass over the training dataset.")
     group.add('--epochs', '-epochs', type=int, default=0,
               help='Deprecated epochs see train_steps')
     group.add('--optim', '-optim', default='sgd',

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -148,9 +148,13 @@ def main(opt, device_id):
         logger.info('Starting training on GPU: %s' % opt.gpu_ranks)
     else:
         logger.info('Starting training on CPU, could be very slow')
+    train_steps = opt.train_steps
+    if opt.single_pass and train_steps > 0:
+        logger.warning("Option single_pass is enabled, ignoring train_steps.")
+        train_steps = 0
     trainer.train(
         train_iter,
-        opt.train_steps,
+        train_steps,
         save_checkpoint_steps=opt.save_checkpoint_steps,
         valid_iter=valid_iter,
         valid_steps=opt.valid_steps)

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -203,14 +203,15 @@ class Trainer(object):
                                   step, valid_stats=valid_stats)
 
             if (self.model_saver is not None
-                and (step == train_steps
-                     or (save_checkpoint_steps != 0
-                         and step % save_checkpoint_steps == 0))):
+                and (save_checkpoint_steps != 0
+                     and step % save_checkpoint_steps == 0)):
                 self.model_saver.save(step)
 
-            if step >= train_steps:
+            if train_steps > 0 and step >= train_steps:
                 break
 
+        if self.model_saver is not None:
+            self.model_saver.save(step)
         return total_stats
 
     def validate(self, valid_iter):

--- a/onmt/utils/statistics.py
+++ b/onmt/utils/statistics.py
@@ -110,10 +110,13 @@ class Statistics(object):
            start (int): start time of step.
         """
         t = self.elapsed_time()
+        step_fmt = "%2d" % step
+        if num_steps > 0:
+            step_fmt = "%s/%5d" % (step_fmt, num_steps)
         logger.info(
-            ("Step %2d/%5d; acc: %6.2f; ppl: %5.2f; xent: %4.2f; " +
+            ("Step %s; acc: %6.2f; ppl: %5.2f; xent: %4.2f; " +
              "lr: %7.5f; %3.0f/%3.0f tok/s; %6.0f sec")
-            % (step, num_steps,
+            % (step_fmt,
                self.accuracy(),
                self.ppl(),
                self.xent(),


### PR DESCRIPTION
I propose a new option `-single_pass` to iterate only once on the dataset. This enables meta training scripts to run the training epoch by epoch, and run arbitrary post-epoch processing such as translation, scoring, etc. In the case of multi-GPU training, we ensure that the total number of batches is a multiple of `opt.accum_cout * opt.world_size` by possibly looping over the dataset.

This also adds support for `-train_steps 0` to iterate on the dataset iterator until exhaustion (which could also be useful for early stopping). With #1272, this combination is now supported:

```text
-save_checkpoint_steps 0 -train_steps 0 -single_pass
```

which means "iterate on the dataset once and save the last checkpoint".