### PR TITLE
Remove non-base datasets.

### DIFF
--- a/onmt/inputters/__init__.py
+++ b/onmt/inputters/__init__.py
@@ -6,18 +6,18 @@ e.g., from a line of text to a sequence of embeddings.
 from onmt.inputters.inputter import \
     load_old_vocab, get_fields, OrderedIterator, \
     build_dataset, build_vocab, old_style_vocab
-from onmt.inputters.dataset_base import DatasetBase
-from onmt.inputters.text_dataset import TextDataset, TextDataReader
-from onmt.inputters.image_dataset import ImageDataset, ImageDataReader
-from onmt.inputters.audio_dataset import AudioDataset, AudioDataReader
+from onmt.inputters.dataset_base import Dataset
+from onmt.inputters.text_dataset import text_sort_key, TextDataReader
+from onmt.inputters.image_dataset import img_sort_key, ImageDataReader
+from onmt.inputters.audio_dataset import audio_sort_key, AudioDataReader
 from onmt.inputters.datareader_base import DataReaderBase
 
 
 str2reader = {
     "text": TextDataReader, "img": ImageDataReader, "audio": AudioDataReader}
 
-__all__ = ['DatasetBase', 'load_old_vocab', 'get_fields', 'DataReaderBase',
+__all__ = ['Dataset', 'load_old_vocab', 'get_fields', 'DataReaderBase',
            'build_dataset', 'old_style_vocab',
            'build_vocab', 'OrderedIterator',
-           'TextDataset', 'ImageDataset', 'AudioDataset',
+           'text_sort_key', 'img_sort_key', 'audio_sort_key',
            'TextDataReader', 'ImageDataReader', 'AudioDataReader']

--- a/onmt/inputters/__init__.py
+++ b/onmt/inputters/__init__.py
@@ -5,7 +5,7 @@ e.g., from a line of text to a sequence of embeddings.
 """
 from onmt.inputters.inputter import \
     load_old_vocab, get_fields, OrderedIterator, \
-    build_dataset, build_vocab, old_style_vocab
+    build_vocab, old_style_vocab, filter_example
 from onmt.inputters.dataset_base import Dataset
 from onmt.inputters.text_dataset import text_sort_key, TextDataReader
 from onmt.inputters.image_dataset import img_sort_key, ImageDataReader
@@ -15,9 +15,12 @@ from onmt.inputters.datareader_base import DataReaderBase
 
 str2reader = {
     "text": TextDataReader, "img": ImageDataReader, "audio": AudioDataReader}
+str2sortkey = {
+    'text': text_sort_key, 'img': img_sort_key, 'audio': audio_sort_key}
+
 
 __all__ = ['Dataset', 'load_old_vocab', 'get_fields', 'DataReaderBase',
-           'build_dataset', 'old_style_vocab',
+           'filter_example', 'old_style_vocab',
            'build_vocab', 'OrderedIterator',
            'text_sort_key', 'img_sort_key', 'audio_sort_key',
            'TextDataReader', 'ImageDataReader', 'AudioDataReader']

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -5,7 +5,6 @@ from tqdm import tqdm
 import torch
 from torchtext.data import Field
 
-from onmt.inputters.dataset_base import DatasetBase
 from onmt.inputters.datareader_base import DataReaderBase
 
 # imports of datatype-specific dependencies
@@ -129,11 +128,9 @@ class AudioDataReader(DataReaderBase):
             yield {side: spect, side + '_path': line, 'indices': i}
 
 
-class AudioDataset(DatasetBase):
-    @staticmethod
-    def sort_key(ex):
-        """Sort using duration time of the sound spectrogram."""
-        return ex.src.size(1)
+def audio_sort_key(ex):
+    """Sort using duration time of the sound spectrogram."""
+    return ex.src.size(1)
 
 
 class AudioSeqField(Field):

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -9,6 +9,56 @@ from torchtext.data import Example
 from torchtext.vocab import Vocab
 
 
+def _join_dicts(*args):
+    """
+    Args:
+        dictionaries with disjoint keys.
+
+    Returns:
+        a single dictionary that has the union of these keys.
+    """
+
+    return dict(chain(*[d.items() for d in args]))
+
+
+def _dynamic_dict(example, src_field, tgt_field):
+    """Create copy-vocab and numericalize with it.
+
+    In-place adds ``"src_map"`` to ``example``. That is the copy-vocab
+    numericalization of the tokenized ``example["src"]``. If ``example``
+    has a ``"tgt"`` key, adds ``"alignment"`` to example. That is the
+    copy-vocab numericalization of the tokenized ``example["tgt"]``. The
+    alignment has an initial and final UNK token to match the BOS and EOS
+    tokens.
+
+    Args:
+        example (dict): An example dictionary with a ``"src"`` key and
+            maybe a ``"tgt"`` key. (This argument changes in place!)
+        src_field (torchtext.data.Field): Field object.
+        tgt_field (torchtext.data.Field): Field object.
+
+    Returns:
+        torchtext.data.Vocab and ``example``, changed as described.
+    """
+
+    src = src_field.tokenize(example["src"])
+    # make a small vocab containing just the tokens in the source sequence
+    unk = src_field.unk_token
+    pad = src_field.pad_token
+    src_ex_vocab = Vocab(Counter(src), specials=[unk, pad])
+    unk_idx = src_ex_vocab.stoi[unk]
+    # Map source tokens to indices in the dynamic dict.
+    src_map = torch.LongTensor([src_ex_vocab.stoi[w] for w in src])
+    example["src_map"] = src_map
+
+    if "tgt" in example:
+        tgt = tgt_field.tokenize(example["tgt"])
+        mask = torch.LongTensor(
+            [unk_idx] + [src_ex_vocab.stoi[w] for w in tgt] + [unk_idx])
+        example["alignment"] = mask
+    return src_ex_vocab, example
+
+
 class Dataset(TorchtextDataset):
     """Contain data and process it.
 
@@ -50,13 +100,16 @@ class Dataset(TorchtextDataset):
             indicating whether to include that example in the dataset.
 
     Attributes:
-        src_vocabs (List): Used with dynamic dict/copy attention.
+        src_vocabs (List[torchtext.data.Vocab]): Used with dynamic dict/copy
+            attention. There is a very short vocab for each src example.
+            It contains just the source words, e.g. so that the generator can
+            predict to copy them.
     """
 
     def __init__(self, fields, readers, data, dirs, sort_key,
                  filter_pred=None):
         self.sort_key = sort_key
-        dynamic_dict = 'src_map' in fields and 'alignment' in fields
+        can_copy = 'src_map' in fields and 'alignment' in fields
 
         read_iters = [r.read(dat[1], dat[0], dir_) for r, dat, dir_
                       in zip(readers, data, dirs)]
@@ -64,14 +117,14 @@ class Dataset(TorchtextDataset):
         # self.src_vocabs is used in collapse_copy_scores and Translator.py
         self.src_vocabs = []
         examples = []
-        for ex_dict in starmap(self._join_dicts, zip(*read_iters)):
-            if dynamic_dict:
+        for ex_dict in starmap(_join_dicts, zip(*read_iters)):
+            if can_copy:
                 src_field = fields['src'][0][1]
                 tgt_field = fields['tgt'][0][1]
                 # this assumes src_field and tgt_field are both text
-                src_vocab, ex_dict = self._dynamic_dict(
+                src_ex_vocab, ex_dict = _dynamic_dict(
                     ex_dict, src_field.base_field, tgt_field.base_field)
-                self.src_vocabs.append(src_vocab)
+                self.src_vocabs.append(src_ex_vocab)
             ex_fields = {k: v for k, v in fields.items() if k in ex_dict}
             ex = Example.fromdict(ex_dict, ex_fields)
             examples.append(ex)
@@ -94,31 +147,3 @@ class Dataset(TorchtextDataset):
         if remove_fields:
             self.fields = []
         torch.save(self, path)
-
-    def _join_dicts(self, *args):
-        """
-        Args:
-            dictionaries with disjoint keys.
-
-        Returns:
-            a single dictionary that has the union of these keys.
-        """
-
-        return dict(chain(*[d.items() for d in args]))
-
-    def _dynamic_dict(self, example, src_field, tgt_field):
-        src = src_field.tokenize(example["src"])
-        # make a small vocab containing just the tokens in the source sequence
-        unk = src_field.unk_token
-        pad = src_field.pad_token
-        src_vocab = Vocab(Counter(src), specials=[unk, pad])
-        # Map source tokens to indices in the dynamic dict.
-        src_map = torch.LongTensor([src_vocab.stoi[w] for w in src])
-        example["src_map"] = src_map
-
-        if "tgt" in example:
-            tgt = tgt_field.tokenize(example["tgt"])
-            mask = torch.LongTensor(
-                [0] + [src_vocab.stoi[w] for w in tgt] + [0])
-            example["alignment"] = mask
-        return src_vocab, example

--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -4,11 +4,12 @@ from itertools import chain, starmap
 from collections import Counter
 
 import torch
-from torchtext.data import Example, Dataset
+from torchtext.data import Dataset as TorchtextDataset
+from torchtext.data import Example
 from torchtext.vocab import Vocab
 
 
-class DatasetBase(Dataset):
+class Dataset(TorchtextDataset):
     """
     A dataset is an object that accepts sequences of raw data (sentence pairs
     in the case of machine translation) and fields which describe how this
@@ -50,7 +51,9 @@ class DatasetBase(Dataset):
         the same structure as in the fields argument passed to the constructor.
     """
 
-    def __init__(self, fields, readers, data, dirs, filter_pred=None):
+    def __init__(self, fields, readers, data, dirs, sort_key,
+                 filter_pred=None):
+        self.sort_key = sort_key
         dynamic_dict = 'src_map' in fields and 'alignment' in fields
 
         read_iters = [r.read(dat[1], dat[0], dir_) for r, dat, dir_
@@ -74,7 +77,7 @@ class DatasetBase(Dataset):
         # the dataset's self.fields should have the same attributes as examples
         fields = dict(chain.from_iterable(ex_fields.values()))
 
-        super(DatasetBase, self).__init__(examples, fields, filter_pred)
+        super(Dataset, self).__init__(examples, fields, filter_pred)
 
     def __getattr__(self, attr):
         # avoid infinite recursion when fields isn't defined

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -5,7 +5,6 @@ import os
 import torch
 from torchtext.data import Field
 
-from onmt.inputters.dataset_base import DatasetBase
 from onmt.inputters.datareader_base import DataReaderBase
 
 # domain specific dependencies
@@ -84,11 +83,9 @@ class ImageDataReader(DataReaderBase):
             yield {side: img, side + '_path': filename, 'indices': i}
 
 
-class ImageDataset(DatasetBase):
-    @staticmethod
-    def sort_key(ex):
-        """Sort using the size of the image: (width, height)."""
-        return ex.src.size(2), ex.src.size(1)
+def img_sort_key(ex):
+    """Sort using the size of the image: (width, height)."""
+    return ex.src.size(2), ex.src.size(1)
 
 
 def batch_img(data, vocab):

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -6,18 +6,15 @@ import math
 
 from collections import Counter, defaultdict
 from itertools import chain, cycle
-from functools import partial
 
 import torch
 import torchtext.data
 from torchtext.data import Field
 from torchtext.vocab import Vocab
 
-from onmt.inputters.dataset_base import Dataset
-from onmt.inputters.text_dataset import text_sort_key, text_fields,\
-    TextMultiField
-from onmt.inputters.image_dataset import img_sort_key, image_fields
-from onmt.inputters.audio_dataset import audio_sort_key, audio_fields
+from onmt.inputters.text_dataset import text_fields, TextMultiField
+from onmt.inputters.image_dataset import image_fields
+from onmt.inputters.audio_dataset import audio_fields
 from onmt.utils.logging import logger
 # backwards compatibility
 from onmt.inputters.text_dataset import _feature_tokenize  # noqa: F401
@@ -247,53 +244,6 @@ def filter_example(ex, use_src_len=True, use_tgt_len=True,
     tgt_len = len(ex.tgt[0])
     return (not use_src_len or min_src_len <= src_len <= max_src_len) and \
         (not use_tgt_len or min_tgt_len <= tgt_len <= max_tgt_len)
-
-
-def build_dataset(fields, data_type, src, src_reader,
-                  src_dir=None, tgt=None, tgt_reader=None,
-                  src_seq_len=50, tgt_seq_len=50, use_filter_pred=True):
-    """Create a dataset from data on disk.
-
-    Args:
-        fields (dict[str, List[Tuple[str, Field]]]): A dict with top-level
-            keys for the sides (e.x., ``'src'``, ``'tgt'``) mapping to
-            lists of (name, Field) pairs.
-        data_type (str): A supported datatype.
-        src: See :func:`src_reader.read()` for details.
-        src_reader (onmt.inputters.DataReaderBase): The disk-to-dict
-            reader for src data.
-        src_dir: See :func:`src_reader.read()` for details.
-        tgt: See :func:`tgt_reader.read()` for details.
-        tgt_reader (onmt.inputters.TextDataReader): Similar to above.
-        src_seq_len: Max acceptable src sequence length. See
-            :func:`filter_example()` for details.
-        tgt_seq_len: Similar to above.
-        use_filter_pred (bool): Whether or not to apply length filtering.
-    """
-
-    sort_keys = {
-        'text': text_sort_key, 'img': img_sort_key, 'audio': audio_sort_key
-    }
-    assert data_type in sort_keys
-    assert src is not None
-
-    # the second conjunct means nothing will be filtered at translation time
-    # if there is no target data
-    if use_filter_pred and tgt is not None:
-        filter_pred = partial(
-            filter_example, use_src_len=data_type == 'text',
-            max_src_len=src_seq_len, max_tgt_len=tgt_seq_len
-        )
-    else:
-        filter_pred = None
-
-    return Dataset(
-        fields,
-        readers=[src_reader, tgt_reader] if tgt else [src_reader],
-        data=[("src", src), ("tgt", tgt)] if tgt else [("src", src)],
-        dirs=[src_dir, None] if tgt else [src_dir],
-        sort_key=sort_keys[data_type],
-        filter_pred=filter_pred)
 
 
 def _pad_vocab_to_multiple(vocab, multiple):

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -13,10 +13,11 @@ import torchtext.data
 from torchtext.data import Field
 from torchtext.vocab import Vocab
 
-from onmt.inputters.text_dataset import TextDataset, text_fields,\
+from onmt.inputters.dataset_base import Dataset
+from onmt.inputters.text_dataset import text_sort_key, text_fields,\
     TextMultiField
-from onmt.inputters.image_dataset import ImageDataset, image_fields
-from onmt.inputters.audio_dataset import AudioDataset, audio_fields
+from onmt.inputters.image_dataset import img_sort_key, image_fields
+from onmt.inputters.audio_dataset import audio_sort_key, audio_fields
 from onmt.utils.logging import logger
 # backwards compatibility
 from onmt.inputters.text_dataset import _feature_tokenize  # noqa: F401
@@ -270,10 +271,10 @@ def build_dataset(fields, data_type, src, src_reader,
         use_filter_pred (bool): Whether or not to apply length filtering.
     """
 
-    dataset_classes = {
-        'text': TextDataset, 'img': ImageDataset, 'audio': AudioDataset
+    sort_keys = {
+        'text': text_sort_key, 'img': img_sort_key, 'audio': audio_sort_key
     }
-    assert data_type in dataset_classes
+    assert data_type in sort_keys
     assert src is not None
 
     # the second conjunct means nothing will be filtered at translation time
@@ -286,11 +287,12 @@ def build_dataset(fields, data_type, src, src_reader,
     else:
         filter_pred = None
 
-    return dataset_classes[data_type](
+    return Dataset(
         fields,
         readers=[src_reader, tgt_reader] if tgt else [src_reader],
         data=[("src", src), ("tgt", tgt)] if tgt else [("src", src)],
         dirs=[src_dir, None] if tgt else [src_dir],
+        sort_key=sort_keys[data_type],
         filter_pred=filter_pred)
 
 

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -5,7 +5,6 @@ import six
 import torch
 from torchtext.data import Field, RawField
 
-from onmt.inputters.dataset_base import DatasetBase
 from onmt.inputters.datareader_base import DataReaderBase
 
 
@@ -36,13 +35,11 @@ class TextDataReader(DataReaderBase):
             yield {side: seq, "indices": i}
 
 
-class TextDataset(DatasetBase):
-    @staticmethod
-    def sort_key(ex):
-        """Sort using the number of tokens in the sequence."""
-        if hasattr(ex, "tgt"):
-            return len(ex.src[0]), len(ex.tgt[0])
-        return len(ex.src[0])
+def text_sort_key(ex):
+    """Sort using the number of tokens in the sequence."""
+    if hasattr(ex, "tgt"):
+        return len(ex.src[0]), len(ex.tgt[0])
+    return len(ex.src[0])
 
 
 # mix this with partial

--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -2,7 +2,7 @@
 from __future__ import unicode_literals, print_function
 
 import torch
-from onmt.inputters.text_dataset import TextDataset
+from onmt.inputters.text_dataset import TextMultiField
 
 
 class TranslationBuilder(object):
@@ -25,6 +25,8 @@ class TranslationBuilder(object):
                  has_tgt=False):
         self.data = data
         self.fields = fields
+        self._has_text_src = isinstance(
+            self.fields["src"][0][1], TextMultiField)
         self.n_best = n_best
         self.replace_unk = replace_unk
         self.has_tgt = has_tgt
@@ -64,7 +66,7 @@ class TranslationBuilder(object):
 
         # Sorting
         inds, perm = torch.sort(batch.indices)
-        if isinstance(self.data, TextDataset):
+        if self._has_text_src:
             src = batch.src[0][:, :, 0].index_select(1, perm)
         else:
             src = None
@@ -73,7 +75,7 @@ class TranslationBuilder(object):
 
         translations = []
         for b in range(batch_size):
-            if isinstance(self.data, TextDataset):
+            if self._has_text_src:
                 src_vocab = self.data.src_vocabs[inds[b]] \
                     if self.data.src_vocabs else None
                 src_raw = self.data.examples[inds[b]].src[0]

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -129,6 +129,7 @@ class Translator(object):
         self.logger = logger
 
         self.use_filter_pred = False
+        self._filter_pred = None
 
         # for debugging
         self.beam_trace = self.dump_beam != ""
@@ -183,15 +184,14 @@ class Translator(object):
         if batch_size is None:
             raise ValueError("batch_size must be set")
 
-        data = inputters.build_dataset(
+        data = inputters.Dataset(
             self.fields,
-            self.data_type,
-            src=src,
-            src_reader=self.src_reader,
-            tgt=tgt,
-            tgt_reader=self.tgt_reader,
-            src_dir=src_dir,
-            use_filter_pred=self.use_filter_pred,
+            readers=([self.src_reader, self.tgt_reader]
+                     if tgt else [self.src_reader]),
+            data=[("src", src), ("tgt", tgt)] if tgt else [("src", src)],
+            dirs=[src_dir, None] if tgt else [src_dir],
+            sort_key=inputters.str2sortkey[self.data_type],
+            filter_pred=self._filter_pred
         )
 
         cur_device = "cuda" if self.cuda else "cpu"


### PR DESCRIPTION
The various [Datatype]Dataset's are just shells that define a ``sort_key`` static method. Since ``torchtext.data.Dataset`` only uses the ``sort_key`` attribute attached to the instance ``self`` (despite defining it at the class level) , we can just make the ``sort_key`` an instance attribute of the ``DatasetBase``. Consequently ``DatasetBase`` is now a general ``Dataset``. After this PR, the file dataset_base.py should be renamed to dataset.py.