### PR TITLE
Freeze tqdm version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 six
-tqdm
+tqdm==4.30.*
 torch>=1.0
 git+https://github.com/pytorch/text
 future


### PR DESCRIPTION
For some reason, the [latest version of the tqdm package](https://github.com/tqdm/tqdm/releases/tag/v4.31.0) is causing issues when run inside Travis. Let's freeze the required version until there is a good reason to update this package.