### PR TITLE
Better buffering, readability in beam_search; random sampling class

### DIFF
--- a/onmt/tests/test_beam.py
+++ b/onmt/tests/test_beam.py
@@ -134,8 +134,6 @@ class TestBeam(unittest.TestCase):
             [6., 5., 4., 3., 2., 1.]), dim=0)
         min_length = 5
         eos_idx = 2
-        # beam includes start token in cur_len count.
-        # Add one to its min_length to compensate
         beam = Beam(beam_sz, 0, 1, eos_idx, n_best=2,
                     exclusion_tokens=set(),
                     min_length=min_length,
@@ -186,8 +184,6 @@ class TestBeam(unittest.TestCase):
             [6., 5., 4., 3., 2., 1.]), dim=0)
         min_length = 5
         eos_idx = 2
-        # beam includes start token in cur_len count.
-        # Add one to its min_length to compensate
         beam = Beam(beam_sz, 0, 1, eos_idx, n_best=2,
                     exclusion_tokens=set(),
                     min_length=min_length,

--- a/onmt/translate/beam_search.py
+++ b/onmt/translate/beam_search.py
@@ -1,7 +1,9 @@
 import torch
 
+from onmt.translate.decode_strategy import DecodeStrategy
 
-class BeamSearch(object):
+
+class BeamSearch(DecodeStrategy):
     """Generation beam search.
 
     Note that the attributes list is not exhaustive. Rather, it highlights
@@ -10,25 +12,20 @@ class BeamSearch(object):
     ``batch_size``).
 
     Args:
-        beam_size (int): Number of beams to use.
-        batch_size (int): Current batch size.
-        pad (int): Magic integer in output vocab.
-        bos (int): Magic integer in output vocab.
-        eos (int): Magic integer in output vocab.
+        beam_size (int): Number of beams to use (see base ``parallel_paths``).
+        batch_size (int): See base.
+        pad (int): See base.
+        bos (int): See base.
+        eos (int): See base.
         n_best (int): Don't stop until at least this many beams have
             reached EOS.
-        mb_device (torch.device or str): Device for memory bank (encoder).
+        mb_device (torch.device or str): See base ``device``.
         global_scorer (onmt.translate.GNMTGlobalScorer): Scorer instance.
-        min_length (int): Shortest acceptable generation, not counting
-            begin-of-sentence or end-of-sentence.
-        max_length (int): Longest acceptable sequence, not counting
-            begin-of-sentence (presumably there has been no EOS
-            yet if max_length is used as a cutoff).
-        return_attention (bool): Whether to work with attention too.
-        block_ngram_repeat (int): Block beams where
-            ``block_ngram_repeat``-grams repeat.
-        exclusion_tokens (set[str]): If a gram contains any of these
-            tokens, it may repeat.
+        min_length (int): See base.
+        max_length (int): See base.
+        return_attention (bool): See base.
+        block_ngram_repeat (int): See base.
+        exclusion_tokens (set[int]): See base.
         memory_lengths (torch.LongTensor): Lengths of encodings. Used for
             masking attentions.
 
@@ -36,19 +33,12 @@ class BeamSearch(object):
         top_beam_finished (torch.ByteTensor): Shape ``(B,)``.
         _batch_offset (torch.LongTensor): Shape ``(B,)``.
         _beam_offset (torch.LongTensor): Shape ``(batch_size x beam_size)``.
-        alive_seq (torch.LongTensor): Shape ``(B x beam_size, step)``. This
-            sequence grows in the ``step`` axis on each call to
-            :func:`advance()`.
+        alive_seq (torch.LongTensor): See base.
         topk_log_probs (torch.FloatTensor): Shape ``(B x beam_size,)``. These
             are the scores used for the topk operation.
-        alive_attn (torch.FloatTensor or NoneType): If tensor, shape is
-            ``(step, B x beam_size, inp_seq_len)``, where ``inp_seq_len``
-            is the (max) length of the input sequence.
         select_indices (torch.LongTensor or NoneType): Shape
             ``(B x beam_size,)``. This is just a flat view of the
             ``_batch_index``.
-        is_finished (torch.ByteTensor or NoneType): Shape
-            ``(B, beam_size)``. Initialized to ``None``.
         topk_scores (torch.FloatTensor): Shape
             ``(B, beam_size)``. These are the
             scores a sequence will receive if it finishes.
@@ -61,41 +51,24 @@ class BeamSearch(object):
             ``(1, B x beam_size, inp_seq_len)``.
         hypotheses (list[list[Tuple[torch.Tensor]]]): Contains a tuple
             of score (float), sequence (long), and attention (float or None).
-        scores (list[list[torch.FloatTensor]]): For each batch, holds a
-            list of beam scores.
-        predictions (list[list[torch.LongTensor]]): For each batch, holds a
-            list of beam prediction sequences.
-        attention (list[list[torch.FloatTensor or list[]]]): For each batch,
-            holds a list of beam attention sequence tensors (or empty lists)
-            having shape ``(step, inp_seq_len)`` where ``inp_seq_len`` is the
-            length of the sample (not the max length of all inp seqs).
     """
 
     def __init__(self, beam_size, batch_size, pad, bos, eos, n_best, mb_device,
                  global_scorer, min_length, max_length, return_attention,
                  block_ngram_repeat, exclusion_tokens, memory_lengths,
                  stepwise_penalty):
-        # magic indices
-        self.pad = pad
-        self.eos = eos
-        self.bos = bos
-
+        super(BeamSearch, self).__init__(
+            pad, bos, eos, batch_size, mb_device, beam_size, min_length,
+            block_ngram_repeat, exclusion_tokens, return_attention,
+            max_length)
         # beam parameters
-        self.min_length = min_length
         self.global_scorer = global_scorer
         self.beam_size = beam_size
-        self.max_length = max_length
-        self.return_attention = return_attention
         self.n_best = n_best
         self.batch_size = batch_size
-        self.block_ngram_repeat = block_ngram_repeat
-        self.exclusion_tokens = exclusion_tokens
 
         # result caching
         self.hypotheses = [[] for _ in range(batch_size)]
-        self.predictions = [[] for _ in range(batch_size)]
-        self.scores = [[] for _ in range(batch_size)]
-        self.attention = [[] for _ in range(batch_size)]
 
         # beam state
         self.top_beam_finished = torch.zeros([batch_size], dtype=torch.uint8)
@@ -103,15 +76,10 @@ class BeamSearch(object):
         self._beam_offset = torch.arange(
             0, batch_size * beam_size, step=beam_size, dtype=torch.long,
             device=mb_device)
-        self.alive_seq = torch.full(
-            [batch_size * beam_size, 1], self.bos, dtype=torch.long,
-            device=mb_device)
         self.topk_log_probs = torch.tensor(
             [0.0] + [float("-inf")] * (beam_size - 1), device=mb_device
         ).repeat(batch_size)
-        self.alive_attn = None
         self.select_indices = None
-        self.is_finished = None
         self._memory_lengths = memory_lengths
 
         # buffers for the topk scores and 'backpointer'
@@ -159,32 +127,13 @@ class BeamSearch(object):
                 _B, self.beam_size)
 
         # force the output to be longer than self.min_length
-        step = self.alive_seq.shape[1]
-        if step <= self.min_length:
-            log_probs[:, self.eos] = -1e20
+        step = len(self)
+        self.ensure_min_length(log_probs)
 
         # Multiply probs by the beam probability.
         log_probs += self.topk_log_probs.view(_B * self.beam_size, 1)
 
-        # block ngram repeats
-        if self.block_ngram_repeat > 0 and step > 1:
-            # iterate over all batches, over all beams
-            for bk in range(self.alive_seq.shape[0]):
-                hyp = self.alive_seq[bk, 1:]
-                ngrams = set()
-                fail = False
-                gram = []
-                for i in range(step - 1):
-                    # Last n tokens, n = block_ngram_repeat
-                    gram = (gram + [hyp[i].item()])[-self.block_ngram_repeat:]
-                    # skip the blocking if any token in gram is excluded
-                    if set(gram) & self.exclusion_tokens:
-                        continue
-                    if tuple(gram) in ngrams:
-                        fail = True
-                    ngrams.add(tuple(gram))
-                if fail:
-                    log_probs[bk] = -10e20
+        self.block_ngram_repeats(log_probs)
 
         # if the sequence ends now, then the penalty is the current
         # length + 1, to include the EOS token
@@ -242,8 +191,7 @@ class BeamSearch(object):
             self.topk_scores -= cov_penalty.view(_B, self.beam_size)
 
         self.is_finished = self.topk_ids.eq(self.eos)
-        if step == self.max_length:
-            self.is_finished.fill_(1)
+        self.ensure_max_length()
 
     def update_finished(self):
         # Penalize beams that finished.

--- a/onmt/translate/beam_search.py
+++ b/onmt/translate/beam_search.py
@@ -52,11 +52,9 @@ class BeamSearch(object):
         topk_scores (torch.FloatTensor): Shape
             ``(B, beam_size)``. These are the
             scores a sequence will receive if it finishes.
-        topk_ids (torch.LongTensor): Shape
-            ``(B, beam_size)``. These are the
+        topk_ids (torch.LongTensor): Shape `(B, beam_size)``. These are the
             word indices of the topk predictions.
-        _batch_index (torch.LongTensor or NoneType): Shape
-            ``(B, beam_size)``.
+        _batch_index (torch.LongTensor): Shape ``(B, beam_size)``.
         _prev_penalty (torch.FloatTensor or NoneType): Shape
             ``(B, beam_size)``. Initialized to ``None``.
         _coverage (torch.FloatTensor or NoneType): Shape

--- a/onmt/translate/decode_strategy.py
+++ b/onmt/translate/decode_strategy.py
@@ -1,0 +1,136 @@
+import torch
+
+
+class DecodeStrategy(object):
+    """Base class for generation strategies.
+
+    Args:
+        pad (int): Magic integer in output vocab.
+        bos (int): Magic integer in output vocab.
+        eos (int): Magic integer in output vocab.
+        batch_size (int): Current batch size.
+        device (torch.device or str): Device for memory bank (encoder).
+        parallel_paths (int): Decoding strategies like beam search
+            use parallel paths. Each batch is repeated ``parallel_paths``
+            times in relevant state tensors.
+        min_length (int): Shortest acceptable generation, not counting
+            begin-of-sentence or end-of-sentence.
+        max_length (int): Longest acceptable sequence, not counting
+            begin-of-sentence (presumably there has been no EOS
+            yet if max_length is used as a cutoff).
+        block_ngram_repeat (int): Block beams where
+            ``block_ngram_repeat``-grams repeat.
+        exclusion_tokens (set[int]): If a gram contains any of these
+            tokens, it may repeat.
+        return_attention (bool): Whether to work with attention too.
+
+    Attributes:
+        pad (int): See above.
+        bos (int): See above.
+        eos (int): See above.
+        predictions (list[list[torch.LongTensor]]): For each batch, holds a
+            list of beam prediction sequences.
+        scores (list[list[torch.FloatTensor]]): For each batch, holds a
+            list of beam scores.
+        attention (list[list[torch.FloatTensor or list[]]]): For each
+            batch, holds a list of beam attention sequence tensors
+            (or empty lists) having shape ``(step, inp_seq_len)`` where
+            ``inp_seq_len`` is the length of the sample (not the max
+            length of all inp seqs).
+        alive_seq (torch.LongTensor): Shape ``(B x parallel_paths, step)``.
+            This sequence grows in the ``step`` axis on each call to
+            :func:`advance()`.
+        is_finished (torch.ByteTensor or NoneType): Shape
+            ``(B, parallel_paths)``. Initialized to ``None``.
+        alive_attn (torch.FloatTensor or NoneType): If tensor, shape is
+            ``(step, B x parallel_paths, inp_seq_len)``, where ``inp_seq_len``
+            is the (max) length of the input sequence.
+        min_length (int): See above.
+        max_length (int): See above.
+        block_ngram_repeat (int): See above.
+        exclusion_tokens (set[int]): See above.
+        return_attention (bool): See above.
+        done (bool): See above.
+
+    """
+    def __init__(self, pad, bos, eos, batch_size, device, parallel_paths,
+                 min_length, block_ngram_repeat, exclusion_tokens,
+                 return_attention, max_length):
+
+        # magic indices
+        self.pad = pad
+        self.bos = bos
+        self.eos = eos
+
+        # result caching
+        self.predictions = [[] for _ in range(batch_size)]
+        self.scores = [[] for _ in range(batch_size)]
+        self.attention = [[] for _ in range(batch_size)]
+
+        self.alive_seq = torch.full(
+            [batch_size * parallel_paths, 1], self.bos,
+            dtype=torch.long, device=device)
+        self.is_finished = torch.zeros(
+            [batch_size, parallel_paths],
+            dtype=torch.uint8, device=device)
+        self.alive_attn = None
+
+        self.min_length = min_length
+        self.max_length = max_length
+        self.block_ngram_repeat = block_ngram_repeat
+        self.exclusion_tokens = exclusion_tokens
+        self.return_attention = return_attention
+
+        self.done = False
+
+    def __len__(self):
+        return self.alive_seq.shape[1]
+
+    def ensure_min_length(self, log_probs):
+        if len(self) <= self.min_length:
+            log_probs[:, self.eos] = -1e20
+
+    def ensure_max_length(self):
+        # add one to account for BOS. Don't account for EOS because hitting
+        # this implies it hasn't been found.
+        if len(self) == self.max_length + 1:
+            self.is_finished.fill_(1)
+
+    def block_ngram_repeats(self, log_probs):
+        cur_len = len(self)
+        if self.block_ngram_repeat > 0 and cur_len > 1:
+            for path_idx in range(self.alive_seq.shape[0]):
+                # skip BOS
+                hyp = self.alive_seq[path_idx, 1:]
+                ngrams = set()
+                fail = False
+                gram = []
+                for i in range(cur_len - 1):
+                    # Last n tokens, n = block_ngram_repeat
+                    gram = (gram + [hyp[i].item()])[-self.block_ngram_repeat:]
+                    # skip the blocking if any token in gram is excluded
+                    if set(gram) & self.exclusion_tokens:
+                        continue
+                    if tuple(gram) in ngrams:
+                        fail = True
+                    ngrams.add(tuple(gram))
+                if fail:
+                    log_probs[path_idx] = -10e20
+
+    def advance(self, log_probs, attn):
+        """DecodeStrategy subclasses should override :func:`advance()`.
+
+        Advance is used to update ``self.alive_seq``, ``self.is_finished``,
+        and, when appropriate, ``self.alive_attn``.
+        """
+
+        raise NotImplementedError()
+
+    def update_finished(self):
+        """DecodeStrategy subclasses should override :func:`update_finished()`.
+
+        ``update_finished`` is used to update ``self.predictions``,
+        ``self.scores``, and other "output" attributes.
+        """
+
+        raise NotImplementedError()

--- a/onmt/translate/random_sampling.py
+++ b/onmt/translate/random_sampling.py
@@ -1,0 +1,130 @@
+import torch
+
+from onmt.translate.decode_strategy import DecodeStrategy
+
+
+def sample_with_temperature(logits, sampling_temp, keep_topk):
+    """Select next tokens randomly from the top k possible next tokens.
+
+    Samples from a categorical distribution over the ``keep_topk`` words using
+    the category probabilities ``logits / sampling_temp``.
+
+    Args:
+        logits (torch.FloatTensor): Shaped ``(batch_size, vocab_size)``.
+            These can be logits (``(-inf, inf)``) or log-probs (``(-inf, 0]``).
+            (The distribution actually uses the log-probabilities
+            ``logits - logits.logsumexp(-1)``, which equals the logits if
+            they are log-probabilities summing to 1.)
+        sampling_temp (float): Used to scale down logits. The higher the
+            value, the more likely it is that a non-max word will be
+            sampled.
+        keep_topk (int): This many words could potentially be chosen. The
+            other logits are set to have probability 0.
+
+    Returns:
+        topk_ids (torch.LongTensor): Shaped ``(batch_size, 1)``. These are
+            the sampled word indices in the output vocab.
+        topk_scores (torch.FloatTensor): Shaped ``(batch_size, 1)``. These
+            are essentially ``(logits / sampling_temp)[topk_ids]``.
+    """
+
+    if sampling_temp == 0.0 or keep_topk == 1:
+        # For temp=0.0, take the argmax to avoid divide-by-zero errors.
+        # keep_topk=1 is also equivalent to argmax.
+        topk_scores, topk_ids = logits.topk(1, dim=-1)
+    else:
+        logits = torch.div(logits, sampling_temp)
+
+        if keep_topk > 0:
+            top_values, top_indices = torch.topk(logits, keep_topk, dim=1)
+            kth_best = top_values[:, -1].view([-1, 1])
+            kth_best = kth_best.repeat([1, logits.shape[1]]).float()
+
+            # Set all logits that are not in the top-k to -10000.
+            # This puts the probabilities close to 0.
+            ignore = torch.lt(logits, kth_best)
+            logits = logits.masked_fill(ignore, -10000)
+
+        dist = torch.distributions.Multinomial(
+            logits=logits, total_count=1)
+        topk_ids = torch.argmax(dist.sample(), dim=1, keepdim=True)
+        topk_scores = logits.gather(dim=1, index=topk_ids)
+    return topk_ids, topk_scores
+
+
+class RandomSampling(DecodeStrategy):
+    """Select next tokens randomly from the top k possible next tokens.
+
+    Args:
+        pad (int): See base.
+        bos (int): See base.
+        eos (int): See base.
+        batch_size (int): See base.
+        device (torch.device or str): See base ``device``.
+        min_length (int): See base.
+        max_length (int): See base.
+        block_ngram_repeat (int): See base.
+        exclusion_tokens (set[int]): See base.
+        return_attention (bool): See base.
+        max_length (int): See base.
+        sampling_temp (float): See :func:`sample_with_temperature()`.
+        keep_topk (int): See :func:`sample_with_temperature()`.
+        memory_length (torch.LongTensor): Lengths of encodings. Used for
+            masking attention.
+    """
+
+    # NOTE: Currently this class doesn't return "final" scores or any form
+    # of Pr(EOS|pred). That is to say, the scores returned by RandomSampling
+    # # are just the scores of the last token (in a batched setting, that
+    # isn't even necessarily EOS since no early stopping is implemented).
+
+    def __init__(self, pad, bos, eos, batch_size, device,
+                 min_length, block_ngram_repeat, exclusion_tokens,
+                 return_attention, max_length, sampling_temp, keep_topk,
+                 memory_length):
+        super(RandomSampling, self).__init__(
+            pad, bos, eos, batch_size, device, 1,
+            min_length, block_ngram_repeat, exclusion_tokens,
+            return_attention, max_length)
+        self.sampling_temp = sampling_temp
+        self.keep_topk = keep_topk
+        self.topk_scores = None
+        self.memory_length = memory_length
+        self.batch_size = batch_size
+        self.select_indices = torch.arange(self.batch_size,
+                                           dtype=torch.long, device=device)
+
+    def advance(self, log_probs, attn):
+        """Select next tokens randomly from the top k possible next tokens.
+
+        Args:
+            log_probs (torch.FloatTensor): Shaped ``(batch_size, vocab_size)``.
+                These can be logits (``(-inf, inf)``) or log-probs
+                (``(-inf, 0]``). (The distribution actually uses the
+                log-probabilities ``logits - logits.logsumexp(-1)``,
+                which equals the logits if they are log-probabilities summing
+                to 1.)
+            attn (torch.FloatTensor): Shaped ``(1, B, inp_seq_len)``.
+        """
+
+        self.ensure_min_length(log_probs)
+        topk_ids, self.topk_scores = sample_with_temperature(
+            log_probs, self.sampling_temp, self.keep_topk)
+
+        self.alive_seq = torch.cat([self.alive_seq, topk_ids], -1)
+        if self.return_attention:
+            if self.alive_attn is None:
+                self.alive_attn = attn
+            else:
+                self.alive_attn = torch.cat([self.alive_attn, attn], 0)
+        self.ensure_max_length()
+
+    def update_finished(self):
+        """Finalize scores and predictions."""
+        assert self.is_finished.all()
+        for b in range(self.batch_size):
+            self.scores[b].append(self.topk_scores[b, 0])
+            self.predictions[b].append(self.alive_seq[b, 1:])
+            self.attention[b].append( \
+                self.alive_attn[:, b, :self.memory_length[b]] \
+                if self.alive_attn is not None else [])

--- a/onmt/translate/random_sampling.py
+++ b/onmt/translate/random_sampling.py
@@ -125,6 +125,6 @@ class RandomSampling(DecodeStrategy):
         for b in range(self.batch_size):
             self.scores[b].append(self.topk_scores[b, 0])
             self.predictions[b].append(self.alive_seq[b, 1:])
-            self.attention[b].append( \
-                self.alive_attn[:, b, :self.memory_length[b]] \
+            self.attention[b].append(
+                self.alive_attn[:, b, :self.memory_length[b]]
                 if self.alive_attn is not None else [])

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -6,19 +6,18 @@ import codecs
 import os
 import math
 import time
+from itertools import count
 
 import torch
 
-from itertools import count
-from onmt.utils.misc import tile
-
 import onmt.model_builder
 import onmt.translate.beam
-from onmt.translate.beam_search import BeamSearch
 import onmt.inputters as inputters
 import onmt.opts as opts
 import onmt.decoders.ensemble
-from onmt.utils.misc import set_random_seed
+from onmt.translate.beam_search import BeamSearch
+from onmt.translate.random_sampling import RandomSampling, sample_with_temperature
+from onmt.utils.misc import tile, set_random_seed
 from onmt.modules.copy_generator import collapse_copy_scores
 
 
@@ -50,35 +49,32 @@ def build_translator(opt, report_score=True, logger=None, out_file=None):
 
 
 class Translator(object):
-    """
-    Uses a model to translate a batch of sentences.
-
+    """Translate a batch of sentences with a saved model.
 
     Args:
-       model (:obj:`onmt.modules.NMTModel`):
-          NMT model to use for translation
-       fields (dict of Fields): data fields
-       opt (obj): command line options
-       model_opt (obj): model options
-       global_scores (:obj:`GlobalScorer`):
-         object to rescore final translations
-       out_file : Output File
-       report_score (bool) : Whether to report scores
-       logger(logging.Logger): logger.
+        model (onmt.modules.NMTModel): NMT model to use for translation
+        fields (dict[str, list[tuple[str, torchtext.data.Field]]]): A dict
+            mapping each side to its list of name-Field pairs.
+        opt (argparse.Namespace): Command line options
+        model_opt (argparse.Namespace): Command line options saved with
+            the model checkpoint.
+        global_scorer (onmt.translate.GNMTGlobalScorer): Translation
+            scoring/reranking object.
+        out_file (TextIO or codecs.StreamReaderWriter): Output file.
+        report_score (bool) : Whether to report scores
+        logger (logging.Logger or NoneType): Logger.
     """
 
     def __init__(
-        self,
-        model,
-        fields,
-        opt,
-        model_opt,
-        global_scorer=None,
-        out_file=None,
-        report_score=True,
-        logger=None
-    ):
-
+            self,
+            model,
+            fields,
+            opt,
+            model_opt,
+            global_scorer=None,
+            out_file=None,
+            report_score=True,
+            logger=None):
         self.model = model
         self.fields = fields
         tgt_field = self.fields["tgt"][0][1].base_field
@@ -89,8 +85,10 @@ class Translator(object):
         self._tgt_unk_idx = self._tgt_vocab.stoi[tgt_field.unk_token]
         self._tgt_vocab_len = len(self._tgt_vocab)
 
-        self.gpu = opt.gpu
-        self.cuda = opt.gpu > -1
+        self._gpu = opt.gpu
+        self._use_cuda = opt.gpu > -1
+        self._dev = torch.device("cuda", self._gpu) \
+            if self._use_cuda else torch.device("cpu")
 
         self.n_best = opt.n_best
         self.max_length = opt.max_length
@@ -139,7 +137,7 @@ class Translator(object):
                 "scores": [],
                 "log_probs": []}
 
-        set_random_seed(opt.seed, self.cuda)
+        set_random_seed(opt.seed, self._use_cuda)
 
     def _log(self, msg):
         if self.logger:
@@ -147,26 +145,31 @@ class Translator(object):
         else:
             print(msg)
 
-    def translate(
-        self,
-        src,
-        tgt=None,
-        src_dir=None,
-        batch_size=None,
-        attn_debug=False
-    ):
-        """
-        Translate content of `src_data_iter` (if not None) or `src_path`
-        and get gold scores if one of `tgt_data_iter` or `tgt_path` is set.
+    def _gold_score(self, batch, memory_bank, src_lengths, src_vocabs,
+                    use_src_map, enc_states, batch_size, src):
+        if "tgt" in batch.__dict__:
+            gs = self._score_target(
+                batch, memory_bank, src_lengths, src_vocabs,
+                batch.src_map if use_src_map else None)
+            self.model.decoder.init_state(src, memory_bank, enc_states)
+        else:
+            gs = [0] * batch_size
+        return gs
 
-        Note: batch_size must not be None
-        Note: one of ('src_path', 'src_data_iter') must not be None
+    def translate(
+            self,
+            src,
+            tgt=None,
+            src_dir=None,
+            batch_size=None,
+            attn_debug=False):
+        """Translate content of ``src`` and get gold scores from ``tgt``.
 
         Args:
-            src_path (str): filepath of source data
-            tgt_path (str): filepath of target data or None
-            src_dir (str): source directory path
-                (used for Audio and Image datasets)
+            src: See :func:`self.src_reader.read()`.
+            tgt: See :func:`self.tgt_reader.read()`.
+            src_dir: See :func:`self.src_reader.read()` (only relevant
+                for certain types of data).
             batch_size (int): size of examples per mini-batch
             attn_debug (bool): enables the attention logging
 
@@ -177,7 +180,6 @@ class Translator(object):
             * all_predictions is a list of `batch_size` lists
                 of `n_best` predictions
         """
-        assert src is not None
 
         if batch_size is None:
             raise ValueError("batch_size must be set")
@@ -192,11 +194,9 @@ class Translator(object):
             filter_pred=self._filter_pred
         )
 
-        cur_device = "cuda" if self.cuda else "cpu"
-
         data_iter = inputters.OrderedIterator(
             dataset=data,
-            device=cur_device,
+            device=self._dev,
             batch_size=batch_size,
             train=False,
             sort=False,
@@ -204,7 +204,7 @@ class Translator(object):
             shuffle=False
         )
 
-        builder = onmt.translate.TranslationBuilder(
+        xlation_builder = onmt.translate.TranslationBuilder(
             data, self.fields, self.n_best, self.replace_unk, tgt
         )
 
@@ -222,7 +222,7 @@ class Translator(object):
             batch_data = self.translate_batch(
                 batch, data.src_vocabs, attn_debug
             )
-            translations = builder.from_batch(batch_data)
+            translations = xlation_builder.from_batch(batch_data)
 
             for trans in translations:
                 all_scores += [trans.pred_scores[:self.n_best]]
@@ -298,40 +298,15 @@ class Translator(object):
                       codecs.open(self.dump_beam, 'w', 'utf-8'))
         return all_scores, all_predictions
 
-    def sample_with_temperature(self, logits, sampling_temp, keep_topk):
-        if sampling_temp == 0.0 or keep_topk == 1:
-            # For temp=0.0, take the argmax to avoid divide-by-zero errors.
-            # keep_topk=1 is also equivalent to argmax.
-            topk_scores, topk_ids = logits.topk(1, dim=-1)
-        else:
-            logits = torch.div(logits, sampling_temp)
-
-            if keep_topk > 0:
-                top_values, top_indices = torch.topk(logits, keep_topk, dim=1)
-                kth_best = top_values[:, -1].view([-1, 1])
-                kth_best = kth_best.repeat([1, logits.shape[1]]).float()
-
-                # Set all logits that are not in the top-k to -1000.
-                # This puts the probabilities close to 0.
-                keep = torch.ge(logits, kth_best).float()
-                logits = (keep * logits) + ((1-keep) * -10000)
-
-            dist = torch.distributions.Multinomial(
-                logits=logits, total_count=1)
-            topk_ids = torch.argmax(dist.sample(), dim=1, keepdim=True)
-            topk_scores = logits.gather(dim=1, index=topk_ids)
-        return topk_ids, topk_scores
-
     def _translate_random_sampling(
-        self,
-        batch,
-        src_vocabs,
-        max_length,
-        min_length=0,
-        sampling_temp=1.0,
-        keep_topk=-1,
-        return_attention=False
-    ):
+            self,
+            batch,
+            src_vocabs,
+            max_length,
+            min_length=0,
+            sampling_temp=1.0,
+            keep_topk=-1,
+            return_attention=False):
         """Alternative to beam search. Do random sampling at each step."""
 
         assert self.beam_size == 1
@@ -341,30 +316,20 @@ class Translator(object):
 
         batch_size = batch.batch_size
 
-        end_token = self._tgt_eos_idx
-
         # Encoder forward.
         src, enc_states, memory_bank, src_lengths = self._run_encoder(batch)
         self.model.decoder.init_state(src, memory_bank, enc_states)
 
         use_src_map = self.copy_attn
 
-        results = {}
-        results["predictions"] = [[] for _ in range(batch_size)]  # noqa: F812
-        results["scores"] = [[] for _ in range(batch_size)]  # noqa: F812
-        results["attention"] = [[] for _ in range(batch_size)]  # noqa: F812
-        results["batch"] = batch
-        if "tgt" in batch.__dict__:
-            results["gold_score"] = self._score_target(
-                batch,
-                memory_bank,
-                src_lengths,
-                src_vocabs,
-                batch.src_map if use_src_map else None
-            )
-            self.model.decoder.init_state(src, memory_bank, enc_states)
-        else:
-            results["gold_score"] = [0] * batch_size
+        results = {
+            "predictions": None,
+            "scores": None,
+            "attention": None,
+            "batch": batch,
+            "gold_score": self._gold_score(
+                batch, memory_bank, src_lengths, src_vocabs, use_src_map,
+                enc_states, batch_size, src)}
 
         memory_lengths = src_lengths
         src_map = batch.src_map if use_src_map else None
@@ -374,14 +339,15 @@ class Translator(object):
         else:
             mb_device = memory_bank.device
 
-        # seq_so_far contains chosen tokens; on each step, dim 1 grows by one.
-        seq_so_far = torch.full(
-            [batch_size, 1], self._tgt_bos_idx,
-            dtype=torch.long, device=mb_device)
-        alive_attn = None
+        random_sampler = RandomSampling(
+            self._tgt_pad_idx, self._tgt_bos_idx, self._tgt_eos_idx,
+            batch_size, mb_device, min_length, self.block_ngram_repeat,
+            self._exclusion_idxs, return_attention, self.max_length,
+            sampling_temp, keep_topk, memory_lengths)
 
         for step in range(max_length):
-            decoder_input = seq_so_far[:, -1].view(1, -1, 1)
+            # Shape: (1, B, 1)
+            decoder_input = random_sampler.alive_seq[:, -1].view(1, -1, 1)
 
             log_probs, attn = self._decode_and_generate(
                 decoder_input,
@@ -391,55 +357,19 @@ class Translator(object):
                 memory_lengths=memory_lengths,
                 src_map=src_map,
                 step=step,
-                batch_offset=torch.arange(batch_size, dtype=torch.long)
+                batch_offset=random_sampler.select_indices
             )
 
-            if step < min_length:
-                log_probs[:, end_token] = -1e20
+            random_sampler.advance(log_probs, attn)
 
-            # Note that what this code calls log_probs are actually logits.
-            topk_ids, topk_scores = self.sample_with_temperature(
-                    log_probs, sampling_temp, keep_topk)
-
-            # Append last prediction.
-            seq_so_far = torch.cat([seq_so_far, topk_ids.view(-1, 1)], -1)
-            if return_attention:
-                current_attn = attn
-                if alive_attn is None:
-                    alive_attn = current_attn
-                else:
-                    alive_attn = torch.cat([alive_attn, current_attn], 0)
-
-        predictions = seq_so_far.view(-1, 1, seq_so_far.size(-1))
-        attention = (
-            alive_attn.view(
-                alive_attn.size(0), -1, 1, alive_attn.size(-1))
-            if alive_attn is not None else None)
-
-        for i in range(topk_scores.size(0)):
-            # Store finished hypotheses for this batch. Unlike in beam search,
-            # there will only ever be 1 hypothesis per example.
-            score = topk_scores[i, 0]
-            pred = predictions[i, 0, 1:]  # Ignore start_token.
-            m_len = memory_lengths[i]
-            attn = attention[:, i, 0, :m_len] if attention is not None else []
-
-            results["scores"][i].append(score)
-            results["predictions"][i].append(pred)
-            results["attention"][i].append(attn)
-
+        random_sampler.update_finished()
+        results["scores"] = random_sampler.scores
+        results["predictions"] = random_sampler.predictions
+        results["attention"] = random_sampler.attention
         return results
 
     def translate_batch(self, batch, src_vocabs, attn_debug):
-        """
-        Translate a batch of sentences.
-
-        Mostly a wrapper around :obj:`Beam`.
-
-        Args:
-           batch (:obj:`Batch`): a batch from a dataset object
-           data (:obj:`Dataset`): the dataset object
-        """
+        """Translate a batch of sentences."""
         with torch.no_grad():
             if self.beam_size == 1:
                 return self._translate_random_sampling(
@@ -450,8 +380,6 @@ class Translator(object):
                     sampling_temp=self.random_sampling_temp,
                     keep_topk=self.sample_from_topk,
                     return_attention=attn_debug or self.replace_unk)
-            elif self.coverage_penalty is None:
-                return self._translate_batch_deprecated(batch, src_vocabs)
             else:
                 return self._translate_batch(
                     batch,
@@ -477,16 +405,15 @@ class Translator(object):
         return src, enc_states, memory_bank, src_lengths
 
     def _decode_and_generate(
-        self,
-        decoder_in,
-        memory_bank,
-        batch,
-        src_vocabs,
-        memory_lengths,
-        src_map=None,
-        step=None,
-        batch_offset=None
-    ):
+            self,
+            decoder_in,
+            memory_bank,
+            batch,
+            src_vocabs,
+            memory_lengths,
+            src_map=None,
+            step=None,
+            batch_offset=None):
         if self.copy_attn:
             # Turn any copied words into UNKs.
             decoder_in = decoder_in.masked_fill(
@@ -532,14 +459,13 @@ class Translator(object):
         return log_probs, attn
 
     def _translate_batch(
-        self,
-        batch,
-        src_vocabs,
-        max_length,
-        min_length=0,
-        n_best=1,
-        return_attention=False
-    ):
+            self,
+            batch,
+            src_vocabs,
+            max_length,
+            min_length=0,
+            n_best=1,
+            return_attention=False):
         # TODO: support these blacklisted features.
         assert not self.dump_beam
 
@@ -552,22 +478,14 @@ class Translator(object):
         src, enc_states, memory_bank, src_lengths = self._run_encoder(batch)
         self.model.decoder.init_state(src, memory_bank, enc_states)
 
-        results = {}
-        results["predictions"] = None
-        results["scores"] = None
-        results["attention"] = None
-        results["batch"] = batch
-        if "tgt" in batch.__dict__:
-            results["gold_score"] = self._score_target(
-                batch,
-                memory_bank,
-                src_lengths,
-                src_vocabs,
-                batch.src_map if use_src_map else None
-            )
-            self.model.decoder.init_state(src, memory_bank, enc_states)
-        else:
-            results["gold_score"] = [0] * batch_size
+        results = {
+            "predictions": None,
+            "scores": None,
+            "attention": None,
+            "batch": batch,
+            "gold_score": self._gold_score(
+                batch, memory_bank, src_lengths, src_vocabs, use_src_map,
+                enc_states, batch_size, src)}
 
         # (2) Repeat src objects `beam_size` times.
         # We use batch_size x beam_size
@@ -613,8 +531,7 @@ class Translator(object):
                 memory_lengths=memory_lengths,
                 src_map=src_map,
                 step=step,
-                batch_offset=beam._batch_offset
-            )
+                batch_offset=beam._batch_offset)
 
             beam.advance(log_probs, attn)
             any_beam_is_finished = beam.is_finished.any()
@@ -672,18 +589,14 @@ class Translator(object):
         src, enc_states, memory_bank, src_lengths = self._run_encoder(batch)
         self.model.decoder.init_state(src, memory_bank, enc_states)
 
-        results = {}
-        results["predictions"] = []
-        results["scores"] = []
-        results["attention"] = []
-        results["batch"] = batch
-        if "tgt" in batch.__dict__:
-            results["gold_score"] = self._score_target(
-                batch, memory_bank, src_lengths, src_vocabs,
-                batch.src_map if use_src_map else None)
-            self.model.decoder.init_state(src, memory_bank, enc_states)
-        else:
-            results["gold_score"] = [0] * batch_size
+        results = {
+            "predictions": [],
+            "scores": [],
+            "attention": [],
+            "batch": batch,
+            "gold_score": self._gold_score(
+                batch, memory_bank, src_lengths, src_vocabs, use_src_map,
+                enc_states, batch_size, src)}
 
         # (2) Repeat src objects `beam_size` times.
         # We use now  batch_size x beam_size (same as fast mode)

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -16,7 +16,7 @@ import onmt.inputters as inputters
 import onmt.opts as opts
 import onmt.decoders.ensemble
 from onmt.translate.beam_search import BeamSearch
-from onmt.translate.random_sampling import RandomSampling, sample_with_temperature
+from onmt.translate.random_sampling import RandomSampling
 from onmt.utils.misc import tile, set_random_seed
 from onmt.modules.copy_generator import collapse_copy_scores
 


### PR DESCRIPTION
I've made ``.view`` calls more literate. By that I mean avoiding ``-1``'s and avoiding referencing the original tensor for dimensions in favor of using hopefully well-named variables. I've tried to make some of the instance attribute uses more readable, too. IMO when dealing with stateful instance attribute tensors, using a buffer/``out`` approach is more readable. So that's what I've done. I'm seeing the same scores, speed (non-significant difference, anyways), and memory usage.

Also,  #1277  broke ``return_attention`` when not using a coverage penalty. This fixes it, and unit tests it.