### PR TITLE
Remove unused command line argument in documentation.

### DIFF
--- a/docs/source/Summarization.md
+++ b/docs/source/Summarization.md
@@ -139,7 +139,6 @@ python -u train.py -data data/cnndm/CNNDM \
                    -normalization tokens \
                    -max_generator_batches 2 \
                    -train_steps 200000 \
-                   -start_checkpoint_at 8 \
                    -accum_count 4 \
                    -share_embeddings \
                    -copy_attn \


### PR DESCRIPTION
There is an unused argument in an example that seems to have been refactored out.