### PR TITLE
Revamp args

### DIFF
--- a/onmt/decoders/ensemble.py
+++ b/onmt/decoders/ensemble.py
@@ -116,16 +116,14 @@ class EnsembleModel(NMTModel):
         self.models = nn.ModuleList(models)
 
 
-def load_test_model(opt, dummy_opt):
+def load_test_model(opt):
     """ Read in multiple models for ensemble """
     shared_fields = None
     shared_model_opt = None
     models = []
     for model_path in opt.models:
         fields, model, model_opt = \
-            onmt.model_builder.load_test_model(opt,
-                                               dummy_opt,
-                                               model_path=model_path)
+            onmt.model_builder.load_test_model(opt, model_path=model_path)
         if shared_fields is None:
             shared_fields = fields
         else:

--- a/onmt/encoders/audio_encoder.py
+++ b/onmt/encoders/audio_encoder.py
@@ -99,7 +99,7 @@ class AudioEncoder(EncoderBase):
         src = src.transpose(0, 1).transpose(0, 3).contiguous() \
                  .view(t, batch_size, nfft)
         orig_lengths = lengths
-        lengths = lengths.view(-1).tolist()
+        lengths = lengths.float().view(-1).tolist()
 
         for l in range(self.enc_layers):
             rnn = getattr(self, 'rnn_%d' % l)
@@ -112,7 +112,7 @@ class AudioEncoder(EncoderBase):
             t, _, _ = memory_bank.size()
             memory_bank = memory_bank.transpose(0, 2)
             memory_bank = pool(memory_bank)
-            lengths = [int(math.floor((length - stride)/stride + 1))
+            lengths = [int(math.floor((length - stride) / stride + 1))
                        for length in lengths]
             memory_bank = memory_bank.transpose(0, 2)
             src = memory_bank

--- a/onmt/encoders/audio_encoder.py
+++ b/onmt/encoders/audio_encoder.py
@@ -99,7 +99,7 @@ class AudioEncoder(EncoderBase):
         src = src.transpose(0, 1).transpose(0, 3).contiguous() \
                  .view(t, batch_size, nfft)
         orig_lengths = lengths
-        lengths = lengths.float().view(-1).tolist()
+        lengths = lengths.view(-1).tolist()
 
         for l in range(self.enc_layers):
             rnn = getattr(self, 'rnn_%d' % l)

--- a/onmt/tests/test_translation_server.py
+++ b/onmt/tests/test_translation_server.py
@@ -1,0 +1,132 @@
+import unittest
+from onmt.translate.translation_server import ServerModel
+
+import os
+
+import torch
+
+from onmt.translate.translator import Translator
+
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+
+
+class TestServerModel(unittest.TestCase):
+    def test_deferred_loading_model_and_unload(self):
+        model_id = 0
+        opt = {"models": ["test_model.pt"]}
+        model_root = TEST_DIR
+        sm = ServerModel(opt, model_id, model_root=model_root, load=False)
+        self.assertFalse(sm.loaded)
+        sm.load()
+        self.assertTrue(sm.loaded)
+        self.assertIsInstance(sm.translator, Translator)
+        sm.unload()
+        self.assertFalse(sm.loaded)
+
+    def test_load_model_on_init_and_unload(self):
+        model_id = 0
+        opt = {"models": ["test_model.pt"]}
+        model_root = TEST_DIR
+        sm = ServerModel(opt, model_id, model_root=model_root, load=True)
+        self.assertTrue(sm.loaded)
+        self.assertIsInstance(sm.translator, Translator)
+        sm.unload()
+        self.assertFalse(sm.loaded)
+
+    def test_tokenizing_with_no_tokenizer_fails(self):
+        model_id = 0
+        opt = {"models": ["test_model.pt"]}
+        model_root = TEST_DIR
+        sm = ServerModel(opt, model_id, model_root=model_root, load=True)
+        with self.assertRaises(ValueError):
+            sm.tokenize("hello world")
+
+    def test_detokenizing_with_no_tokenizer_fails(self):
+        model_id = 0
+        opt = {"models": ["test_model.pt"]}
+        model_root = TEST_DIR
+        sm = ServerModel(opt, model_id, model_root=model_root, load=True)
+        with self.assertRaises(ValueError):
+            sm.detokenize("hello world")
+
+    if torch.cuda.is_available():
+        def test_moving_to_gpu_and_back(self):
+            torch.cuda.set_device(torch.device("cuda", 0))
+            model_id = 0
+            opt = {"models": ["test_model.pt"]}
+            model_root = TEST_DIR
+            sm = ServerModel(opt, model_id, model_root=model_root, load=True)
+            for p in sm.translator.model.parameters():
+                self.assertEqual(p.device.type, "cpu")
+            sm.to_gpu()
+            for p in sm.translator.model.parameters():
+                self.assertEqual(p.device.type, "cuda")
+                self.assertEqual(p.device.index, 0)
+            sm.to_cpu()
+            for p in sm.translator.model.parameters():
+                self.assertEqual(p.device.type, "cpu")
+
+        def test_initialize_on_gpu_and_move_back(self):
+            torch.cuda.set_device(torch.device("cuda", 0))
+            model_id = 0
+            opt = {"models": ["test_model.pt"], "gpu": 0}
+            model_root = TEST_DIR
+            sm = ServerModel(opt, model_id, model_root=model_root, load=True)
+            for p in sm.translator.model.parameters():
+                self.assertEqual(p.device.type, "cuda")
+                self.assertEqual(p.device.index, 0)
+            sm.to_gpu()
+            for p in sm.translator.model.parameters():
+                self.assertEqual(p.device.type, "cuda")
+                self.assertEqual(p.device.index, 0)
+            sm.to_cpu()
+            for p in sm.translator.model.parameters():
+                self.assertEqual(p.device.type, "cpu")
+
+        if torch.cuda.device_count() > 1:
+            def test_initialize_on_nonzero_gpu_and_back(self):
+                torch.cuda.set_device(torch.device("cuda", 1))
+                model_id = 0
+                opt = {"models": ["test_model.pt"], "gpu": 1}
+                model_root = TEST_DIR
+                sm = ServerModel(opt, model_id, model_root=model_root,
+                                 load=True)
+                for p in sm.translator.model.parameters():
+                    self.assertEqual(p.device.type, "cuda")
+                    self.assertEqual(p.device.index, 1)
+                sm.to_gpu()
+                for p in sm.translator.model.parameters():
+                    self.assertEqual(p.device.type, "cuda")
+                    self.assertEqual(p.device.index, 1)
+                sm.to_cpu()
+                for p in sm.translator.model.parameters():
+                    self.assertEqual(p.device.type, "cpu")
+
+    def test_run(self):
+        model_id = 0
+        opt = {"models": ["test_model.pt"]}
+        model_root = TEST_DIR
+        sm = ServerModel(opt, model_id, model_root=model_root, load=True)
+        inp = [{"src": "hello how are you today"},
+               {"src": "good morning to you ."}]
+        results, scores, n_best, time = sm.run(inp)
+        self.assertIsInstance(results, list)
+        for sentence_string in results:
+            self.assertIsInstance(sentence_string, str)
+        self.assertIsInstance(scores, list)
+        for elem in scores:
+            self.assertIsInstance(elem, float)
+        self.assertEqual(len(results), len(scores))
+        self.assertEqual(len(scores), len(inp))
+        self.assertEqual(n_best, 1)
+        self.assertEqual(len(time), 1)
+        self.assertIsInstance(time, dict)
+        self.assertIn("translation", time)
+
+    def test_nbest_init_fails(self):
+        model_id = 0
+        opt = {"models": ["test_model.pt"], "n_best": 2}
+        model_root = TEST_DIR
+        with self.assertRaises(ValueError):
+            sm = ServerModel(opt, model_id, model_root=model_root, load=True)

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -1,16 +1,9 @@
 #!/usr/bin/env python
-"""
-    Training on a single process
-"""
-
-import configargparse
-
+"""Training on a single process."""
 import os
 from itertools import chain
 
 import torch
-
-import onmt.opts as opts
 
 from onmt.inputters.inputter import build_dataset_iter, \
     load_old_vocab, old_style_vocab
@@ -20,6 +13,7 @@ from onmt.utils.misc import set_random_seed
 from onmt.trainer import build_trainer
 from onmt.models import build_model_saver
 from onmt.utils.logging import init_logger, logger
+from onmt.utils.parse import ArgumentParser
 
 
 def _check_save_model_path(opt):
@@ -40,43 +34,16 @@ def _tally_parameters(model):
     return enc + dec, enc, dec
 
 
-def training_opt_postprocessing(opt, device_id):
-    if opt.word_vec_size != -1:
-        opt.src_word_vec_size = opt.word_vec_size
-        opt.tgt_word_vec_size = opt.word_vec_size
-
-    if opt.layers != -1:
-        opt.enc_layers = opt.layers
-        opt.dec_layers = opt.layers
-
-    if opt.rnn_size != -1:
-        opt.enc_rnn_size = opt.rnn_size
-        opt.dec_rnn_size = opt.rnn_size
-
-        # this check is here because audio allows the encoder and decoder to
-        # be different sizes, but other model types do not yet
-        same_size = opt.enc_rnn_size == opt.dec_rnn_size
-        assert opt.model_type == 'audio' or same_size, \
-            "The encoder and decoder rnns must be the same size for now"
-
-    opt.brnn = opt.encoder_type == "brnn"
-
-    assert opt.rnn_type != "SRU" or opt.gpu_ranks, \
-        "Using SRU requires -gpu_ranks set."
-
-    if torch.cuda.is_available() and not opt.gpu_ranks:
-        logger.info("WARNING: You have a CUDA device, \
-                    should run with -gpu_ranks")
-
+def configure_process(opt, device_id):
     if device_id >= 0:
         torch.cuda.set_device(device_id)
     set_random_seed(opt.seed, device_id >= 0)
 
-    return opt
-
 
 def main(opt, device_id):
-    opt = training_opt_postprocessing(opt, device_id)
+    # NOTE: It's important that ``opt`` has been validated and updated
+    # at this point.
+    configure_process(opt, device_id)
     init_logger(opt.log_file)
     # Load checkpoint if we resume from a previous training.
     if opt.train_from:
@@ -84,15 +51,9 @@ def main(opt, device_id):
         checkpoint = torch.load(opt.train_from,
                                 map_location=lambda storage, loc: storage)
 
-        # Load default opts values then overwrite it with opts from
-        # the checkpoint. It's usefull in order to re-train a model
-        # after adding a new option (not set in checkpoint)
-        dummy_parser = configargparse.ArgumentParser()
-        opts.model_opts(dummy_parser)
-        default_opt = dummy_parser.parse_known_args([])[0]
-
-        model_opt = default_opt
-        model_opt.__dict__.update(checkpoint['opt'].__dict__)
+        model_opt = ArgumentParser.ckpt_model_opts(checkpoint["opt"])
+        ArgumentParser.update_model_opts(model_opt)
+        ArgumentParser.validate_model_opts(model_opt)
         logger.info('Loading vocab from checkpoint at %s.' % opt.train_from)
         vocab = checkpoint['vocab']
     else:
@@ -103,8 +64,8 @@ def main(opt, device_id):
     # check for code where vocab is saved instead of fields
     # (in the future this will be done in a smarter way)
     if old_style_vocab(vocab):
-        data_type = opt.model_type
-        fields = load_old_vocab(vocab, data_type, dynamic_dict=opt.copy_attn)
+        fields = load_old_vocab(
+            vocab, opt.model_type, dynamic_dict=opt.copy_attn)
     else:
         fields = vocab
 
@@ -161,16 +122,3 @@ def main(opt, device_id):
 
     if opt.tensorboard:
         trainer.report_manager.tensorboard_writer.close()
-
-
-if __name__ == "__main__":
-    parser = configargparse.ArgumentParser(
-        description='train.py',
-        formatter_class=configargparse.ArgumentDefaultsHelpFormatter)
-
-    opts.add_md_help_argument(parser)
-    opts.model_opts(parser)
-    opts.train_opts(parser)
-
-    opt = parser.parse_args()
-    main(opt)

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
-""" REST Translation server """
+"""REST Translation server."""
 from __future__ import print_function
 import sys
 import os
-import configargparse
 import time
 import json
 import threading
@@ -15,13 +14,12 @@ import onmt.opts
 
 from onmt.utils.logging import init_logger
 from onmt.utils.misc import set_random_seed
+from onmt.utils.parse import ArgumentParser
 from onmt.translate.translator import build_translator
 
 
 def critical(func):
-    """
-        Decorator for critical section (mutually exclusive code)
-    """
+    """Decorator for critical section (mutually exclusive code)"""
     def wrapper(server_model, *args, **kwargs):
         if not server_model.running_lock.acquire(blocking=True, timeout=120):
             raise ServerModelError("Model %d running lock timeout"
@@ -66,7 +64,7 @@ class ServerModelError(Exception):
     pass
 
 
-class TranslationServer():
+class TranslationServer(object):
     def __init__(self):
         self.models = {}
         self.next_id = 0
@@ -170,23 +168,24 @@ class TranslationServer():
         return models
 
 
-class ServerModel:
+class ServerModel(object):
+    """Wrap a model with server functionality.
+
+    Args:
+        opt (dict): Options for the Translator
+        model_id (int): Model ID
+        tokenizer_opt (dict): Options for the tokenizer or None
+        load (bool): whether to load the model during :func:`__init__()`
+        timeout (int): Seconds before running :func:`do_timeout()`
+            Negative values means no timeout
+        on_timeout (str): Options are ["to_cpu", "unload"]. Set what to do on
+            timeout (see :func:`do_timeout()`.)
+        model_root (str): Path to the model directory
+            it must contain the model and tokenizer file
+    """
+
     def __init__(self, opt, model_id, tokenizer_opt=None, load=False,
                  timeout=-1, on_timeout="to_cpu", model_root="./"):
-        """
-            Args:
-                opt: (dict) options for the Translator
-                model_id: (int) model id
-                tokenizer_opt: (dict) options for the tokenizer or None
-                load: (bool) whether to load the model during __init__
-                timeout: (int) seconds before running `do_timeout`
-                         Negative values means no timeout
-                on_timeout: (str) in ["to_cpu", "unload"] set what to do on
-                            timeout (see function `do_timeout`)
-                model_root: (str) path to the model directory
-                            it must contain de model and tokenizer file
-
-        """
         self.model_root = model_root
         self.opt = self.parse_opt(opt)
         if self.opt.n_best > 1:
@@ -219,15 +218,17 @@ class ServerModel:
 
     def parse_opt(self, opt):
         """Parse the option set passed by the user using `onmt.opts`
-           Args:
-               opt: (dict) options passed by the user
 
-           Returns:
-               opt: (Namespace) full set of options for the Translator
+       Args:
+           opt (dict): Options passed by the user
+
+       Returns:
+           opt (argparse.Namespace): full set of options for the Translator
         """
+
         prec_argv = sys.argv
         sys.argv = sys.argv[:1]
-        parser = configargparse.ArgumentParser()
+        parser = ArgumentParser()
         onmt.opts.translate_opts(parser)
 
         models = opt['models']
@@ -247,6 +248,7 @@ class ServerModel:
                 sys.argv += ['-%s' % k, str(v)]
 
         opt = parser.parse_args()
+        ArgumentParser.validate_translate_opts(opt)
         opt.cuda = opt.gpu > -1
 
         sys.argv = prec_argv
@@ -317,13 +319,14 @@ class ServerModel:
     def run(self, inputs):
         """Translate `inputs` using this model
 
-            Args:
-                inputs: [{"src": "..."},{"src": ...}]
+        Args:
+            inputs (List[dict[str, str]]): [{"src": "..."},{"src": ...}]
 
-            Returns:
-                result: (list) translations
-                times: (dict) containing times
+        Returns:
+            result (list): translations
+            times (dict): containing times
         """
+
         self.stop_unload_timer()
 
         timer = Timer()
@@ -421,9 +424,12 @@ class ServerModel:
         return results, scores, self.opt.n_best, timer.times
 
     def do_timeout(self):
-        """Timeout function that free GPU memory by moving the model to CPU
-           or unloading it; depending on `self.on_timemout` value
+        """Timeout function that frees GPU memory.
+
+        Moves the model to CPU or unloads it; depending on
+        attr`self.on_timemout` value
         """
+
         if self.on_timeout == "unload":
             self.logger.info("Timeout: unloading model %d" % self.model_id)
             self.unload()
@@ -467,37 +473,36 @@ class ServerModel:
 
     @critical
     def to_cpu(self):
-        """Move the model to CPU and clear CUDA cache
-        """
+        """Move the model to CPU and clear CUDA cache."""
         self.translator.model.cpu()
         if self.opt.cuda:
             torch.cuda.empty_cache()
 
     def to_gpu(self):
-        """Move the model to GPU
-        """
+        """Move the model to GPU."""
         torch.cuda.set_device(self.opt.gpu)
         self.translator.model.cuda()
 
     def maybe_tokenize(self, sequence):
-        """Tokenize the sequence (or not)
+        """Tokenize the sequence (or not).
 
-           Same args/returns as `tokenize`
+        Same args/returns as `tokenize`
         """
+
         if self.tokenizer_opt is not None:
             return self.tokenize(sequence)
         return sequence
 
     def tokenize(self, sequence):
-        """Tokenize a single sequence
+        """Tokenize a single sequence.
 
-            Args:
-                sequence: (str) the sequence to tokenize
+        Args:
+            sequence (str): The sequence to tokenize.
 
-            Returns:
-                tok: (str) the tokenized sequence
-
+        Returns:
+            tok (str): The tokenized sequence.
         """
+
         if self.tokenizer is None:
             raise ValueError("No tokenizer loaded")
 
@@ -512,8 +517,9 @@ class ServerModel:
     def maybe_detokenize(self, sequence):
         """De-tokenize the sequence (or not)
 
-           Same args/returns as `tokenize`
+        Same args/returns as :func:`tokenize()`
         """
+
         if self.tokenizer_opt is not None and ''.join(sequence.split()) != '':
             return self.detokenize(sequence)
         return sequence
@@ -521,8 +527,9 @@ class ServerModel:
     def detokenize(self, sequence):
         """Detokenize a single sequence
 
-           Same args/returns as `tokenize`
+        Same args/returns as :func:`tokenize()`
         """
+
         if self.tokenizer is None:
             raise ValueError("No tokenizer loaded")
 

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -21,7 +21,7 @@ from onmt.translate.translator import build_translator
 def critical(func):
     """Decorator for critical section (mutually exclusive code)"""
     def wrapper(server_model, *args, **kwargs):
-        if not server_model.running_lock.acquire(blocking=True, timeout=120):
+        if not server_model.running_lock.acquire(True, 120):
             raise ServerModelError("Model %d running lock timeout"
                                    % server_model.model_id)
         try:

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """ Translator Class and builder """
 from __future__ import print_function
-import configargparse
 import codecs
 import os
 import math
@@ -13,7 +12,6 @@ import torch
 import onmt.model_builder
 import onmt.translate.beam
 import onmt.inputters as inputters
-import onmt.opts as opts
 import onmt.decoders.ensemble
 from onmt.translate.beam_search import BeamSearch
 from onmt.translate.random_sampling import RandomSampling
@@ -25,13 +23,9 @@ def build_translator(opt, report_score=True, logger=None, out_file=None):
     if out_file is None:
         out_file = codecs.open(opt.output, 'w+', 'utf-8')
 
-    dummy_parser = configargparse.ArgumentParser(description='train.py')
-    opts.model_opts(dummy_parser)
-    dummy_opt = dummy_parser.parse_known_args([])[0]
-
     load_test_model = onmt.decoders.ensemble.load_test_model \
         if len(opt.models) > 1 else onmt.model_builder.load_test_model
-    fields, model, model_opt = load_test_model(opt, dummy_opt.__dict__)
+    fields, model, model_opt = load_test_model(opt)
 
     scorer = onmt.translate.GNMTGlobalScorer.from_opt(opt)
 
@@ -92,9 +86,6 @@ class Translator(object):
 
         self.n_best = opt.n_best
         self.max_length = opt.max_length
-
-        if opt.beam_size != 1 and opt.random_sampling_topk != 1:
-            raise ValueError('Can either do beam search OR random sampling.')
 
         self.beam_size = opt.beam_size
         self.random_sampling_temp = opt.random_sampling_temp

--- a/onmt/utils/parse.py
+++ b/onmt/utils/parse.py
@@ -1,0 +1,115 @@
+import configargparse as cfargparse
+import os
+
+import torch
+
+import onmt.opts as opts
+from onmt.utils.logging import logger
+
+
+class ArgumentParser(cfargparse.ArgumentParser):
+    def __init__(
+            self,
+            md_help=True,
+            config_file_parser_class=cfargparse.YAMLConfigFileParser,
+            formatter_class=cfargparse.ArgumentDefaultsHelpFormatter,
+            **kwargs):
+        super(ArgumentParser, self).__init__(
+            config_file_parser_class=config_file_parser_class,
+            formatter_class=formatter_class,
+            **kwargs)
+        if md_help:
+            opts.add_md_help_argument(self)
+
+    @classmethod
+    def defaults(cls, *args):
+        """Get default arguments added to a parser by all ``*args``."""
+        dummy_parser = cls()
+        for callback in args:
+            callback(dummy_parser)
+        defaults = dummy_parser.parse_known_args([])[0]
+        return defaults
+
+    @classmethod
+    def update_model_opts(cls, model_opt):
+        if model_opt.word_vec_size != -1:
+            model_opt.src_word_vec_size = model_opt.word_vec_size
+            model_opt.tgt_word_vec_size = model_opt.word_vec_size
+
+        if model_opt.layers != -1:
+            model_opt.enc_layers = model_opt.layers
+            model_opt.dec_layers = model_opt.layers
+
+        if model_opt.rnn_size != -1:
+            model_opt.enc_rnn_size = model_opt.rnn_size
+            model_opt.dec_rnn_size = model_opt.rnn_size
+
+        model_opt.brnn = model_opt.model_type == "brnn"
+
+    @classmethod
+    def validate_model_opts(cls, model_opt):
+        assert model_opt.model_type in ["text", "img", "audio"], \
+            "Unsupported model type %s" % model_opt.model_type
+
+        # this check is here because audio allows the encoder and decoder to
+        # be different sizes, but other model types do not yet
+        same_size = model_opt.enc_rnn_size == model_opt.dec_rnn_size
+        assert model_opt.model_type == 'audio' or same_size, \
+            "The encoder and decoder rnns must be the same size for now"
+
+        assert model_opt.rnn_type != "SRU" or model_opt.gpu_ranks, \
+            "Using SRU requires -gpu_ranks set."
+        if model_opt.share_embeddings:
+            if model_opt.model_type != "text":
+                raise AssertionError(
+                    "--share_embeddings requires --model_type text.")
+        if model_opt.model_dtype == "fp16":
+            logger.warning(
+                "FP16 is experimental, the generated checkpoints may "
+                "be incompatible with a future version")
+
+    @classmethod
+    def ckpt_model_opts(cls, ckpt_opt):
+        # Load default opt values, then overwrite with the opts in
+        # the checkpoint. That way, if there are new options added,
+        # the defaults are used.
+        opt = cls.defaults(opts.model_opts)
+        opt.__dict__.update(ckpt_opt.__dict__)
+        return opt
+
+    @classmethod
+    def validate_train_opts(cls, opt):
+        if opt.epochs:
+            raise AssertionError(
+                "-epochs is deprecated please use -train_steps.")
+        if opt.truncated_decoder > 0 and opt.accum_count > 1:
+            raise AssertionError("BPTT is not compatible with -accum > 1")
+        if opt.gpuid:
+            raise AssertionError("gpuid is deprecated \
+                  see world_size and gpu_ranks")
+        if torch.cuda.is_available() and not opt.gpu_ranks:
+            logger.info("WARNING: You have a CUDA device, \
+                        should run with -gpu_ranks")
+
+    @classmethod
+    def validate_translate_opts(cls, opt):
+        if opt.beam_size != 1 and opt.random_sampling_topk != 1:
+            raise ValueError('Can either do beam search OR random sampling.')
+
+    @classmethod
+    def validate_preprocess_args(cls, opt):
+        assert opt.max_shard_size == 0, \
+            "-max_shard_size is deprecated. Please use \
+            -shard_size (number of examples) instead."
+        assert opt.shuffle == 0, \
+            "-shuffle is not implemented. Please shuffle \
+            your data before pre-processing."
+
+        assert os.path.isfile(opt.train_src) \
+            and os.path.isfile(opt.train_tgt), \
+            "Please check path of your train src and tgt files!"
+
+        assert not opt.valid_src or os.path.isfile(opt.valid_src), \
+            "Please check path of your valid src file!"
+        assert not opt.valid_tgt or os.path.isfile(opt.valid_tgt), \
+            "Please check path of your valid tgt file!"

--- a/onmt/utils/parse.py
+++ b/onmt/utils/parse.py
@@ -32,15 +32,15 @@ class ArgumentParser(cfargparse.ArgumentParser):
 
     @classmethod
     def update_model_opts(cls, model_opt):
-        if model_opt.word_vec_size != -1:
+        if model_opt.word_vec_size > 0:
             model_opt.src_word_vec_size = model_opt.word_vec_size
             model_opt.tgt_word_vec_size = model_opt.word_vec_size
 
-        if model_opt.layers != -1:
+        if model_opt.layers > 0:
             model_opt.enc_layers = model_opt.layers
             model_opt.dec_layers = model_opt.layers
 
-        if model_opt.rnn_size != -1:
+        if model_opt.rnn_size > 0:
             model_opt.enc_rnn_size = model_opt.rnn_size
             model_opt.dec_rnn_size = model_opt.rnn_size
 

--- a/train.py
+++ b/train.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python
-"""
-    Main training workflow
-"""
-
-import configargparse
+"""Train models."""
 import os
 import signal
 import torch
@@ -13,21 +9,13 @@ import onmt.utils.distributed
 
 from onmt.utils.logging import logger
 from onmt.train_single import main as single_main
+from onmt.utils.parse import ArgumentParser
 
 
 def main(opt):
-    if opt.rnn_type == "SRU" and not opt.gpu_ranks:
-        raise AssertionError("Using SRU requires -gpu_ranks set.")
-
-    if opt.epochs:
-        raise AssertionError("-epochs is deprecated please use -train_steps.")
-
-    if opt.truncated_decoder > 0 and opt.accum_count > 1:
-        raise AssertionError("BPTT is not compatible with -accum > 1")
-
-    if opt.gpuid:
-        raise AssertionError("gpuid is deprecated \
-              see world_size and gpu_ranks")
+    ArgumentParser.validate_train_opts(opt)
+    ArgumentParser.update_model_opts(opt)
+    ArgumentParser.validate_model_opts(opt)
 
     nb_gpu = len(opt.gpu_ranks)
 
@@ -106,13 +94,9 @@ class ErrorHandler(object):
 
 
 if __name__ == "__main__":
-    parser = configargparse.ArgumentParser(
-        description='train.py',
-        config_file_parser_class=configargparse.YAMLConfigFileParser,
-        formatter_class=configargparse.ArgumentDefaultsHelpFormatter)
+    parser = ArgumentParser(description='train.py')
 
     opts.config_opts(parser)
-    opts.add_md_help_argument(parser)
     opts.model_opts(parser)
     opts.train_opts(parser)
 

--- a/translate.py
+++ b/translate.py
@@ -2,15 +2,18 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
-import configargparse
 from onmt.utils.logging import init_logger
 from onmt.utils.misc import split_corpus
 from onmt.translate.translator import build_translator
 
 import onmt.opts as opts
+from onmt.utils.parse import ArgumentParser
 
 
 def main(opt):
+    ArgumentParser.validate_translate_opts(opt)
+    logger = init_logger(opt.log_file)
+
     translator = build_translator(opt, report_score=True)
     src_shards = split_corpus(opt.src, opt.shard_size)
     tgt_shards = split_corpus(opt.tgt, opt.shard_size) \
@@ -29,14 +32,10 @@ def main(opt):
 
 
 if __name__ == "__main__":
-    parser = configargparse.ArgumentParser(
-        description='translate.py',
-        config_file_parser_class=configargparse.YAMLConfigFileParser,
-        formatter_class=configargparse.ArgumentDefaultsHelpFormatter)
+    parser = ArgumentParser(description='translate.py')
+
     opts.config_opts(parser)
-    opts.add_md_help_argument(parser)
     opts.translate_opts(parser)
 
     opt = parser.parse_args()
-    logger = init_logger(opt.log_file)
     main(opt)


### PR DESCRIPTION
Working towards addressing #1231. This moves validating opts and getting default ("dummy") opts into a new ``ArgumentParser`` class. By default, that class uses the desired formatters and adds the md help.

I do validation and updating close to the entry point so the rest of the code can assume opts are clean. I choose to do validation in ``main()``'s instead of ``if __name__``'s so that you could e.g. test that main fails if passed bad args. (I didn't add those tests. Just saying they could be useful.)

In updating test_models.py to use the new parser, I ran across a few things with the audio encoder test:
1. In test_models.py, ``opt.layers`` was never forwarded to ``opt.enc_layers``/``opt.dec_layers`` so the test where ``opt.enc_layers`` = 10 was running but the number of layers was still default (2). That's now fixed by adding ``ArgumentParser.update_model_opts(opt)``.
2. In audio_encoder.py ``forward()``, the ``lengths`` update ``[int(math.floor((length - stride) / stride + 1)) for length in lengths]`` means that ``lengths`` has to be large "enough" depending on the number of layers. Believe that's roughly ``min(lengths) >= stride**n_layers``. Testing a stride of 2 and n_layers of 10 requires that lengths isn't really feasible since ``tgt_l`` would have to be huge. I left a comment to that effect and left stride at 1.

Now, server.py and translation_server.py still use ``configargparse`` directly. I don't think that code is tested and I didn't want to break it.