### PR TITLE
Compute and store moving average in fp32

### DIFF
--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -109,7 +109,7 @@ class Trainer(object):
         self.average_decay = average_decay
         self.moving_average = None
         self.average_every = average_every
-        self.model_dtype=model_dtype
+        self.model_dtype = model_dtype
 
         assert grad_accum_count > 0
         if grad_accum_count > 1:
@@ -253,7 +253,7 @@ class Trainer(object):
             valid_model = deepcopy(self.model)
             for avg, param in zip(self.moving_average,
                                   valid_model.parameters()):
-                param.data = avg.data.half() if model_dtype == "fp16" \
+                param.data = avg.data.half() if self.model_dtype == "fp16" \
                     else avg.data
         else:
             valid_model = self.model

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -57,7 +57,8 @@ def build_trainer(opt, device_id, model, fields, optim, model_saver=None):
                            gpu_verbose_level, report_manager,
                            model_saver=model_saver if gpu_rank == 0 else None,
                            average_decay=average_decay,
-                           average_every=average_every)
+                           average_every=average_every,
+                           model_dtype=opt.model_dtype)
     return trainer
 
 
@@ -90,7 +91,7 @@ class Trainer(object):
                  trunc_size=0, shard_size=32,
                  norm_method="sents", grad_accum_count=1, n_gpu=1, gpu_rank=1,
                  gpu_verbose_level=0, report_manager=None, model_saver=None,
-                 average_decay=0, average_every=1):
+                 average_decay=0, average_every=1, model_dtype='fp32'):
         # Basic attributes.
         self.model = model
         self.train_loss = train_loss
@@ -108,6 +109,7 @@ class Trainer(object):
         self.average_decay = average_decay
         self.moving_average = None
         self.average_every = average_every
+        self.model_dtype=model_dtype
 
         assert grad_accum_count > 0
         if grad_accum_count > 1:
@@ -138,7 +140,7 @@ class Trainer(object):
 
     def _update_average(self, step):
         if self.moving_average is None:
-            copy_params = [params.detach()
+            copy_params = [params.detach().float()
                            for params in self.model.parameters()]
             self.moving_average = copy_params
         else:
@@ -148,7 +150,7 @@ class Trainer(object):
                                      self.model.parameters()):
                 self.moving_average[i] = \
                     (1 - average_decay) * avg + \
-                    average_decay * cpt.detach()
+                    cpt.detach().float() * average_decay
 
     def train(self,
               train_iter,
@@ -251,7 +253,8 @@ class Trainer(object):
             valid_model = deepcopy(self.model)
             for avg, param in zip(self.moving_average,
                                   valid_model.parameters()):
-                param.data = avg.data
+                param.data = avg.data.half() if model_dtype == "fp16" \
+                    else avg.data
         else:
             valid_model = self.model
 


### PR DESCRIPTION
We noticed that fp16 moving average computation may underflow for some values of `-average_decay` (e.g. 1e10-4), and lead to diverging results, so we shall make it in `.float()` in either fp16 or fp32 training mode.