### PR TITLE
Simplify fields structure

### DIFF
--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -217,6 +217,6 @@ class AudioSeqField(Field):
         return arr
 
 
-def audio_fields(base_name, **kwargs):
+def audio_fields(**kwargs):
     audio = AudioSeqField(pad_index=0, batch_first=True, include_lengths=True)
-    return [(base_name, audio)]
+    return audio

--- a/onmt/inputters/image_dataset.py
+++ b/onmt/inputters/image_dataset.py
@@ -99,8 +99,8 @@ def batch_img(data, vocab):
     return imgs
 
 
-def image_fields(base_name, **kwargs):
+def image_fields(**kwargs):
     img = Field(
         use_vocab=False, dtype=torch.float,
         postprocessing=batch_img, sequential=False)
-    return [(base_name, img)]
+    return img

--- a/onmt/inputters/text_dataset.py
+++ b/onmt/inputters/text_dataset.py
@@ -151,7 +151,7 @@ class TextMultiField(RawField):
         return self.fields[item]
 
 
-def text_fields(base_name, **kwargs):
+def text_fields(**kwargs):
     """Create text fields.
 
     Args:
@@ -164,11 +164,12 @@ def text_fields(base_name, **kwargs):
         truncate (bool or NoneType, optional): Defaults to ``None``.
 
     Returns:
-        List[Tuple[str, TextMultiField]]
+        TextMultiField
     """
 
     n_feats = kwargs["n_feats"]
     include_lengths = kwargs["include_lengths"]
+    base_name = kwargs["base_name"]
     pad = kwargs.get("pad", "<blank>")
     bos = kwargs.get("bos", "<s>")
     eos = kwargs.get("eos", "</s>")
@@ -190,4 +191,4 @@ def text_fields(base_name, **kwargs):
         fields_.append((name, feat))
     assert fields_[0][0] == base_name  # sanity check
     field = TextMultiField(fields_[0][0], fields_[0][1], fields_[1:])
-    return [(base_name, field)]
+    return field

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -106,7 +106,8 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None, gpu_id=None):
     """
     Args:
         model_opt: the option loaded from checkpoint.
-        fields: `Field` objects for the model.
+        fields (dict[str, torchtext.data.Field]):
+            `Field` objects for the model.
         gpu (bool): whether to use gpu.
         checkpoint: the model gnerated by train phase, or a resumed snapshot
                     model from a stopped training.
@@ -125,9 +126,7 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None, gpu_id=None):
 
     # Build embeddings.
     if model_opt.model_type == "text":
-        src_fields = [f for n, f in fields['src']]
-        assert len(src_fields) == 1
-        src_field = src_fields[0]
+        src_field = fields["src"]
         src_emb = build_embeddings(model_opt, src_field)
     else:
         src_emb = None
@@ -136,11 +135,8 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None, gpu_id=None):
     encoder = build_encoder(model_opt, src_emb)
 
     # Build decoder.
-    tgt_fields = [f for n, f in fields['tgt']]
-    assert len(tgt_fields) == 1
-    tgt_field = tgt_fields[0]
-    tgt_emb = build_embeddings(
-        model_opt, tgt_field, for_encoder=False)
+    tgt_field = fields["tgt"]
+    tgt_emb = build_embeddings(model_opt, tgt_field, for_encoder=False)
 
     # Share the embedding matrix - preprocess with share_vocab required.
     if model_opt.share_embeddings:
@@ -169,15 +165,14 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None, gpu_id=None):
             gen_func = nn.LogSoftmax(dim=-1)
         generator = nn.Sequential(
             nn.Linear(model_opt.dec_rnn_size,
-                      len(fields["tgt"][0][1].base_field.vocab)),
+                      len(fields["tgt"].base_field.vocab)),
             Cast(torch.float32),
             gen_func
         )
         if model_opt.share_decoder_embeddings:
             generator[0].weight = decoder.embeddings.word_lut.weight
     else:
-        assert len(fields["tgt"]) == 1
-        tgt_base_field = fields["tgt"][0][1].base_field
+        tgt_base_field = fields["tgt"].base_field
         vocab_size = len(tgt_base_field.vocab)
         pad_idx = tgt_base_field.vocab.stoi[tgt_base_field.pad_token]
         generator = CopyGenerator(model_opt.dec_rnn_size, vocab_size, pad_idx)

--- a/onmt/tests/test_models.py
+++ b/onmt/tests/test_models.py
@@ -28,7 +28,7 @@ class TestModel(unittest.TestCase):
         self.opt = opt
 
     def get_field(self):
-        src = onmt.inputters.get_fields("text", 0, 0)["src"][0][1]
+        src = onmt.inputters.get_fields("text", 0, 0)["src"]
         src.base_field.build_vocab([])
         return src
 

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -6,7 +6,6 @@
 import configargparse
 
 import os
-from itertools import chain
 
 import torch
 
@@ -110,14 +109,14 @@ def main(opt, device_id):
 
     # Report src and tgt vocab sizes, including for features
     for side in ['src', 'tgt']:
-        for name, f in fields[side]:
-            try:
-                f_iter = iter(f)
-            except TypeError:
-                f_iter = [(name, f)]
-            for sn, sf in f_iter:
-                if sf.use_vocab:
-                    logger.info(' * %s vocab size = %d' % (sn, len(sf.vocab)))
+        f = fields[side]
+        try:
+            f_iter = iter(f)
+        except TypeError:
+            f_iter = [(side, f)]
+        for sn, sf in f_iter:
+            if sf.use_vocab:
+                logger.info(' * %s vocab size = %d' % (sn, len(sf.vocab)))
 
     # Build model.
     model = build_model(model_opt, opt, fields, checkpoint)
@@ -136,13 +135,9 @@ def main(opt, device_id):
     trainer = build_trainer(
         opt, device_id, model, fields, optim, model_saver=model_saver)
 
-    # this line is kind of a temporary kludge because different objects expect
-    # fields to have a different structure
-    dataset_fields = dict(chain.from_iterable(fields.values()))
-
-    train_iter = build_dataset_iter("train", dataset_fields, opt)
+    train_iter = build_dataset_iter("train", fields, opt)
     valid_iter = build_dataset_iter(
-        "valid", dataset_fields, opt, is_train=False)
+        "valid", fields, opt, is_train=False)
 
     if len(opt.gpu_ranks):
         logger.info('Starting training on GPU: %s' % opt.gpu_ranks)

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -31,7 +31,8 @@ def build_trainer(opt, device_id, model, fields, optim, model_saver=None):
         model_saver(:obj:`onmt.models.ModelSaverBase`): the utility object
             used to save the model
     """
-    tgt_field = fields['tgt'][0][1].base_field
+
+    tgt_field = dict(fields)["tgt"].base_field
     train_loss = onmt.utils.loss.build_loss_compute(model, tgt_field, opt)
     valid_loss = onmt.utils.loss.build_loss_compute(
         model, tgt_field, opt, train=False)

--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -15,7 +15,7 @@ class TranslationBuilder(object):
 
     Args:
        data (DataSet):
-       fields (dict of Fields): data fields
+       fields (List[Tuple[str, torchtext.data.Field]]): data fields
        n_best (int): number of translations produced
        replace_unk (bool): replace unknown words using attention
        has_tgt (bool): will the batch have gold targets
@@ -26,13 +26,13 @@ class TranslationBuilder(object):
         self.data = data
         self.fields = fields
         self._has_text_src = isinstance(
-            self.fields["src"][0][1], TextMultiField)
+            dict(self.fields)["src"], TextMultiField)
         self.n_best = n_best
         self.replace_unk = replace_unk
         self.has_tgt = has_tgt
 
     def _build_target_tokens(self, src, src_vocab, src_raw, pred, attn):
-        tgt_field = self.fields["tgt"][0][1].base_field
+        tgt_field = dict(self.fields)["tgt"].base_field
         vocab = tgt_field.vocab
         tokens = []
         for tok in pred:

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -53,7 +53,7 @@ class Translator(object):
 
     Args:
         model (onmt.modules.NMTModel): NMT model to use for translation
-        fields (dict[str, list[tuple[str, torchtext.data.Field]]]): A dict
+        fields (dict[str, torchtext.data.Field]): A dict
             mapping each side to its list of name-Field pairs.
         src_reader (inputters.DataReaderBase): Source reader.
         tgt_reader (inputters.TextDataReader): Target reader.
@@ -120,7 +120,7 @@ class Translator(object):
             seed=-1):
         self.model = model
         self.fields = fields
-        tgt_field = self.fields["tgt"][0][1].base_field
+        tgt_field = dict(self.fields)["tgt"].base_field
         self._tgt_vocab = tgt_field.vocab
         self._tgt_eos_idx = self._tgt_vocab.stoi[tgt_field.eos_token]
         self._tgt_pad_idx = self._tgt_vocab.stoi[tgt_field.pad_token]
@@ -196,7 +196,7 @@ class Translator(object):
 
         Args:
             model (onmt.modules.NMTModel): See :func:`__init__()`.
-            fields (dict[str, list[tuple[str, torchtext.data.Field]]]): See
+            fields (dict[str, torchtext.data.Field]): See
                 :func:`__init__()`.
             opt (argparse.Namespace): Command line options
             model_opt (argparse.Namespace): Command line options saved with

--- a/tools/embeddings_to_torch.py
+++ b/tools/embeddings_to_torch.py
@@ -19,9 +19,9 @@ def get_vocabs(dict_path):
             vocab = next((v for n, v in fields if n == side), None)
         else:
             try:
-                vocab = fields[side][0][1].base_field.vocab
+                vocab = fields[side].base_field.vocab
             except AttributeError:
-                vocab = fields[side][0][1].vocab
+                vocab = fields[side].vocab
         vocs.append(vocab)
     enc_vocab, dec_vocab = vocs
 

--- a/tools/extract_embeddings.py
+++ b/tools/extract_embeddings.py
@@ -48,8 +48,8 @@ def main():
         fields = onmt.inputters.load_old_vocab(vocab)
     else:
         fields = vocab
-    src_dict = fields['src'][0][1].base_field.vocab  # assumes src is text
-    tgt_dict = fields['tgt'][0][1].base_field.vocab
+    src_dict = fields['src'].base_field.vocab  # assumes src is text
+    tgt_dict = fields['tgt'].base_field.vocab
 
     model_opt = checkpoint['opt']
     for arg in dummy_opt.__dict__:


### PR DESCRIPTION
This reduces the ``fields`` object to ``dict[str, Field]`` in all cases.

On #1292 it came up that ``fields`` is sometimes ``dict[str, list[tuple[str, Field]]]`` and sometimes ``[list[tuple[str, Field]]``. On the other hand, torchtext is (usually) using ``dict[str, Field]``.

I tested that you can:
Preprocess on master, train on PR.
Preprocess and train on master, translate on PR.
Preprocess and train on master, train from checkpoint on PR.
And pull request script checks against legacy formats.

So I think this is completely backwards compatible.