### PR TITLE
Allow forcing FP32 at inference of FP16 models

### DIFF
--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -97,6 +97,8 @@ def load_test_model(opt, model_path=None):
 
     model = build_base_model(model_opt, fields, use_gpu(opt), checkpoint,
                              opt.gpu)
+    if opt.fp32:
+        model.float()
     model.eval()
     model.generator.eval()
     return fields, model, model_opt

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -522,6 +522,9 @@ def translate_opts(parser):
               help='Path to model .pt file(s). '
               'Multiple models can be specified, '
               'for ensemble decoding.')
+    group.add('--fp32', '-fp32', action='store_true',
+              help="""Force the model to be in FP32
+              because FP16 is very slow on GTX1080(ti).""")
     group.add('--avg_raw_probs', '-avg_raw_probs', action='store_true',
               help="""If this is set, during ensembling scores from
               different models will be combined by averaging their


### PR DESCRIPTION

On some hardware (GTX 1080/1080ti) FP16 is way slower than FP32.

this option allows to force FP32 decoding even if the model is FP16.
