### PR TITLE
Fix doctr deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: python
 python:
   - "2.7"
   - "3.5"
+git:
+  depth: false
 addons:
   apt:
     packages:
@@ -75,5 +77,4 @@ matrix:
         - pip install -r docs/requirements.txt
         - cd docs/; make html; cd ..
         - set -e
-        #- doctr deploy --built-docs docs/build/html/ .
-
+        - doctr deploy --built-docs docs/build/html/ .


### PR DESCRIPTION
The Travis shallow Git clone seems to cause issues with doctr:

```text
fatal: missing blob object '271af2ebbb5de8b1cb69c0b7e177bcc4ab2e34dc'
error: github.com:OpenNMT/OpenNMT-py.git did not send all necessary objects
```

Making a deep clone appears to fix this issue.