### PR TITLE
Add flask dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,6 @@ matrix:
         - pip install doctr
       script:
         - pip install -r docs/requirements.txt
-        - cd docs/; make html; cd ..
         - set -e
+        - cd docs/ && make html && cd ..
         - doctr deploy --built-docs docs/build/html/ .

--- a/requirements.opt.txt
+++ b/requirements.opt.txt
@@ -8,3 +8,4 @@ pyrouge
 pyonmttok
 opencv-python
 git+https://github.com/NVIDIA/apex
+flask

--- a/requirements.opt.txt
+++ b/requirements.opt.txt
@@ -8,4 +8,3 @@ pyrouge
 pyonmttok
 opencv-python
 git+https://github.com/NVIDIA/apex
-flask


### PR DESCRIPTION
This adds Flask as an optional dependency.

#1311 broke Github Pages. There was an error saying flask wasn't available. That would make it impossible to import server.py, which is now part of the docs. There's no tests on server.py directly so it makes sense that Travis didn't break. Not 100% sure this will fix it, but either way flask is an optional dependency so it should probably be listed here.