### PR TITLE
Fix translate.py bug (OpenNMT/OpenNMT-py#1317)

### DIFF
--- a/translate.py
+++ b/translate.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+from itertools import repeat
+
 from onmt.utils.logging import init_logger
 from onmt.utils.misc import split_corpus
 from onmt.translate.translator import build_translator
@@ -17,7 +19,7 @@ def main(opt):
     translator = build_translator(opt, report_score=True)
     src_shards = split_corpus(opt.src, opt.shard_size)
     tgt_shards = split_corpus(opt.tgt, opt.shard_size) \
-        if opt.tgt is not None else [None]*opt.shard_size
+        if opt.tgt is not None else repeat(None)
     shard_pairs = zip(src_shards, tgt_shards)
 
     for i, (src_shard, tgt_shard) in enumerate(shard_pairs):


### PR DESCRIPTION
`translate.py` would ignore all sentences after processing `shard_size*shard_size` sentences in `src`, if no `tgt` file was provided. This commit fixes this issue (#1317).

I've run all the tests as well, but none of them seem to actually target `translate.py`. I tested it manually using the following parameters on a ~1000 line source file:

```bash
python  translate.py --model model_step_10000.pt --src 1000-line-test.txt --batch_size 1 --shard_size 1 --output pred1.txt
python  translate.py --model model_step_10000.pt --src 1000-line-test.txt --batch_size 1 --output pred2.txt
python  translate.py --model model_step_10000.pt --src 1000-line-test.txt --output pred3.txt
python  translate.py --model model_step_10000.pt --src 1000-line-test.txt --batch_size 1 --shard_size 10 --output pred4.txt
python  translate.py --model model_step_10000.pt --src 1000-line-test.txt --batch_size 10 --shard_size 1 --output pred5.txt
```

All outputs were identical. If you'd like me to run more tests, let me know!