### PR TITLE
tgt/src ratio based beam stopping condition

### DIFF
--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -607,6 +607,8 @@ def translate_opts(parser):
     group.add('--length_penalty', '-length_penalty', default='none',
               choices=['none', 'wu', 'avg'],
               help="Length Penalty to use.")
+    group.add('--ratio', '-ratio', type=float, default=-0.,
+              help="Ratio based beam stop condition")
     group.add('--coverage_penalty', '-coverage_penalty', default='none',
               choices=['none', 'wu', 'summary'],
               help="Coverage Penalty to use.")

--- a/onmt/tests/test_beam_search.py
+++ b/onmt/tests/test_beam_search.py
@@ -39,7 +39,7 @@ class TestBeamSearch(unittest.TestCase):
                 beam_sz, batch_sz, 0, 1, 2, 2,
                 torch.device("cpu"), GlobalScorerStub(), 0, 30,
                 False, ngram_repeat, set(),
-                torch.randint(0, 30, (batch_sz,)), False)
+                torch.randint(0, 30, (batch_sz,)), False, 0.)
             for i in range(ngram_repeat + 4):
                 # predict repeat_idx over and over again
                 word_probs = torch.full(
@@ -69,7 +69,7 @@ class TestBeamSearch(unittest.TestCase):
                 beam_sz, batch_sz, 0, 1, 2, 2,
                 torch.device("cpu"), GlobalScorerStub(), 0, 30,
                 False, ngram_repeat, set(),
-                torch.randint(0, 30, (batch_sz,)), False)
+                torch.randint(0, 30, (batch_sz,)), False, 0.)
             for i in range(ngram_repeat + 4):
                 # non-interesting beams are going to get dummy values
                 word_probs = torch.full(
@@ -116,7 +116,7 @@ class TestBeamSearch(unittest.TestCase):
                 beam_sz, batch_sz, 0, 1, 2, 2,
                 torch.device("cpu"), GlobalScorerStub(), 0, 30,
                 False, ngram_repeat, {repeat_idx_ignored},
-                torch.randint(0, 30, (batch_sz,)), False)
+                torch.randint(0, 30, (batch_sz,)), False, 0.)
             for i in range(ngram_repeat + 4):
                 # non-interesting beams are going to get dummy values
                 word_probs = torch.full(
@@ -173,7 +173,7 @@ class TestBeamSearch(unittest.TestCase):
             beam = BeamSearch(beam_sz, batch_sz, 0, 1, 2, 2,
                               torch.device("cpu"), GlobalScorerStub(),
                               min_length, 30, False, 0, set(),
-                              lengths, False)
+                              lengths, False, 0.)
             all_attns = []
             for i in range(min_length + 4):
                 # non-interesting beams are going to get dummy values
@@ -228,7 +228,7 @@ class TestBeamSearch(unittest.TestCase):
             beam_sz, batch_sz, 0, 1, 2, 2,
             torch.device("cpu"), GlobalScorerStub(),
             min_length, 30, False, 0, set(),
-            torch.randint(0, 30, (batch_sz,)), False)
+            torch.randint(0, 30, (batch_sz,)), False, 0.)
         for i in range(min_length + 4):
             # non-interesting beams are going to get dummy values
             word_probs = torch.full(
@@ -286,7 +286,7 @@ class TestBeamSearch(unittest.TestCase):
             beam_sz, batch_sz, 0, 1, 2, 2,
             torch.device("cpu"), GlobalScorerStub(),
             min_length, 30, True, 0, set(),
-            inp_lens, False)
+            inp_lens, False, 0.)
         for i in range(min_length + 2):
             # non-interesting beams are going to get dummy values
             word_probs = torch.full(
@@ -497,7 +497,7 @@ class TestBeamSearchAgainstReferenceCase(unittest.TestCase):
             self.BEAM_SZ, self.BATCH_SZ, 0, 1, 2, self.N_BEST,
             torch.device("cpu"), GlobalScorerStub(),
             0, 30, False, 0, set(),
-            torch.randint(0, 30, (self.BATCH_SZ,)), False)
+            torch.randint(0, 30, (self.BATCH_SZ,)), False, 0.)
 
         expected_beam_scores = self.init_step(beam, 1)
         expected_beam_scores = self.first_step(beam, expected_beam_scores, 1)
@@ -515,7 +515,7 @@ class TestBeamWithLengthPenalty(TestBeamSearchAgainstReferenceCase):
             self.BEAM_SZ, self.BATCH_SZ, 0, 1, 2, self.N_BEST,
             torch.device("cpu"), scorer,
             0, 30, False, 0, set(),
-            torch.randint(0, 30, (self.BATCH_SZ,)), False)
+            torch.randint(0, 30, (self.BATCH_SZ,)), False, 0.)
         expected_beam_scores = self.init_step(beam, 1.)
         expected_beam_scores = self.first_step(beam, expected_beam_scores, 3)
         expected_beam_scores = self.second_step(beam, expected_beam_scores, 4)

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -93,6 +93,7 @@ class Translator(object):
             n_best=1,
             min_length=0,
             max_length=100,
+            ratio=0.,
             beam_size=30,
             random_sampling_topk=1,
             random_sampling_temp=1,
@@ -135,6 +136,7 @@ class Translator(object):
         self.sample_from_topk = random_sampling_topk
 
         self.min_length = min_length
+        self.ratio = ratio
         self.stepwise_penalty = stepwise_penalty
         self.dump_beam = dump_beam
         self.block_ngram_repeat = block_ngram_repeat
@@ -218,6 +220,7 @@ class Translator(object):
             n_best=opt.n_best,
             min_length=opt.min_length,
             max_length=opt.max_length,
+            ratio=opt.ratio,
             beam_size=opt.beam_size,
             random_sampling_topk=opt.random_sampling_topk,
             random_sampling_temp=opt.random_sampling_temp,
@@ -507,6 +510,7 @@ class Translator(object):
                     src_vocabs,
                     self.max_length,
                     min_length=self.min_length,
+                    ratio=self.ratio,
                     n_best=self.n_best,
                     return_attention=attn_debug or self.replace_unk)
 
@@ -588,6 +592,7 @@ class Translator(object):
             src_vocabs,
             max_length,
             min_length=0,
+            ratio=0.,
             n_best=1,
             return_attention=False):
         # TODO: support these blacklisted features.
@@ -636,6 +641,7 @@ class Translator(object):
             eos=self._tgt_eos_idx,
             bos=self._tgt_bos_idx,
             min_length=min_length,
+            ratio=ratio,
             max_length=max_length,
             mb_device=mb_device,
             return_attention=return_attention,


### PR DESCRIPTION

Based on this paper http://aclweb.org/anthology/D18-1342

this PR replaces #1336 which was done on an old codebase.

Usage:
translate.py -length_penalty avg -ratio 1.1
where 1.1 is the predicted ratio tgt_len / src_len

I tested it on a few engines, it brings  some improvements.