### PR TITLE
Add phrase_table translation argument

### DIFF
--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -629,12 +629,17 @@ def translate_opts(parser):
     group.add('--replace_unk', '-replace_unk', action="store_true",
               help="Replace the generated UNK tokens with the "
                    "source token that had highest attention weight. If "
-                   "phrase_table is provided, it will lookup the "
+                   "phrase_table is provided, it will look up the "
                    "identified source token and give the corresponding "
-                   "target token. If it is not provided(or the identified "
-                   "source token does not exist in the table) then it "
-                   "will copy the source token")
-
+                   "target token. If it is not provided (or the identified "
+                   "source token does not exist in the table), then it "
+                   "will copy the source token.")
+    group.add('--phrase_table', '-phrase_table', type=str, default="",
+              help="If phrase_table is provided (with replace_unk), it will "
+                   "look up the identified source token and give the corresponding "
+                   "target token. If it is not provided (or the identified "
+                   "source token does not exist in the table), then it "
+                   "will copy the source token.")
     group = parser.add_argument_group('Logging')
     group.add('--verbose', '-verbose', action="store_true",
               help='Print scores and predictions for each sentence')

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -636,10 +636,10 @@ def translate_opts(parser):
                    "will copy the source token.")
     group.add('--phrase_table', '-phrase_table', type=str, default="",
               help="If phrase_table is provided (with replace_unk), it will "
-                   "look up the identified source token and give the corresponding "
-                   "target token. If it is not provided (or the identified "
-                   "source token does not exist in the table), then it "
-                   "will copy the source token.")
+                   "look up the identified source token and give the "
+                   "corresponding target token. If it is not provided "
+                   "(or the identified source token does not exist in "
+                   "the table), then it will copy the source token.")
     group = parser.add_argument_group('Logging')
     group.add('--verbose', '-verbose', action="store_true",
               help='Print scores and predictions for each sentence')

--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals, print_function
 import torch
 from onmt.inputters.text_dataset import TextMultiField
 
-
 class TranslationBuilder(object):
     """
     Build a word-based translation from the batch output
@@ -22,13 +21,14 @@ class TranslationBuilder(object):
     """
 
     def __init__(self, data, fields, n_best=1, replace_unk=False,
-                 has_tgt=False):
+                 has_tgt=False, phrase_table=""):
         self.data = data
         self.fields = fields
         self._has_text_src = isinstance(
             dict(self.fields)["src"], TextMultiField)
         self.n_best = n_best
         self.replace_unk = replace_unk
+        self.phrase_table = phrase_table
         self.has_tgt = has_tgt
 
     def _build_target_tokens(self, src, src_vocab, src_raw, pred, attn):
@@ -48,6 +48,11 @@ class TranslationBuilder(object):
                 if tokens[i] == tgt_field.unk_token:
                     _, max_index = attn[i].max(0)
                     tokens[i] = src_raw[max_index.item()]
+                    if self.phrase_table != "":
+                        with open(self.phrase_table, "r") as f:
+                            for line in f:
+                                if line.startswith(src_raw[max_index.item()]):
+                                    tokens[i] = line.split('|||')[1].strip()
         return tokens
 
     def from_batch(self, translation_batch):

--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals, print_function
 import torch
 from onmt.inputters.text_dataset import TextMultiField
 
+
 class TranslationBuilder(object):
     """
     Build a word-based translation from the batch output

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -102,6 +102,7 @@ class Translator(object):
             block_ngram_repeat=0,
             ignore_when_blocking=frozenset(),
             replace_unk=False,
+            phrase_table="",
             data_type="text",
             verbose=False,
             report_bleu=False,
@@ -149,6 +150,7 @@ class Translator(object):
         if self.replace_unk and not self.model.decoder.attentional:
             raise ValueError(
                 "replace_unk requires an attentional decoder.")
+        self.phrase_table = phrase_table
         self.data_type = data_type
         self.verbose = verbose
         self.report_bleu = report_bleu
@@ -229,6 +231,7 @@ class Translator(object):
             block_ngram_repeat=opt.block_ngram_repeat,
             ignore_when_blocking=set(opt.ignore_when_blocking),
             replace_unk=opt.replace_unk,
+            phrase_table=opt.phrase_table,
             data_type=opt.data_type,
             verbose=opt.verbose,
             report_bleu=opt.report_bleu,
@@ -264,7 +267,8 @@ class Translator(object):
             tgt=None,
             src_dir=None,
             batch_size=None,
-            attn_debug=False):
+            attn_debug=False,
+            phrase_table=""):
         """Translate content of ``src`` and get gold scores from ``tgt``.
 
         Args:
@@ -307,7 +311,7 @@ class Translator(object):
         )
 
         xlation_builder = onmt.translate.TranslationBuilder(
-            data, self.fields, self.n_best, self.replace_unk, tgt
+            data, self.fields, self.n_best, self.replace_unk, tgt, self.phrase_table
         )
 
         # Statistics

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -311,7 +311,8 @@ class Translator(object):
         )
 
         xlation_builder = onmt.translate.TranslationBuilder(
-            data, self.fields, self.n_best, self.replace_unk, tgt, self.phrase_table
+            data, self.fields, self.n_best, self.replace_unk, tgt,
+            self.phrase_table
         )
 
         # Statistics


### PR DESCRIPTION
If `phrase_table` is provided (with replace_unk), it will look up the identified source token and give the corresponding target token. If it is not provided (or the identified source token does not exist in the table), then it will copy the source token. Tested with both _translate.py_ and _server.py_ (with conf.json).

The default behaviour of the `-replace_unk` option is substituting `<unk>` (for an unknown word) with the source word that has the highest attention weight. Adding the option `-phrase_table` as well, it will look up in the phrase table file for a possible translation instead. If a valid replacement is not found, only then the source token will be copied.

The phrase table is a file with one translation per line in the format:
`source|||target`
Where source and target are case sensitive and single tokens.

**Example with translate.py:**
`python3 OpenNMT-py/translate.py -model available_models/my.model_step_100000.pt -src source.txt -output prep.txt -replace_unk -phrase_table phrase-table.txt
`

**Example with server.py:**
`python3 OpenNMT-py/server.py --ip "0.0.0.0" --port 5000 --url_root "/translator" --config available_models/conf.json
`

`curl -i -X POST -H "Content-Type: application/json" -d '[{"src": "this is a test for model 100", "id": 100}]' http://127.0.0.1:5000/translator/translate
`

... where conf.json is:
```
{
    "models_root": "/home/available_models",
    "models": [
        {   
            "id": 100,
            "model": "my.model_step_100000.pt",
            "timeout": 600,
            "on_timeout": "to_cpu",
            "load": true,
            "opt": {
                "beam_size": 1,
                "replace_unk": true,
                "phrase_table": "/home/available_models/phrase-table.txt"
            }
        }  
    ]   
}
```