### PR TITLE
Write attention debug output to logger

### DIFF
--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -372,7 +372,10 @@ class Translator(object):
                             "{:*>10.7f} ", "{:>10.7f} ", max_index)
                         output += row_format.format(word, *row) + '\n'
                         row_format = "{:>10.10} " + "{:>10.7f} " * len(srcs)
-                    os.write(1, output.encode('utf-8'))
+                    if self.logger:
+                        self.logger.info(output)
+                    else:
+                        os.write(1, output.encode('utf-8'))
 
         end_time = time.time()
 


### PR DESCRIPTION
This PR modifies the Translator class to write the attention output (attn_debug=True) to the logger, instead of stdout, if the Translator object has a logger. Currently, the attention output is always written to stdout.