### PR TITLE
Check vocabulary files exist at start of preprocessing

### DIFF
--- a/onmt/utils/parse.py
+++ b/onmt/utils/parse.py
@@ -113,3 +113,8 @@ class ArgumentParser(cfargparse.ArgumentParser):
             "Please check path of your valid src file!"
         assert not opt.valid_tgt or os.path.isfile(opt.valid_tgt), \
             "Please check path of your valid tgt file!"
+
+        assert not opt.src_vocab or os.path.isfile(opt.src_vocab), \
+            "Please check path of your src vocab!"
+        assert not opt.tgt_vocab or os.path.isfile(opt.tgt_vocab), \
+            "Please check path of your tgt vocab!"


### PR DESCRIPTION
This PR modifies the preprocessing code to check that src_vocab and tgt_vocab exist, if they are specified as parameters.

This prevents the problem where a user specifies vocab files that do not exist, and waits for the preprocessing script to reach the vocab generation step only to have the program crash.