### PR TITLE
Avoid padding indices in MeanEncoder

### DIFF
--- a/onmt/encoders/mean_encoder.py
+++ b/onmt/encoders/mean_encoder.py
@@ -38,7 +38,8 @@ class MeanEncoder(EncoderBase):
             mean = torch.bmm(mask.unsqueeze(1), emb.transpose(0, 1)).squeeze(1)
         else:
             mean = emb.mean(0)
-            
+
+        mean = mean.expand(self.num_layers, batch, emb_dim)
         memory_bank = emb
         encoder_final = (mean, mean)
         return encoder_final, memory_bank, lengths

--- a/onmt/encoders/mean_encoder.py
+++ b/onmt/encoders/mean_encoder.py
@@ -34,8 +34,8 @@ class MeanEncoder(EncoderBase):
         if lengths is not None:
             # we avoid padding while mean pooling
             mask = sequence_mask(lengths).float()
-            coefs = mask / lengths.unsqueeze(1).float()
-            mean = torch.bmm(coefs.unsqueeze(1), emb).squeeze(1)
+            mask = mask / lengths.unsqueeze(1).float()
+            mean = torch.bmm(mask.unsqueeze(1), emb.transpose(0, 1)).squeeze(1)
         else:
             mean = emb.mean(0)
             


### PR DESCRIPTION
Hi @pltrdy 

As we talked about, small patch in MeanEncoder that avoids including the padding when computing the mean.

Let me known if there's anything missing