### PR TITLE
Add a progress bar to the training loop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ multi-bleu.perl
 .idea
 *.sublime-*
 .DS_Store
+.vscode
 data/
 
 # Byte-compiled / optimized / DLL files

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
-from tqdm import tqdm
+import enlighten
 
 import torch
 from torchtext.data import Field
@@ -115,7 +115,11 @@ class AudioDataReader(DataReaderBase):
         if isinstance(data, str):
             data = DataReaderBase._read_file(data)
 
-        for i, line in enumerate(tqdm(data)):
+        pbar = enlighten.Counter(
+            total=len(data),
+            desc='Progress:',
+            unit='lines')
+        for i, line in enumerate(data):
             line = line.decode("utf-8").strip()
             audio_path = os.path.join(src_dir, line)
             if not os.path.exists(audio_path):
@@ -123,6 +127,8 @@ class AudioDataReader(DataReaderBase):
 
             assert os.path.exists(audio_path), \
                 'audio path %s not found' % line
+
+            pbar.update()
 
             spect = self.extract_features(audio_path)
             yield {side: spect, side + '_path': line, 'indices': i}

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -112,11 +112,14 @@ class AudioDataReader(DataReaderBase):
         assert src_dir is not None and os.path.exists(src_dir),\
             "src_dir must be a valid directory if data_type is audio"
 
+        data_len = DataReaderBase._count_lines(data)
+
         if isinstance(data, str):
             data = DataReaderBase._read_file(data)
 
-        pbar = enlighten.Counter(
-            total=len(data),
+        manager = enlighten.get_manager()
+        pbar = manager.counter(
+            total=data_len,
             desc='Progress:',
             unit='lines')
         for i, line in enumerate(data):

--- a/onmt/inputters/datareader_base.py
+++ b/onmt/inputters/datareader_base.py
@@ -34,6 +34,16 @@ class DataReaderBase(object):
                 yield line
 
     @staticmethod
+    def _count_lines(path):
+        if isinstance(path, (list,)):
+            return len(path)
+        else:
+            with open(path) as f:
+                for i, l in enumerate(f):
+                    pass
+            return i + 1
+
+    @staticmethod
     def _raise_missing_dep(*missing_deps):
         """Raise missing dep exception with standard error message."""
         raise MissingDependencyException(

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -493,6 +493,8 @@ def train_opts(parser):
               help="Number of warmup steps for custom decay.")
 
     group = parser.add_argument_group('Logging')
+    group.add('--no_pbar', '-no_pbar', action='store_true',
+              help="Don't show a progress bar.")
     group.add('--report_every', '-report_every', type=int, default=50,
               help="Print stats at this interval.")
     group.add('--log_file', '-log_file', type=str, default="",

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -277,7 +277,7 @@ class Trainer(object):
                 pbar_valid.close()
                 pbar_valid = manager.counter(
                     total=valid_steps,
-                    desc='Next Validation:',
+                    desc='Next Validation',
                     unit='steps')
 
             if (self.model_saver is not None

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -211,12 +211,12 @@ class Trainer(object):
         manager = enlighten.get_manager()
         pbar_train = manager.counter(
             total=train_steps,
-            desc='Total Progress:',
+            desc='Training       ',
             unit='steps')
         pbar_valid = manager.counter(
             total=valid_steps,
             leave=False,
-            desc='Valid Progress:',
+            desc='Next Validation',
             unit='steps')
 
         if self.n_gpu > 1:

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -223,7 +223,7 @@ class Trainer(object):
         manager = enlighten.get_manager(stream=stream)
         pbar_train = manager.counter(
             total=train_steps,
-            desc='Total Training Progress:',
+            desc='Training Progress:',
             unit='steps')
 
         if self.n_gpu > 1:

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -223,12 +223,12 @@ class Trainer(object):
         manager = enlighten.get_manager(stream=stream)
         pbar_train = manager.counter(
             total=train_steps,
-            desc='Training       ',
+            desc='Total Training Progress:',
             unit='steps')
         pbar_valid = manager.counter(
             total=valid_steps,
             leave=False,
-            desc='Next Validation',
+            desc='Next Validation:        ',
             unit='steps')
 
         if self.n_gpu > 1:

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -225,11 +225,6 @@ class Trainer(object):
             total=train_steps,
             desc='Total Training Progress:',
             unit='steps')
-        pbar_valid = manager.counter(
-            total=valid_steps,
-            leave=False,
-            desc='Next Validation:        ',
-            unit='steps')
 
         if self.n_gpu > 1:
             train_iter = itertools.islice(
@@ -263,7 +258,6 @@ class Trainer(object):
                 self.optim.learning_rate(),
                 report_stats)
             pbar_train.update()
-            pbar_valid.update()
 
             if valid_iter is not None and step % valid_steps == 0:
                 if self.gpu_verbose_level > 0:
@@ -286,11 +280,6 @@ class Trainer(object):
                     # If the patience has reached the limit, stop training
                     if self.earlystopper.has_stopped():
                         break
-                pbar_valid.close()
-                pbar_valid = manager.counter(
-                    total=valid_steps,
-                    desc='Next Validation',
-                    unit='steps')
 
             if (self.model_saver is not None
                 and (save_checkpoint_steps != 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 six
+enlighten
 tqdm==4.30.*
 torch>=1.0
 git+https://github.com/pytorch/text.git@master#wheel=torchtext

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 six
 enlighten
-tqdm==4.30.*
 torch>=1.0
 git+https://github.com/pytorch/text.git@master#wheel=torchtext
 future


### PR DESCRIPTION
This pull request adds a progress bar to the training loop using [Enlighten](https://python-enlighten.readthedocs.io). I tried to add one with tqdm but ran into some problems due to the logging.

There are two progress bars: one for total completion and another for next validation.

Since it has an ETA, this is related to https://github.com/OpenNMT/OpenNMT-py/issues/1397.