### PR TITLE
Check -gpu_ranks option to ensure saving a model

### DIFF
--- a/onmt/utils/parse.py
+++ b/onmt/utils/parse.py
@@ -90,11 +90,15 @@ class ArgumentParser(cfargparse.ArgumentParser):
         if torch.cuda.is_available() and not opt.gpu_ranks:
             logger.info("WARNING: You have a CUDA device, \
                         should run with -gpu_ranks")
-        if opt.world_size <= len(opt.gpu_ranks) and \
-                min(opt.gpu_ranks[:opt.world_size]) > 0:
+        if opt.world_size < len(opt.gpu_ranks):
             raise AssertionError(
-                  "gpu_ranks should have master(=0) rank "
-                  "unless -world_size is larger than len(gpu_ranks).")
+                  "parameter counts of -gpu_ranks must be less or equal "
+                  "than -world_size.")
+        if opt.world_size == len(opt.gpu_ranks) and \
+                min(opt.gpu_ranks) > 0:
+            raise AssertionError(
+                  "-gpu_ranks should have master(=0) rank "
+                  "unless -world_size is greater than len(gpu_ranks).")
 
     @classmethod
     def validate_translate_opts(cls, opt):

--- a/onmt/utils/parse.py
+++ b/onmt/utils/parse.py
@@ -81,15 +81,20 @@ class ArgumentParser(cfargparse.ArgumentParser):
     def validate_train_opts(cls, opt):
         if opt.epochs:
             raise AssertionError(
-                "-epochs is deprecated please use -train_steps.")
+                  "-epochs is deprecated please use -train_steps.")
         if opt.truncated_decoder > 0 and max(opt.accum_count) > 1:
             raise AssertionError("BPTT is not compatible with -accum > 1")
         if opt.gpuid:
-            raise AssertionError("gpuid is deprecated \
-                  see world_size and gpu_ranks")
+            raise AssertionError(
+                  "gpuid is deprecated see world_size and gpu_ranks")
         if torch.cuda.is_available() and not opt.gpu_ranks:
             logger.info("WARNING: You have a CUDA device, \
                         should run with -gpu_ranks")
+        if opt.world_size <= len(opt.gpu_ranks) and \
+                min(opt.gpu_ranks[:opt.world_size]) > 0:
+            raise AssertionError(
+                  "gpu_ranks should have master(=0) rank "
+                  "unless -world_size is larger than len(gpu_ranks).")
 
     @classmethod
     def validate_translate_opts(cls, opt):


### PR DESCRIPTION
This PR modifies validate_train_opts() class method to check gpu_ranks option, to ensure saving a model against #1322, even though FAQ document covered this problem.

Assuming locally-distributed environment, list some possible cases:
 (1) -world_size 1 and -gpu_ranks 1 --> raise assertion
 (2) -world_size 2 and -gpu_ranks 1 3 2 0 --> raise assertion, truncate gpu_ranks array with world_size(=[1, 3])
 (3) -world_size 4 and -gpu_ranks 2 3 --> safe, worker node
 (4) -world_size 4 and -gpu_ranks 0 1 --> safe, master node
 (5) -world_size 1(as default) without assigning gpu_ranks parameter explicitly --> safe, train.py will call single_main() methods, in case of 1 GPU only.

additionally, it modifies some AssertionError messages for indentation and print messages neatly.