### PR TITLE
Fix unwanted behaviour when loading vocab from text file with words frequency option

### DIFF
--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -285,7 +285,7 @@ def _build_field_vocab(field, counter, size_multiple=1, **kwargs):
         _pad_vocab_to_multiple(field.vocab, size_multiple)
 
 
-def _load_vocab(vocab_path, name, counters):
+def _load_vocab(vocab_path, name, counters, min_freq):
     # counters changes in place
     vocab = _read_vocab_file(vocab_path, name)
     vocab_size = len(vocab)
@@ -293,7 +293,7 @@ def _load_vocab(vocab_path, name, counters):
     for i, token in enumerate(vocab):
         # keep the order of tokens specified in the vocab file by
         # adding them to the counter with decreasing counting values
-        counters[name][token] = vocab_size - i
+        counters[name][token] = vocab_size - i + min_freq
     return vocab, vocab_size
 
 
@@ -351,13 +351,15 @@ def build_vocab(train_dataset_files, fields, data_type, share_vocab,
     # Load vocabulary
     if src_vocab_path:
         src_vocab, src_vocab_size = _load_vocab(
-            src_vocab_path, "src", counters)
+            src_vocab_path, "src", counters,
+            src_words_min_frequency)
     else:
         src_vocab = None
 
     if tgt_vocab_path:
         tgt_vocab, tgt_vocab_size = _load_vocab(
-            tgt_vocab_path, "tgt", counters)
+            tgt_vocab_path, "tgt", counters,
+            tgt_words_min_frequency)
     else:
         tgt_vocab = None
 


### PR DESCRIPTION
@flauted this should fix the issue mentioned in #1413 

For reference: it was introduced [here](https://github.com/OpenNMT/OpenNMT-py/pull/1216/files#diff-55eec480db97bda4ea4ea8fc498bfad6L284). This, in combination with some -src_words_min_frequency or tgt_words_min_frequency option may lead to removing some of the last tokens of the vocab.