### PR TITLE
Remove unnecessary `view` for linear operation

### DIFF
--- a/onmt/modules/global_attention.py
+++ b/onmt/modules/global_attention.py
@@ -114,7 +114,7 @@ class GlobalAttention(nn.Module):
 
         if self.attn_type in ["general", "dot"]:
             if self.attn_type == "general":
-                h_t_ = self.linear_in(h_t_)
+                h_t = self.linear_in(h_t)
             h_s_ = h_s.transpose(1, 2)
             # (batch, t_len, d) x (batch, d, s_len) --> (batch, t_len, s_len)
             return torch.bmm(h_t, h_s_)

--- a/onmt/modules/global_attention.py
+++ b/onmt/modules/global_attention.py
@@ -114,26 +114,24 @@ class GlobalAttention(nn.Module):
 
         if self.attn_type in ["general", "dot"]:
             if self.attn_type == "general":
-                h_t_ = h_t.view(tgt_batch * tgt_len, tgt_dim)
                 h_t_ = self.linear_in(h_t_)
-                h_t = h_t_.view(tgt_batch, tgt_len, tgt_dim)
             h_s_ = h_s.transpose(1, 2)
             # (batch, t_len, d) x (batch, d, s_len) --> (batch, t_len, s_len)
             return torch.bmm(h_t, h_s_)
         else:
             dim = self.dim
-            wq = self.linear_query(h_t.view(-1, dim))
+            wq = self.linear_query(h_t)
             wq = wq.view(tgt_batch, tgt_len, 1, dim)
             wq = wq.expand(tgt_batch, tgt_len, src_len, dim)
 
-            uh = self.linear_context(h_s.contiguous().view(-1, dim))
+            uh = self.linear_context(h_s.contiguous())
             uh = uh.view(src_batch, 1, src_len, dim)
             uh = uh.expand(src_batch, tgt_len, src_len, dim)
 
             # (batch, t_len, s_len, d)
             wquh = torch.tanh(wq + uh)
 
-            return self.v(wquh.view(-1, dim)).view(tgt_batch, tgt_len, src_len)
+            return self.v(wquh).view(tgt_batch, tgt_len, src_len)
 
     def forward(self, source, memory_bank, memory_lengths=None, coverage=None):
         """


### PR DESCRIPTION
The `Linear` module of pytorch should accept arbitrary size of input tensor as long as the last dimension equals to the input dimension. So these `view` operations can be safely removed.

However I didn't test it yet, I just edit them on Github