### PR TITLE
[WIP] Introduce sentence weighting

### DIFF
--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -110,7 +110,6 @@ class Dataset(TorchtextDataset):
                  filter_pred=None):
         self.sort_key = sort_key
         can_copy = 'src_map' in fields and 'alignment' in fields
-
         read_iters = [r.read(dat[1], dat[0], dir_) for r, dat, dir_
                       in zip(readers, data, dirs)]
 
@@ -127,6 +126,8 @@ class Dataset(TorchtextDataset):
                 self.src_vocabs.append(src_ex_vocab)
             ex_fields = {k: [(k, v)] for k, v in fields.items() if
                          k in ex_dict}
+            if 'weights' in ex_dict.keys():
+                ex_dict['weights'] = float(ex_dict['weights'])
             ex = Example.fromdict(ex_dict, ex_fields)
             examples.append(ex)
 

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -120,6 +120,9 @@ def get_fields(
     indices = Field(use_vocab=False, dtype=torch.long, sequential=False)
     fields["indices"] = indices
 
+    weights = Field(use_vocab=False, dtype=torch.long, sequential=False)
+    fields["weights"] = weights
+
     if dynamic_dict:
         src_map = Field(
             use_vocab=False, dtype=torch.float,

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -196,7 +196,7 @@ def preprocess_opts(parser):
     group.add('--train_ids', '-train_ids', nargs='+', default=[None],
               help="ids to name training shards, used for corpus weighting")
     group.add('--sentence_weights', '-sentence_weights',
-              nargs='+', default=None,
+              nargs='+', default=None, action=CastNone,
               help="Path(s) to the training examples sentence weights")
     group.add('--valid_src', '-valid_src',
               help="Path to the validation source data")
@@ -736,6 +736,18 @@ class StoreLoggingLevelAction(configargparse.Action):
         # Get the key 'value' in the dict, or just use 'value'
         level = StoreLoggingLevelAction.LEVELS.get(value, value)
         setattr(namespace, self.dest, level)
+
+
+class CastNone(configargparse.Action):
+    def __init__(self, option_strings, dest, help=None, **kwargs):
+        super(CastNone, self).__init__(
+            option_strings, dest, help=help, **kwargs)
+
+    def __call__(self, parser, namespace, value, option_string=None):
+        for i, item in enumerate(value):
+            if item.lower() == "none":
+                value[i] = None
+        setattr(namespace, self.dest, value)
 
 
 class DeprecateAction(configargparse.Action):

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -195,6 +195,9 @@ def preprocess_opts(parser):
               help="Path(s) to the training target data")
     group.add('--train_ids', '-train_ids', nargs='+', default=[None],
               help="ids to name training shards, used for corpus weighting")
+    group.add('--sentence_weights', '-sentence_weights',
+              nargs='+', default=None,
+              help="Path(s) to the training examples sentence weights")
     group.add('--valid_src', '-valid_src',
               help="Path to the validation source data")
     group.add('--valid_tgt', '-valid_tgt',

--- a/onmt/tests/test_preprocess.py
+++ b/onmt/tests/test_preprocess.py
@@ -49,11 +49,12 @@ class TestData(unittest.TestCase):
 
         src_reader = onmt.inputters.str2reader[opt.data_type].from_opt(opt)
         tgt_reader = onmt.inputters.str2reader["text"].from_opt(opt)
+        weights_reader = onmt.inputters.str2reader["text"].from_opt(opt)
         preprocess.build_save_dataset(
-            'train', fields, src_reader, tgt_reader, opt)
+            'train', fields, src_reader, tgt_reader, weights_reader, opt)
 
         preprocess.build_save_dataset(
-            'valid', fields, src_reader, tgt_reader, opt)
+            'valid', fields, src_reader, tgt_reader, weights_reader, opt)
 
         # Remove the generated *pt files.
         for pt in glob.glob(SAVE_DATA_PREFIX + '*.pt'):

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -99,15 +99,14 @@ def main(opt, device_id):
         opt, device_id, model, fields, optim, model_saver=model_saver)
 
     train_iterables = []
-    for train_id in opt.data_ids:
-        if train_id:
+    if len(opt.data_ids) > 1:
+        for train_id in opt.data_ids:
             shard_base = "train_" + train_id
-        else:
-            shard_base = "train"
-        iterable = build_dataset_iter(shard_base, fields, opt, multi=True)
-        train_iterables.append(iterable)
-
-    train_iter = MultipleDatasetIterator(train_iterables, device_id, opt)
+            iterable = build_dataset_iter(shard_base, fields, opt, multi=True)
+            train_iterables.append(iterable)
+        train_iter = MultipleDatasetIterator(train_iterables, device_id, opt)
+    else:
+        train_iter = build_dataset_iter("train", fields, opt)
 
     valid_iter = build_dataset_iter(
         "valid", fields, opt, is_train=False)

--- a/onmt/utils/loss.py
+++ b/onmt/utils/loss.py
@@ -118,8 +118,8 @@ class LossComputeBase(nn.Module):
 
         """
         if weights is None:
-            weights = torch.ones(loss.size()).to(loss.device) * 2
-        weights = weights.float()
+            weights = torch.ones(loss.size()).to(loss.device)
+        weights = weights.float().to(loss.device)
         weighted_sum = (loss * weights).sum()
         return weighted_sum
 

--- a/train.py
+++ b/train.py
@@ -125,6 +125,8 @@ def batch_producer(generator_to_serve, queues, semaphore, opt):
             if hasattr(b, 'alignment') else None
         b.src_map = b.src_map.to(torch.device(device_id)) \
             if hasattr(b, 'src_map') else None
+        b.weights = b.weights.to(torch.device(device_id)) \
+            if hasattr(b, 'weights') else None
 
         # hack to dodge unpicklable `dict_keys`
         b.fields = list(b.fields)


### PR DESCRIPTION
Basic idea: give an additional file when preprocessing, containing sentence weights.

These weights will be stored in the torchtext `Example`s and will be used to weight the loss in `_compute_loss`.

I introduce the `-sentence_weights` opt, to which we are supposed to pass some text file(s) containing the weights for each sentence / example. If several corpora are passed according to #1413 upgrades, such weight files should be passed as well. If we want/have weights for only some of the corpora in the list, we can pass `None`/`none` instead of the filename and it will be cast to python `None` by argparse, and weights of 1 will be assigned.

I did some tests on basic translation / speech / image runs, and it seems to be running without any issue.
