### PR TITLE
Using Producer-Consumer for batches

### DIFF
--- a/onmt/inputters/dataset_base.py
+++ b/onmt/inputters/dataset_base.py
@@ -50,6 +50,7 @@ def _dynamic_dict(example, src_field, tgt_field):
     # Map source tokens to indices in the dynamic dict.
     src_map = torch.LongTensor([src_ex_vocab.stoi[w] for w in src])
     example["src_map"] = src_map
+    example["src_ex_vocab"] = src_ex_vocab
 
     if "tgt" in example:
         tgt = tgt_field.tokenize(example["tgt"])

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -617,7 +617,8 @@ class MultipleDatasetIterator(object):
         self.index = -1
         self.iterables = []
         for shard in train_shards:
-            self.iterables.append(build_dataset_iter(shard, fields, opt, multi=True))
+            self.iterables.append(
+                build_dataset_iter(shard, fields, opt, multi=True))
         self.init_iterators = True
         self.weights = opt.data_weights
         self.batch_size = opt.batch_size

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -9,7 +9,7 @@ from itertools import chain, cycle
 
 import torch
 import torchtext.data
-from torchtext.data import Field
+from torchtext.data import Field, RawField
 from torchtext.vocab import Vocab
 from torchtext.data.utils import RandomShuffler
 
@@ -125,6 +125,10 @@ def get_fields(
             use_vocab=False, dtype=torch.float,
             postprocessing=make_src, sequential=False)
         fields["src_map"] = src_map
+        
+        src_ex_vocab = RawField()
+        # setattr(src_ex_vocab, 'sequential', True)
+        fields["src_ex_vocab"] = src_ex_vocab
 
         align = Field(
             use_vocab=False, dtype=torch.long,

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -521,12 +521,12 @@ def _pool(data, batch_size, batch_size_fn, batch_size_multiple,
     for p in torchtext.data.batch(
             data, batch_size * pool_factor,
             batch_size_fn=batch_size_fn):
-        p_batch = batch_iter(
+        p_batch = list(batch_iter(
             sorted(p, key=sort_key),
             batch_size,
             batch_size_fn=batch_size_fn,
-            batch_size_multiple=batch_size_multiple)
-        for b in random_shuffler(list(p_batch)):
+            batch_size_multiple=batch_size_multiple))
+        for b in random_shuffler(p_batch):
             yield b
 
 
@@ -610,18 +610,21 @@ class MultipleDatasetIterator(object):
     respective weights, and yields a batch in the wanted proportions.
     """
     def __init__(self,
-                 iterables,
+                 train_shards,
+                 fields,
                  device,
                  opt):
         self.index = -1
-        self.iterators = [iter(iterable) for iterable in iterables]
-        self.iterables = iterables
+        self.iterables = []
+        for shard in train_shards:
+            self.iterables.append(build_dataset_iter(shard, fields, opt, multi=True))
+        self.init_iterators = True
         self.weights = opt.data_weights
         self.batch_size = opt.batch_size
         self.batch_size_fn = max_tok_len \
             if opt.batch_type == "tokens" else None
         self.batch_size_multiple = 8 if opt.model_dtype == "fp16" else 1
-        self.device = "cuda" if device >= 0 else "cpu"
+        self.device = device
         # Temporarily load one shard to retrieve sort_key for data_type
         temp_dataset = torch.load(self.iterables[0]._paths[0])
         self.sort_key = temp_dataset.sort_key
@@ -630,6 +633,9 @@ class MultipleDatasetIterator(object):
         del temp_dataset
 
     def _iter_datasets(self):
+        if self.init_iterators:
+            self.iterators = [iter(iterable) for iterable in self.iterables]
+            self.init_iterators = False
         for weight in self.weights:
             self.index = (self.index + 1) % len(self.iterators)
             for i in range(weight):
@@ -640,18 +646,19 @@ class MultipleDatasetIterator(object):
             yield next(iterator)
 
     def __iter__(self):
-        for minibatch in _pool(
-                self._iter_examples(),
-                self.batch_size,
-                self.batch_size_fn,
-                self.batch_size_multiple,
-                self.sort_key,
-                self.random_shuffler,
-                self.pool_factor):
-            minibatch = sorted(minibatch, key=self.sort_key, reverse=True)
-            yield torchtext.data.Batch(minibatch,
-                                       self.iterables[0].dataset,
-                                       self.device)
+        while True:
+            for minibatch in _pool(
+                    self._iter_examples(),
+                    self.batch_size,
+                    self.batch_size_fn,
+                    self.batch_size_multiple,
+                    self.sort_key,
+                    self.random_shuffler,
+                    self.pool_factor):
+                minibatch = sorted(minibatch, key=self.sort_key, reverse=True)
+                yield torchtext.data.Batch(minibatch,
+                                           self.iterables[0].dataset,
+                                           self.device)
 
 
 class DatasetLazyIter(object):
@@ -683,9 +690,9 @@ class DatasetLazyIter(object):
         self.pool_factor = pool_factor
 
     def _iter_dataset(self, path):
+        logger.info('Loading dataset from %s' % path)
         cur_dataset = torch.load(path)
-        logger.info('Loading dataset from %s, number of examples: %d' %
-                    (path, len(cur_dataset)))
+        logger.info('number of examples: %d' % len(cur_dataset))
         cur_dataset.fields = self.fields
         cur_iter = OrderedIterator(
             dataset=cur_dataset,
@@ -704,10 +711,12 @@ class DatasetLazyIter(object):
             self.dataset = cur_iter.dataset
             yield batch
 
-        cur_dataset.examples = None
-        gc.collect()
-        del cur_dataset
-        gc.collect()
+        # NOTE: This is causing some issues for consumer/producer,
+        # as we may still have some of those examples in some queue
+        # cur_dataset.examples = None
+        # gc.collect()
+        # del cur_dataset
+        # gc.collect()
 
     def __iter__(self):
         num_batches = 0
@@ -762,6 +771,8 @@ def build_dataset_iter(corpus_type, fields, opt, is_train=True, multi=False):
     """
     dataset_paths = list(sorted(
         glob.glob(opt.data + '.' + corpus_type + '.[0-9]*.pt')))
+    assert dataset_paths != [], \
+        "Check data %s - %s" % (opt.data, corpus_type)
     if not dataset_paths:
         return None
     if multi:
@@ -788,3 +799,8 @@ def build_dataset_iter(corpus_type, fields, opt, is_train=True, multi=False):
         repeat=not opt.single_pass,
         num_batches_multiple=max(opt.accum_count) * opt.world_size,
         yield_raw_example=multi)
+
+
+def build_dataset_iter_multiple(train_shards, fields, opt):
+    return MultipleDatasetIterator(
+        train_shards, fields, "cuda" if opt.gpu_ranks else "cpu", opt)

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -127,7 +127,6 @@ def get_fields(
         fields["src_map"] = src_map
 
         src_ex_vocab = RawField()
-        # setattr(src_ex_vocab, 'sequential', True)
         fields["src_ex_vocab"] = src_ex_vocab
 
         align = Field(

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -125,7 +125,7 @@ def get_fields(
             use_vocab=False, dtype=torch.float,
             postprocessing=make_src, sequential=False)
         fields["src_map"] = src_map
-        
+
         src_ex_vocab = RawField()
         # setattr(src_ex_vocab, 'sequential', True)
         fields["src_ex_vocab"] = src_ex_vocab

--- a/onmt/modules/copy_generator.py
+++ b/onmt/modules/copy_generator.py
@@ -5,7 +5,7 @@ from onmt.utils.misc import aeq
 from onmt.utils.loss import LossComputeBase
 
 
-def collapse_copy_scores(scores, batch, tgt_vocab, src_vocabs,
+def collapse_copy_scores(scores, batch, tgt_vocab, src_vocabs=None,
                          batch_dim=1, batch_offset=None):
     """
     Given scores from an expanded dictionary
@@ -16,9 +16,12 @@ def collapse_copy_scores(scores, batch, tgt_vocab, src_vocabs,
     for b in range(scores.size(batch_dim)):
         blank = []
         fill = []
-        batch_id = batch_offset[b] if batch_offset is not None else b
-        index = batch.indices.data[batch_id]
-        src_vocab = src_vocabs[index]
+        # batch_id = batch_offset[b] if batch_offset is not None else b
+        # index = batch.indices.data[batch_id]
+        # src_vocab = src_vocabs[index]
+        if src_vocabs is None:
+            src_vocab = batch.src_ex_vocab[b]
+            # print(src_vocab)
         for i in range(1, len(src_vocab)):
             sw = src_vocab.itos[i]
             ti = tgt_vocab.stoi[sw]
@@ -216,7 +219,7 @@ class CopyGeneratorLossCompute(LossComputeBase):
         # and is used only for stats
         scores_data = collapse_copy_scores(
             self._unbottle(scores.clone(), batch.batch_size),
-            batch, self.tgt_vocab, batch.dataset.src_vocabs)
+            batch, self.tgt_vocab, None)
         scores_data = self._bottle(scores_data)
 
         # this block does not depend on the loss value computed above

--- a/onmt/modules/copy_generator.py
+++ b/onmt/modules/copy_generator.py
@@ -16,12 +16,14 @@ def collapse_copy_scores(scores, batch, tgt_vocab, src_vocabs=None,
     for b in range(scores.size(batch_dim)):
         blank = []
         fill = []
-        # batch_id = batch_offset[b] if batch_offset is not None else b
-        # index = batch.indices.data[batch_id]
-        # src_vocab = src_vocabs[index]
+
         if src_vocabs is None:
             src_vocab = batch.src_ex_vocab[b]
-            # print(src_vocab)
+        else:
+            batch_id = batch_offset[b] if batch_offset is not None else b
+            index = batch.indices.data[batch_id]
+            src_vocab = src_vocabs[index]
+
         for i in range(1, len(src_vocab)):
             sw = src_vocab.itos[i]
             ti = tgt_vocab.stoi[sw]

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -343,6 +343,8 @@ def train_opts(parser):
               help="IP of master for torch.distributed training.")
     group.add('--master_port', '-master_port', default=10000, type=int,
               help="Port of master for torch.distributed training.")
+    group.add('--queue_size', '-queue_size', default=400, type=int,
+              help="Size of queue for each process in producer/consumer")
 
     group.add('--seed', '-seed', type=int, default=-1,
               help="Random seed used for the experiments "

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -3,7 +3,6 @@
 import os
 
 import torch
-import torchtext
 
 from onmt.inputters.inputter import build_dataset_iter, \
     load_old_vocab, old_style_vocab, MultipleDatasetIterator
@@ -104,18 +103,20 @@ def main(opt, device_id, batch_queue=None, semaphore=None):
         if len(opt.data_ids) > 1:
             for train_id in opt.data_ids:
                 shard_base = "train_" + train_id
-                iterable = build_dataset_iter(shard_base, fields, opt, multi=True)
+                iterable = build_dataset_iter(
+                    shard_base, fields, opt, multi=True)
                 train_iterables.append(iterable)
-            train_iter = MultipleDatasetIterator(train_iterables, device_id, opt)
+            train_iter = MultipleDatasetIterator(
+                train_iterables, device_id, opt)
         else:
             train_iter = build_dataset_iter("train", fields, opt)
     else:
-        assert semaphore is not None, "Using batch_queue requires semaphore as well"
+        assert semaphore is not None, \
+            "Using batch_queue requires semaphore as well"
 
         def _train_iter():
             while True:
                 batch = batch_queue.get()
-                cur_device = torch.cuda.current_device()
                 semaphore.release()
 
                 yield batch
@@ -134,7 +135,7 @@ def main(opt, device_id, batch_queue=None, semaphore=None):
         logger.warning("Option single_pass is enabled, ignoring train_steps.")
         train_steps = 0
     trainer.train(
-        train_iter,    
+        train_iter,
         train_steps,
         save_checkpoint_steps=opt.save_checkpoint_steps,
         valid_iter=valid_iter,

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -51,7 +51,6 @@ def main(opt, device_id, batch_queue=None, semaphore=None):
         logger.info('Loading checkpoint from %s' % opt.train_from)
         checkpoint = torch.load(opt.train_from,
                                 map_location=lambda storage, loc: storage)
-
         model_opt = ArgumentParser.ckpt_model_opts(checkpoint["opt"])
         ArgumentParser.update_model_opts(model_opt)
         ArgumentParser.validate_model_opts(model_opt)

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -110,7 +110,7 @@ def main(opt, device_id, batch_queue, semaphore):
     #     train_iter = build_dataset_iter("train", fields, opt)
     def _train_iter():
         while True:
-            clean = False
+            clean = True
             if clean:
                 batch = batch_queue.get()
                 cur_device = torch.cuda.current_device()

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -10,7 +10,6 @@
 """
 
 from copy import deepcopy
-import itertools
 import torch
 import traceback
 

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -161,6 +161,8 @@ class Trainer(object):
         normalization = 0
         self.accum_count = self._accum_count(self.optim.training_step)
         for batch in iterator:
+            # print("in iterator")
+            # print("batch: ", str(batch.src))
             batches.append(batch)
             if self.norm_method == "tokens":
                 num_tokens = batch.tgt[1:, :, 0].ne(
@@ -221,14 +223,14 @@ class Trainer(object):
         report_stats = onmt.utils.Statistics()
         self._start_report_manager(start_time=total_stats.start_time)
 
-        if self.n_gpu > 1:
-            train_iter = itertools.islice(
-                train_iter, self.gpu_rank, None, self.n_gpu)
+        # if self.n_gpu > 1:
+        #     train_iter = itertools.islice(
+        #         train_iter, self.gpu_rank, None, self.n_gpu)
 
         for i, (batches, normalization) in enumerate(
                 self._accum_batches(train_iter)):
             step = self.optim.training_step
-
+            # print("train iter")
             # UPDATE DROPOUT
             self._maybe_update_dropout(step)
 

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -161,8 +161,6 @@ class Trainer(object):
         normalization = 0
         self.accum_count = self._accum_count(self.optim.training_step)
         for batch in iterator:
-            # print("in iterator")
-            # print("batch: ", str(batch.src))
             batches.append(batch)
             if self.norm_method == "tokens":
                 num_tokens = batch.tgt[1:, :, 0].ne(
@@ -223,14 +221,9 @@ class Trainer(object):
         report_stats = onmt.utils.Statistics()
         self._start_report_manager(start_time=total_stats.start_time)
 
-        # if self.n_gpu > 1:
-        #     train_iter = itertools.islice(
-        #         train_iter, self.gpu_rank, None, self.n_gpu)
-
         for i, (batches, normalization) in enumerate(
                 self._accum_batches(train_iter)):
             step = self.optim.training_step
-            # print("train iter")
             # UPDATE DROPOUT
             self._maybe_update_dropout(step)
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -107,7 +107,8 @@ def build_save_dataset(corpus_type, fields, src_reader, tgt_reader, opt):
                                 f_iter, all_data):
                             has_vocab = (sub_n == 'src' and src_vocab) or \
                                         (sub_n == 'tgt' and tgt_vocab)
-                            if hasattr(sub_f, 'sequential') and sub_f.sequential and not has_vocab:
+                            if (hasattr(sub_f, 'sequential')
+                                    and sub_f.sequential and not has_vocab):
                                 val = fd
                                 counters[sub_n].update(val)
             if maybe_id:

--- a/preprocess.py
+++ b/preprocess.py
@@ -107,7 +107,7 @@ def build_save_dataset(corpus_type, fields, src_reader, tgt_reader, opt):
                                 f_iter, all_data):
                             has_vocab = (sub_n == 'src' and src_vocab) or \
                                         (sub_n == 'tgt' and tgt_vocab)
-                            if sub_f.sequential and not has_vocab:
+                            if hasattr(sub_f, 'sequential') and sub_f.sequential and not has_vocab:
                                 val = fd
                                 counters[sub_n].update(val)
             if maybe_id:

--- a/train.py
+++ b/train.py
@@ -88,8 +88,9 @@ def batch_producer(generator_to_serve, queues, semaphore):
 
         for device_id, q in enumerate(queues):
             if not q.full():
-                clean = False
+                clean = True
                 if clean:
+                    b.dataset = None 
                     if isinstance(b.src, tuple):
                         b.src = tuple([_.to(torch.device(device_id)) 
                                        for _ in b.src])
@@ -97,6 +98,9 @@ def batch_producer(generator_to_serve, queues, semaphore):
                         b.src = b.src.to(torch.device(device_id))
                     b.tgt = b.tgt.to(torch.device(device_id))
                     b.indices = b.indices.to(torch.device(device_id))
+                    b.alignment = b.alignment.to(torch.device(device_id)) if hasattr(b, 'alignment') else None
+                    b.src_map = b.src_map.to(torch.device(device_id)) if hasattr(b, 'src_map') else None
+                    
                     # hack to dodge unpicklable `dict_keys`
                     b.fields = list(b.fields)
                     q.put(b, False)

--- a/train.py
+++ b/train.py
@@ -7,11 +7,13 @@ import torch
 import onmt.opts as opts
 import onmt.utils.distributed
 
-from onmt.utils.logging import logger
+from onmt.utils.logging import init_logger, logger
 from onmt.train_single import main as single_main
 from onmt.utils.parse import ArgumentParser
 from onmt.inputters.inputter import build_dataset_iter, \
-    load_old_vocab, old_style_vocab, MultipleDatasetIterator
+    load_old_vocab, old_style_vocab, build_dataset_iter_multiple
+
+from itertools import cycle
 
 
 def main(opt):
@@ -44,13 +46,11 @@ def main(opt):
         fields = vocab
 
     if len(opt.data_ids) > 1:
-        train_iterables = []
+        train_shards = []
         for train_id in opt.data_ids:
             shard_base = "train_" + train_id
-            iterable = build_dataset_iter(shard_base, fields, opt, multi=True)
-            train_iterables.append(iterable)
-        train_iter = MultipleDatasetIterator(
-            train_iterables, "cuda" if opt.gpu_ranks else "cpu", opt)
+            train_shards.append(shard_base)
+        train_iter = build_dataset_iter_multiple(train_shards, fields, opt)
     else:
         train_iter = build_dataset_iter("train", fields, opt)
 
@@ -59,23 +59,22 @@ def main(opt):
     if opt.world_size > 1:
         queues = []
         mp = torch.multiprocessing.get_context('spawn')
-        semaphore = mp.Semaphore(opt.world_size)
+        semaphore = mp.Semaphore(opt.world_size * opt.queue_size)
         # Create a thread to listen for errors in the child processes.
         error_queue = mp.SimpleQueue()
         error_handler = ErrorHandler(error_queue)
         # Train with multiprocessing.
         procs = []
         for device_id in range(nb_gpu):
-            q = mp.Queue(1)
+            q = mp.Queue(opt.queue_size)
             queues += [q]
             procs.append(mp.Process(target=run, args=(
                 opt, device_id, error_queue, q, semaphore), daemon=True))
             procs[device_id].start()
             logger.info(" Starting process pid: %d  " % procs[device_id].pid)
             error_handler.add_child(procs[device_id].pid)
-
         procs.append(mp.Process(target=batch_producer,
-                                args=(train_iter, queues, semaphore,),
+                                args=(train_iter, queues, semaphore, opt,),
                      daemon=True))
         procs[-1].start()
         error_handler.add_child(procs[-1].pid)
@@ -89,34 +88,37 @@ def main(opt):
         single_main(opt, -1)
 
 
-def batch_producer(generator_to_serve, queues, semaphore):
+def batch_producer(generator_to_serve, queues, semaphore, opt):
+    init_logger(opt.log_file)
     generator_to_serve = iter(generator_to_serve)
+    queue_generator = cycle(queues)
 
-    for b in generator_to_serve:
+    def next_batch(device_id):
+        new_batch = next(generator_to_serve)
         semaphore.acquire()
+        return new_batch
 
-        for device_id, q in enumerate(queues):
-            if not q.full():
-                b.dataset = None
-                if isinstance(b.src, tuple):
-                    b.src = tuple([_.to(torch.device(device_id))
-                                   for _ in b.src])
-                else:
-                    b.src = b.src.to(torch.device(device_id))
-                b.tgt = b.tgt.to(torch.device(device_id))
-                b.indices = b.indices.to(torch.device(device_id))
-                b.alignment = b.alignment.to(torch.device(device_id)) \
-                    if hasattr(b, 'alignment') else None
-                b.src_map = b.src_map.to(torch.device(device_id)) \
-                    if hasattr(b, 'src_map') else None
+    b = next_batch(0)
 
-                # hack to dodge unpicklable `dict_keys`
-                b.fields = list(b.fields)
-                q.put(b, False)
+    for device_id, q in cycle(enumerate(queues)):
+        if not q.full():
+            b.dataset = None
+            if isinstance(b.src, tuple):
+                b.src = tuple([_.to(torch.device(device_id))
+                               for _ in b.src])
+            else:
+                b.src = b.src.to(torch.device(device_id))
+            b.tgt = b.tgt.to(torch.device(device_id))
+            b.indices = b.indices.to(torch.device(device_id))
+            b.alignment = b.alignment.to(torch.device(device_id)) \
+                if hasattr(b, 'alignment') else None
+            b.src_map = b.src_map.to(torch.device(device_id)) \
+                if hasattr(b, 'src_map') else None
 
-                break
-        else:
-            raise ValueError("Hmmm, should not happen, I mean, never.")
+            # hack to dodge unpicklable `dict_keys`
+            b.fields = list(b.fields)
+            q.put(b, False)
+            b = next_batch(device_id)
 
 
 def run(opt, device_id, error_queue, batch_queue, semaphore):

--- a/train.py
+++ b/train.py
@@ -73,14 +73,15 @@ def main(opt):
             procs[device_id].start()
             logger.info(" Starting process pid: %d  " % procs[device_id].pid)
             error_handler.add_child(procs[device_id].pid)
-        procs.append(mp.Process(target=batch_producer,
+        producer = mp.Process(target=batch_producer,
                                 args=(train_iter, queues, semaphore, opt,),
-                     daemon=True))
-        procs[-1].start()
-        error_handler.add_child(procs[-1].pid)
+                     daemon=True)
+        producer.start()
+        error_handler.add_child(producer.pid)
 
         for p in procs:
             p.join()
+        producer.terminate()
 
     elif nb_gpu == 1:  # case 1 GPU only
         single_main(opt, 0)

--- a/train.py
+++ b/train.py
@@ -91,7 +91,6 @@ def main(opt):
 def batch_producer(generator_to_serve, queues, semaphore, opt):
     init_logger(opt.log_file)
     generator_to_serve = iter(generator_to_serve)
-    queue_generator = cycle(queues)
 
     def next_batch(device_id):
         new_batch = next(generator_to_serve)

--- a/train.py
+++ b/train.py
@@ -74,8 +74,8 @@ def main(opt):
             logger.info(" Starting process pid: %d  " % procs[device_id].pid)
             error_handler.add_child(procs[device_id].pid)
         producer = mp.Process(target=batch_producer,
-                                args=(train_iter, queues, semaphore, opt,),
-                     daemon=True)
+                              args=(train_iter, queues, semaphore, opt,),
+                              daemon=True)
         producer.start()
         error_handler.add_child(producer.pid)
 


### PR DESCRIPTION
Goal: load the dataset only once in RAM (instead of n_gpu times) which enables much bigger datasets or less sharding.

The idea is to have a producer that reads data (i.e. shards) and sends batch to consumers (i.e. process that actually trains the model).

It's *quite* working now, but we're still investigating not trivial cases with @francoishernandez  (including Multiple dataset that show weird behavior)