### PR TITLE
New apex amp API

### DIFF
--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -214,8 +214,6 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None, gpu_id=None):
 
     model.generator = generator
     model.to(device)
-    if model_opt.model_dtype == 'fp16':
-        model.half()
 
     return model
 

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -179,6 +179,10 @@ def model_opts(parser):
     group.add('--loss_scale', '-loss_scale', type=float, default=0,
               help="For FP16 training, the static loss scale to use. If not "
                    "set, the loss scale is dynamically computed.")
+    group.add('--apex_opt_level', '-apex_opt_level', type=str, default="O2",
+              choices=["O0", "O1", "O2", "O3"],
+              help="For FP16 training, the opt_level to use."
+                   "See https://nvidia.github.io/apex/amp.html#opt-levels.")
 
 
 def preprocess_opts(parser):

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -294,8 +294,7 @@ class Trainer(object):
             valid_model = deepcopy(self.model)
             for avg, param in zip(self.moving_average,
                                   valid_model.parameters()):
-                param.data = avg.data.half() if self.model_dtype == "fp16" \
-                    else avg.data
+                param.data = avg.data
         else:
             valid_model = self.model
 

--- a/onmt/utils/optimizers.py
+++ b/onmt/utils/optimizers.py
@@ -311,6 +311,7 @@ class Optimizer(object):
         """Wrapper for backward pass. Some optimizer requires ownership of the
         backward pass."""
         if self._with_fp16_wrapper:
+            import apex
             with apex.amp.scale_loss(loss, self._optimizer) as scaled_loss:
                 scaled_loss.backward()
         else:
@@ -328,6 +329,7 @@ class Optimizer(object):
                 self._optimizer.update_master_grads()
             if hasattr(self._optimizer, "clip_master_grads") and \
                self._max_grad_norm > 0:
+                import apex
                 torch.nn.utils.glip_grad_norm_(
                     apex.amp.master_params(self), self._max_grad_norm)
         for group in self._optimizer.param_groups:

--- a/onmt/utils/optimizers.py
+++ b/onmt/utils/optimizers.py
@@ -90,7 +90,8 @@ def build_torch_optimizer(model, opt):
             [model, model.generator],
             optimizer,
             opt_level=opt.apex_opt_level,
-            loss_scale=loss_scale)
+            loss_scale=loss_scale,
+            keep_batchnorm_fp32=False if opt.optim == "fusedadam" else None)
 
     return optimizer
 

--- a/onmt/utils/optimizers.py
+++ b/onmt/utils/optimizers.py
@@ -87,8 +87,10 @@ def build_torch_optimizer(model, opt):
         import apex
         loss_scale = "dynamic" if opt.loss_scale == 0 else opt.loss_scale
         model, optimizer = apex.amp.initialize(
-            [model, model.generator], optimizer, opt_level="O2",
-            keep_batchnorm_fp32=False, loss_scale=loss_scale)
+            [model, model.generator],
+            optimizer,
+            opt_level=opt.apex_opt_level,
+            loss_scale=loss_scale)
 
     return optimizer
 

--- a/onmt/utils/parse.py
+++ b/onmt/utils/parse.py
@@ -63,10 +63,6 @@ class ArgumentParser(cfargparse.ArgumentParser):
             if model_opt.model_type != "text":
                 raise AssertionError(
                     "--share_embeddings requires --model_type text.")
-        if model_opt.model_dtype == "fp16":
-            logger.warning(
-                "FP16 is experimental, the generated checkpoints may "
-                "be incompatible with a future version")
 
     @classmethod
     def ckpt_model_opts(cls, ckpt_opt):


### PR DESCRIPTION
This PR updates the current mixed precision codepath with the new apex amp API according to the [guidelines](https://nvidia.github.io/apex/amp.html#transition-guide-for-old-api-users).

Default is `opt_level` "O2" which seems to correspond to what we were doing before. This can be changed by passing the `-apex_opt_level` option.
