### PR TITLE
Fix a potential IndexError when translating with replace_unk

### DIFF
--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -47,7 +47,6 @@ class TranslationBuilder(object):
         if self.replace_unk and attn is not None and src is not None:
             for i in range(len(tokens)):
                 if tokens[i] == tgt_field.unk_token:
-                    _, max_index = attn[i].max(0)
                     _, max_index = attn[i][:len(src_raw)].max(0)
                     if self.phrase_table != "":
                         with open(self.phrase_table, "r") as f:

--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -48,6 +48,7 @@ class TranslationBuilder(object):
             for i in range(len(tokens)):
                 if tokens[i] == tgt_field.unk_token:
                     _, max_index = attn[i][:len(src_raw)].max(0)
+                    tokens[i] = src_raw[max_index.item()]
                     if self.phrase_table != "":
                         with open(self.phrase_table, "r") as f:
                             for line in f:

--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -48,7 +48,7 @@ class TranslationBuilder(object):
             for i in range(len(tokens)):
                 if tokens[i] == tgt_field.unk_token:
                     _, max_index = attn[i].max(0)
-                    tokens[i] = src_raw[max_index.item()]
+                    _, max_index = attn[i][:len(src_raw)].max(0)
                     if self.phrase_table != "":
                         with open(self.phrase_table, "r") as f:
                             for line in f:


### PR DESCRIPTION
When using `translate.py` with `replace_unk`,  the argmax of the attention can potentially be on the padding instead of a real source token.
The code currently uses: `_, max_index = attn[i].max(0)` and uses this value to retrieve the token from the source sequence: `src_raw[max_index.item()]`.

However, `max_index.item()` can potentially be greater than the length of `src_raw`, which results in: `IndexError: list index out of range`.

This fix takes the argmax of the attention only among the actual source tokens. 

(by the way, this never happened to me in the past, although I am using the exact same settings for a long time now)