### PR TITLE
Minor change in MultiHeadedAttention  documentation

### DIFF
--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -87,7 +87,7 @@ class MultiHeadedAttention(nn.Module):
            query (FloatTensor): set of `query_len`
                query vectors  ``(batch, query_len, dim)``
            mask: binary mask indicating which keys have
-               non-zero attention ``(batch, query_len, key_len)``
+               zero attention ``(batch, query_len, key_len)``
         Returns:
            (FloatTensor, FloatTensor):
 

--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -86,8 +86,8 @@ class MultiHeadedAttention(nn.Module):
                value vectors ``(batch, key_len, dim)``
            query (FloatTensor): set of `query_len`
                query vectors  ``(batch, query_len, dim)``
-           mask: binary mask indicating which keys have
-               zero attention ``(batch, query_len, key_len)``
+           mask: binary mask 1/0 indicating which keys have
+               zero / non-zero attention ``(batch, query_len, key_len)``
         Returns:
            (FloatTensor, FloatTensor):
 


### PR DESCRIPTION
`mask` refers to positions which need to have zero-attention. This is also suggested by line 200 in same file `scores.masked_fill(mask, -1e18)`