### PR TITLE
Allow implicit batch_size in translation_server

### DIFF
--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -394,7 +394,9 @@ class ServerModel(object):
             try:
                 scores, predictions = self.translator.translate(
                     texts_to_translate,
-                    batch_size=self.opt.batch_size)
+                    batch_size=len(texts_to_translate)
+                    if self.opt.batch_size == 0
+                    else self.opt.batch_size)
             except (RuntimeError, Exception) as e:
                 err = "Error: %s" % str(e)
                 self.logger.error(err)


### PR DESCRIPTION
Allow implicit `batch_size` in `translation_server` when setting "batch_size" option to 0 in config.
This allows to consider the size of the batch sent in the request as the batch_size for inference.