### PR TITLE
[fix] ensure building sequence mask on same device as lengths

### DIFF
--- a/onmt/utils/misc.py
+++ b/onmt/utils/misc.py
@@ -34,7 +34,7 @@ def sequence_mask(lengths, max_len=None):
     """
     batch_size = lengths.numel()
     max_len = max_len or lengths.max()
-    return (torch.arange(0, max_len)
+    return (torch.arange(0, max_len, device=lengths.device)
             .type_as(lengths)
             .repeat(batch_size, 1)
             .lt(lengths.unsqueeze(1)))


### PR DESCRIPTION
`sequence_mask` could be built on wrong device if `torch.cuda.current_device()` was different than `lengths.device` (which is the device where stuff should happen).