### PR TITLE
Use functions as preprocess / postprocess in REST server

### DIFF
--- a/onmt/translate/process_zh.py
+++ b/onmt/translate/process_zh.py
@@ -1,0 +1,40 @@
+from pyhanlp import HanLP
+from snownlp import SnowNLP
+import pkuseg
+
+
+# Chinese segmentation
+def ZH_segmentator(line):
+    segments = pkuseg.pkuseg().cut(line)
+    sequence = " ".join(segments)
+    return sequence
+
+
+# Chinese simplify -> Chinese traditional standard
+def ZH_traditional_standard(line):
+    line_traditional = HanLP.convertToTraditionalChinese(line)
+    return line_traditional
+
+
+# Chinese simplify -> Chinese traditional (HongKong)
+def ZH_traditional_HK(line):
+    line_traditional = HanLP.s2hk(line)
+    return line_traditional
+
+
+# Chinese simplify -> Chinese traditional (Taiwan)
+def ZH_traditional_TW(line):
+    line_traditional = HanLP.s2tw(line)
+    return line_traditional
+
+
+# Chinese traditional -> Chinese simplify (v1)
+def ZH_simplify(u_line):
+    simple_line = HanLP.convertToSimplifiedChinese(u_line)
+    return simple_line
+
+
+# Chinese traditional -> Chinese simplify (v2)
+def ZH_simplify_v2(u_line):
+    simple_line = SnowNLP(u_line).han
+    return simple_line

--- a/onmt/translate/process_zh.py
+++ b/onmt/translate/process_zh.py
@@ -5,36 +5,29 @@ import pkuseg
 
 # Chinese segmentation
 def ZH_segmentator(line):
-    segments = pkuseg.pkuseg().cut(line)
-    sequence = " ".join(segments)
-    return sequence
+    return " ".join(pkuseg.pkuseg().cut(line))
 
 
 # Chinese simplify -> Chinese traditional standard
 def ZH_traditional_standard(line):
-    line_traditional = HanLP.convertToTraditionalChinese(line)
-    return line_traditional
+    return HanLP.convertToTraditionalChinese(line)
 
 
 # Chinese simplify -> Chinese traditional (HongKong)
 def ZH_traditional_HK(line):
-    line_traditional = HanLP.s2hk(line)
-    return line_traditional
+    return HanLP.s2hk(line)
 
 
 # Chinese simplify -> Chinese traditional (Taiwan)
 def ZH_traditional_TW(line):
-    line_traditional = HanLP.s2tw(line)
-    return line_traditional
+    return HanLP.s2tw(line)
 
 
 # Chinese traditional -> Chinese simplify (v1)
-def ZH_simplify(u_line):
-    simple_line = HanLP.convertToSimplifiedChinese(u_line)
-    return simple_line
+def ZH_simplify(line):
+    return HanLP.convertToSimplifiedChinese(line)
 
 
 # Chinese traditional -> Chinese simplify (v2)
-def ZH_simplify_v2(u_line):
-    simple_line = SnowNLP(u_line).han
-    return simple_line
+def ZH_simplify_v2(line):
+    return SnowNLP(line).han

--- a/onmt/translate/process_zh.py
+++ b/onmt/translate/process_zh.py
@@ -14,12 +14,12 @@ def zh_traditional_standard(line):
 
 
 # Chinese simplify -> Chinese traditional (HongKong)
-def zh_traditional_HK(line):
+def zh_traditional_hk(line):
     return HanLP.s2hk(line)
 
 
 # Chinese simplify -> Chinese traditional (Taiwan)
-def zh_traditional_TW(line):
+def zh_traditional_tw(line):
     return HanLP.s2tw(line)
 
 

--- a/onmt/translate/process_zh.py
+++ b/onmt/translate/process_zh.py
@@ -4,30 +4,30 @@ import pkuseg
 
 
 # Chinese segmentation
-def ZH_segmentator(line):
+def zh_segmentator(line):
     return " ".join(pkuseg.pkuseg().cut(line))
 
 
 # Chinese simplify -> Chinese traditional standard
-def ZH_traditional_standard(line):
+def zh_traditional_standard(line):
     return HanLP.convertToTraditionalChinese(line)
 
 
 # Chinese simplify -> Chinese traditional (HongKong)
-def ZH_traditional_HK(line):
+def zh_traditional_HK(line):
     return HanLP.s2hk(line)
 
 
 # Chinese simplify -> Chinese traditional (Taiwan)
-def ZH_traditional_TW(line):
+def zh_traditional_TW(line):
     return HanLP.s2tw(line)
 
 
 # Chinese traditional -> Chinese simplify (v1)
-def ZH_simplify(line):
+def zh_simplify(line):
     return HanLP.convertToSimplifiedChinese(line)
 
 
 # Chinese traditional -> Chinese simplify (v2)
-def ZH_simplify_v2(line):
+def zh_simplify_v2(line):
     return SnowNLP(line).han

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -9,7 +9,7 @@ import json
 import threading
 import re
 import traceback
-
+import importlib
 import torch
 import onmt.opts
 
@@ -93,6 +93,7 @@ class TranslationServer(object):
                       'load': conf.get('load', None),
                       'preprocess_opt': conf.get('preprocess', None),
                       'tokenizer_opt': conf.get('tokenizer', None),
+                      'postprocess_opt': conf.get('postprocess', None),
                       'on_timeout': conf.get('on_timeout', None),
                       'model_root': conf.get('model_root', self.models_root)
                       }
@@ -185,9 +186,11 @@ class ServerModel(object):
     Args:
         opt (dict): Options for the Translator
         model_id (int): Model ID
-        preprocess_opt (dict): Options for preprocess processus or None
+        preprocess_opt (list): Options for preprocess processus or None
                                (extend for CJK)
         tokenizer_opt (dict): Options for the tokenizer or None
+        postprocess_opt (list): Options for postprocess processus or None
+                                (extend for CJK)
         load (bool): whether to load the model during :func:`__init__()`
         timeout (int): Seconds before running :func:`do_timeout()`
             Negative values means no timeout
@@ -198,7 +201,8 @@ class ServerModel(object):
     """
 
     def __init__(self, opt, model_id, preprocess_opt=None, tokenizer_opt=None,
-                 load=False, timeout=-1, on_timeout="to_cpu", model_root="./"):
+                 postprocess_opt=None, load=False, timeout=-1,
+                 on_timeout="to_cpu", model_root="./"):
         self.model_root = model_root
         self.opt = self.parse_opt(opt)
         if self.opt.n_best > 1:
@@ -207,6 +211,7 @@ class ServerModel(object):
         self.model_id = model_id
         self.preprocess_opt = preprocess_opt
         self.tokenizer_opt = tokenizer_opt
+        self.postprocess_opt = postprocess_opt
         self.timeout = timeout
         self.on_timeout = on_timeout
 
@@ -290,16 +295,13 @@ class ServerModel(object):
         timer.tick("model_loading")
         if self.preprocess_opt is not None:
             self.logger.info("Loading preprocessor")
-            self.preprocessor = {}
-            if self.preprocess_opt['ZH_simplify'] is True:
-                from snownlp import SnowNLP
-                self.preprocessor['ZH_simplify'] = SnowNLP
-            if self.preprocess_opt['ZH_segmentation'] is True:
-                import pkuseg
-                seg = pkuseg.pkuseg()
-                self.preprocessor['ZH_segmentation'] = seg
+            self.preprocessor = []
+            for function_path in self.preprocess_opt:
+                function = get_function_by_path(function_path)
+                self.preprocessor.append(function)
+
             if len(self.preprocessor) == 0:
-                raise ValueError("Invalid value for preprocess.")
+                print("No preprocess function loaded.")
 
         if self.tokenizer_opt is not None:
             self.logger.info("Loading tokenizer")
@@ -338,6 +340,16 @@ class ServerModel(object):
                 self.tokenizer = tokenizer
             else:
                 raise ValueError("Invalid value for tokenizer type")
+
+        if self.postprocess_opt is not None:
+            self.logger.info("Loading postprocessor")
+            self.postprocessor = []
+            for function_path in self.postprocess_opt:
+                function = get_function_by_path(function_path)
+                self.postprocessor.append(function)
+
+            if len(self.postprocessor) == 0:
+                print("No postprocess function loaded.")
 
         self.load_time = timer.tick()
         self.reset_unload_timer()
@@ -441,6 +453,8 @@ class ServerModel(object):
         results = [self.maybe_detokenize(item)
                    for item in results]
 
+        results = [self.maybe_postprocess(item)
+                   for item in results]
         # build back results with empty texts
         for i in empty_indices:
             results.insert(i, "")
@@ -532,13 +546,8 @@ class ServerModel(object):
         """
         if self.preprocessor is None:
             raise ValueError("No preprocessor loaded")
-        if 'ZH_simplify' in self.preprocessor:
-            call = self.preprocessor['ZH_simplify']  # SnowNLP
-            sequence = call(sequence).han
-        if 'ZH_segmentation' in self.preprocessor:
-            call = self.preprocessor['ZH_segmentation'].cut  # pkuseg.pkuseg()
-            segments = call(sequence)
-            sequence = " ".join(segments)
+        for function in self.preprocessor:
+            sequence = function(sequence)
         return sequence
 
     def maybe_tokenize(self, sequence):
@@ -597,3 +606,39 @@ class ServerModel(object):
             detok = self.tokenizer.detokenize(sequence.split())
 
         return detok
+
+    def maybe_postprocess(self, sequence):
+        """Postprocess the sequence (or not)
+
+        """
+
+        if self.postprocess_opt is not None:
+            return self.postprocess(sequence)
+        return sequence
+
+    def postprocess(self, sequence):
+        """Preprocess a single sequence.
+
+        Args:
+            sequence (str): The sequence to process.
+
+        Returns:
+            sequence (str): The postprocessed sequence.
+        """
+        if self.postprocessor is None:
+            raise ValueError("No postprocessor loaded")
+        for function in self.postprocessor:
+            sequence = function(sequence)
+        return sequence
+
+
+def get_function_by_path(path, args=[], kwargs={}):
+    module_name = ".".join(path.split(".")[:-1])
+    function_name = path.split(".")[-1]
+    try:
+        module = importlib.import_module(module_name)
+    except ValueError as e:
+        print("Cannot import module '%s'" % module_name)
+        raise e
+    function = getattr(module, function_name)
+    return function

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -91,6 +91,7 @@ class TranslationServer(object):
                                         parameter for model #%d""" % i)
             kwargs = {'timeout': conf.get('timeout', None),
                       'load': conf.get('load', None),
+                      'preprocess_opt': conf.get('preprocess', None),
                       'tokenizer_opt': conf.get('tokenizer', None),
                       'on_timeout': conf.get('on_timeout', None),
                       'model_root': conf.get('model_root', self.models_root)
@@ -184,6 +185,8 @@ class ServerModel(object):
     Args:
         opt (dict): Options for the Translator
         model_id (int): Model ID
+        preprocess_opt (dict): Options for preprocess processus or None
+                               (extend for CJK)
         tokenizer_opt (dict): Options for the tokenizer or None
         load (bool): whether to load the model during :func:`__init__()`
         timeout (int): Seconds before running :func:`do_timeout()`
@@ -194,14 +197,15 @@ class ServerModel(object):
             it must contain the model and tokenizer file
     """
 
-    def __init__(self, opt, model_id, tokenizer_opt=None, load=False,
-                 timeout=-1, on_timeout="to_cpu", model_root="./"):
+    def __init__(self, opt, model_id, preprocess_opt=None, tokenizer_opt=None,
+                 load=False, timeout=-1, on_timeout="to_cpu", model_root="./"):
         self.model_root = model_root
         self.opt = self.parse_opt(opt)
         if self.opt.n_best > 1:
             raise ValueError("Values of n_best > 1 are not supported")
 
         self.model_id = model_id
+        self.preprocess_opt = preprocess_opt
         self.tokenizer_opt = tokenizer_opt
         self.timeout = timeout
         self.on_timeout = on_timeout
@@ -284,6 +288,19 @@ class ServerModel(object):
             raise ServerModelError("Runtime Error: %s" % str(e))
 
         timer.tick("model_loading")
+        if self.preprocess_opt is not None:
+            self.logger.info("Loading preprocessor")
+            self.preprocessor = {}
+            if self.preprocess_opt['ZH_simplify'] is True:
+                from snownlp import SnowNLP
+                self.preprocessor['ZH_simplify'] = SnowNLP
+            if self.preprocess_opt['ZH_segmentation'] is True:
+                import pkuseg
+                seg = pkuseg.pkuseg()
+                self.preprocessor['ZH_segmentation'] = seg
+            if len(self.preprocessor) == 0:
+                raise ValueError("Invalid value for preprocess.")
+
         if self.tokenizer_opt is not None:
             self.logger.info("Loading tokenizer")
 
@@ -380,7 +397,8 @@ class ServerModel(object):
                 if match_after is not None:
                     whitespaces_after = match_after.group(0)
                 head_spaces.append(whitespaces_before)
-                tok = self.maybe_tokenize(src.strip())
+                preprocessed_src = self.maybe_preprocess(src.strip())
+                tok = self.maybe_tokenize(preprocessed_src)
                 texts.append(tok)
                 sslength.append(len(tok.split()))
                 tail_spaces.append(whitespaces_after)
@@ -493,6 +511,35 @@ class ServerModel(object):
         """Move the model to GPU."""
         torch.cuda.set_device(self.opt.gpu)
         self.translator.model.cuda()
+
+    def maybe_preprocess(self, sequence):
+        """Preprocess the sequence (or not)
+
+        """
+
+        if self.preprocess_opt is not None:
+            return self.preprocess(sequence)
+        return sequence
+
+    def preprocess(self, sequence):
+        """Preprocess a single sequence.
+
+        Args:
+            sequence (str): The sequence to preprocess.
+
+        Returns:
+            sequence (str): The preprocessed sequence.
+        """
+        if self.preprocessor is None:
+            raise ValueError("No preprocessor loaded")
+        if 'ZH_simplify' in self.preprocessor:
+            call = self.preprocessor['ZH_simplify']  # SnowNLP
+            sequence = call(sequence).han
+        if 'ZH_segmentation' in self.preprocessor:
+            call = self.preprocessor['ZH_segmentation'].cut  # pkuseg.pkuseg()
+            segments = call(sequence)
+            sequence = " ".join(segments)
+        return sequence
 
     def maybe_tokenize(self, sequence):
         """Tokenize the sequence (or not).

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -187,7 +187,6 @@ class ServerModel(object):
         opt (dict): Options for the Translator
         model_id (int): Model ID
         preprocess_opt (list): Options for preprocess processus or None
-
                                (extend for CJK)
         tokenizer_opt (dict): Options for the tokenizer or None
         postprocess_opt (list): Options for postprocess processus or None
@@ -297,12 +296,10 @@ class ServerModel(object):
         if self.preprocess_opt is not None:
             self.logger.info("Loading preprocessor")
             self.preprocessor = []
+
             for function_path in self.preprocess_opt:
                 function = get_function_by_path(function_path)
                 self.preprocessor.append(function)
-
-            if len(self.preprocessor) == 0:
-                print("No preprocess function loaded.")
 
         if self.tokenizer_opt is not None:
             self.logger.info("Loading tokenizer")
@@ -345,12 +342,10 @@ class ServerModel(object):
         if self.postprocess_opt is not None:
             self.logger.info("Loading postprocessor")
             self.postprocessor = []
+
             for function_path in self.postprocess_opt:
                 function = get_function_by_path(function_path)
                 self.postprocessor.append(function)
-
-            if len(self.postprocessor) == 0:
-                print("No postprocess function loaded.")
 
         self.load_time = timer.tick()
         self.reset_unload_timer()


### PR DESCRIPTION
Add preprocess and postprocess option in REST server. As its usually needed in some cases, like normalize punctuation. Particularly useful for Chinese language, as there are different standard for Chinese. To use these two option, you need to pass a list of python function in a json configure file as the process pipeline. The function receive the sentence as argument and return processed sentence.
Ex:
"preprocess":[
                "onmt.translate.process_zh.zh_simplify",
                "onmt.translate.process_zh.zh_segmentator"
            ],
"postprocess":[
                "onmt.translate.process_zh.punctuation_en2zh",
                "onmt.translate.process_zh.zh_traditional_standard"
            ]