### PR TITLE
[fix] remove implicit check in preprocess

### DIFF
--- a/preprocess.py
+++ b/preprocess.py
@@ -108,7 +108,7 @@ def build_save_dataset(corpus_type, fields, src_reader, tgt_reader, opt):
                             has_vocab = (sub_n == 'src' and
                                          src_vocab is not None) or \
                                         (sub_n == 'tgt' and
-                                         tgt_vocabis not None)
+                                         tgt_vocab is not None)
                             if (hasattr(sub_f, 'sequential')
                                     and sub_f.sequential and not has_vocab):
                                 val = fd

--- a/preprocess.py
+++ b/preprocess.py
@@ -105,8 +105,10 @@ def build_save_dataset(corpus_type, fields, src_reader, tgt_reader, opt):
                             all_data = getattr(ex, name)
                         for (sub_n, sub_f), fd in zip(
                                 f_iter, all_data):
-                            has_vocab = (sub_n == 'src' and src_vocab) or \
-                                        (sub_n == 'tgt' and tgt_vocab)
+                            has_vocab = (sub_n == 'src' and
+                                         src_vocab is not None) or \
+                                        (sub_n == 'tgt' and
+                                         tgt_vocabis not None)
                             if (hasattr(sub_f, 'sequential')
                                     and sub_f.sequential and not has_vocab):
                                 val = fd


### PR DESCRIPTION
There were some implicit checks on `src_vocab` and `tgt_vocab` in preprocessing.
This was creating some unwanted behavior when loading an existing vocab as a text file.