### PR TITLE
Pytorch 1.2 compatibility for mask manipulation

### DIFF
--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -67,6 +67,11 @@ class TransformerDecoderLayer(nn.Module):
                 device=tgt_pad_mask.device,
                 dtype=torch.uint8)
             future_mask = future_mask.triu_(1).view(1, tgt_len, tgt_len)
+            # BoolTensor was introduced in pytorch 1.2
+            try:
+                future_mask = future_mask.bool()
+            except AttributeError:
+                pass
             dec_mask = torch.gt(tgt_pad_mask + future_mask, 0)
 
         input_norm = self.layer_norm_1(inputs)

--- a/onmt/modules/global_attention.py
+++ b/onmt/modules/global_attention.py
@@ -180,7 +180,7 @@ class GlobalAttention(nn.Module):
         if memory_lengths is not None:
             mask = sequence_mask(memory_lengths, max_len=align.size(-1))
             mask = mask.unsqueeze(1)  # Make it broadcastable.
-            align.masked_fill_(1 - mask, -float('inf'))
+            align.masked_fill_(~mask, -float('inf'))
 
         # Softmax or sparsemax to normalize attention weights
         if self.attn_func == "softmax":

--- a/onmt/translate/beam_search.py
+++ b/onmt/translate/beam_search.py
@@ -73,6 +73,11 @@ class BeamSearch(DecodeStrategy):
 
         # beam state
         self.top_beam_finished = torch.zeros([batch_size], dtype=torch.uint8)
+        # BoolTensor was introduced in pytorch 1.2
+        try:
+            self.top_beam_finished = self.top_beam_finished.bool()
+        except AttributeError:
+            pass
         self.best_scores = torch.full([batch_size], -1e10, dtype=torch.float,
                                       device=mb_device)
 


### PR DESCRIPTION
This PR tracks the changes needed to make the codebase compatible with the recent [pytorch 1.2 release](https://github.com/pytorch/pytorch/releases/tag/v1.2.0).

The only issues encountered for now are consequences of the introduction of `torch.BoolTensor`. Some others may appear down the line.

Should fix #1524 #1525.