### PR TITLE
add simple -side argument check and help messages for -file_type 'field'

### DIFF
--- a/tools/create_vocabulary.py
+++ b/tools/create_vocabulary.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import argparse
+import os
 import sys
 
+# run create_vocabulary.py without install opennmt-py
+try:
+    import onmt
+except ImportError as error:
+    sys.path.insert(1, os.path.join(sys.path[0], '..'))
 
 def read_files_batch(file_list):
     """Reads the provided files in batches"""
@@ -51,7 +57,8 @@ def main():
                                corresponding to the argument 'side'.""")
     parser.add_argument("-file", type=str, nargs="+", required=True)
     parser.add_argument("-out_file", type=str, required=True)
-    parser.add_argument("-side", type=str)
+    parser.add_argument("-side", choices=['src', 'tgt'],
+                        help="Specifies 'src' or 'tgt' side for 'field' file_type.")
 
     opt = parser.parse_args()
 
@@ -72,6 +79,9 @@ def main():
                                    reverse=True):
                 f.write("{0}\n".format(w))
     else:
+        if opt.side not in ['src', 'tgt']:
+            raise ValueError("If using -file_type='field', specifies "
+                             "'src' or 'tgt' argument for -side.")
         import torch
         from onmt.inputters.inputter import _old_style_vocab
         print("Reading input file...")

--- a/tools/create_vocabulary.py
+++ b/tools/create_vocabulary.py
@@ -1,14 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import argparse
-import os
 import sys
+import os
 
-# run create_vocabulary.py without install opennmt-py
-try:
-    import onmt
-except ImportError as error:
-    sys.path.insert(1, os.path.join(sys.path[0], '..'))
 
 def read_files_batch(file_list):
     """Reads the provided files in batches"""
@@ -16,7 +11,6 @@ def read_files_batch(file_list):
     fd_list = []  # File descriptor list
 
     exit = False  # Flag used for quitting the program in case of error
-
     try:
         for filename in file_list:
             fd_list.append(open(filename))
@@ -57,8 +51,8 @@ def main():
                                corresponding to the argument 'side'.""")
     parser.add_argument("-file", type=str, nargs="+", required=True)
     parser.add_argument("-out_file", type=str, required=True)
-    parser.add_argument("-side", choices=['src', 'tgt'],
-                        help="Specifies 'src' or 'tgt' side for 'field' file_type.")
+    parser.add_argument("-side", choices=['src', 'tgt'], help="""Specifies
+                               'src' or 'tgt' side for 'field' file_type.""")
 
     opt = parser.parse_args()
 
@@ -83,7 +77,12 @@ def main():
             raise ValueError("If using -file_type='field', specifies "
                              "'src' or 'tgt' argument for -side.")
         import torch
-        from onmt.inputters.inputter import _old_style_vocab
+        try:
+            from onmt.inputters.inputter import _old_style_vocab
+        except ImportError as error:
+            sys.path.insert(1, os.path.join(sys.path[0], '..'))
+            from onmt.inputters.inputter import _old_style_vocab
+
         print("Reading input file...")
         if not len(opt.file) == 1:
             raise ValueError("If using -file_type='field', only pass one "

--- a/tools/create_vocabulary.py
+++ b/tools/create_vocabulary.py
@@ -79,7 +79,7 @@ def main():
         import torch
         try:
             from onmt.inputters.inputter import _old_style_vocab
-        except ImportError as error:
+        except ImportError:
             sys.path.insert(1, os.path.join(sys.path[0], '..'))
             from onmt.inputters.inputter import _old_style_vocab
 


### PR DESCRIPTION
This PR modifies tools/create_vocabulary.py, to help beginners to assign -side arguments properly when using -file_type 'field'. and additionaly, able to run without install OpenNMT-py.