### PR TITLE
Switch tensorboardX to official TensorBoard

### DIFF
--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -536,10 +536,10 @@ def train_opts(parser):
               help="Send logs to this crayon server.")
     group.add('--exp', '-exp', type=str, default="",
               help="Name of the experiment for logging.")
-    # Use TensorboardX for visualization during training
+    # Use Tensorboard for visualization during training
     group.add('--tensorboard', '-tensorboard', action="store_true",
-              help="Use tensorboardX for visualization during training. "
-                   "Must have the library tensorboardX.")
+              help="Use tensorboard for visualization during training. "
+                   "Must have the library tensorboard >= 1.14.")
     group.add("--tensorboard_log_dir", "-tensorboard_log_dir",
               type=str, default="runs/onmt",
               help="Log directory for Tensorboard. "

--- a/onmt/utils/report_manager.py
+++ b/onmt/utils/report_manager.py
@@ -10,7 +10,7 @@ from onmt.utils.logging import logger
 
 def build_report_manager(opt):
     if opt.tensorboard:
-        from tensorboardX import SummaryWriter
+        from torch.utils.tensorboard import SummaryWriter
         tensorboard_log_dir = opt.tensorboard_log_dir
 
         if not opt.train_from:

--- a/requirements.opt.txt
+++ b/requirements.opt.txt
@@ -9,3 +9,4 @@ pyonmttok
 opencv-python
 git+https://github.com/NVIDIA/apex
 flask
+tensorboard>=1.14


### PR DESCRIPTION
Switch to official TensorBoard support by Pytorch since v1.1.0.
No need to install tensorboardX anymore, use torch.utils.tensorboard instead.
To visualize the training with TensorBoard GUI, we need the package TensorBoard >= 1.14.
 