### PR TITLE
Remove Python2 Travis / switch to pytorch 1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: xenial
 language: python
 python:
-  - "2.7"
   - "3.5"
 git:
   depth: false
@@ -14,8 +13,7 @@ addons:
       - sox
 before_install:
   # Install CPU version of PyTorch.
-  - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then pip install https://download.pytorch.org/whl/cpu/torch-1.1.0-cp27-cp27mu-linux_x86_64.whl; fi
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pip install https://download.pytorch.org/whl/cpu/torch-1.1.0-cp35-cp35m-linux_x86_64.whl; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pip install https://download.pytorch.org/whl/cpu/torch-1.2.0-cp35-cp35m-linux_x86_64.whl; fi
   - pip install -r requirements.txt
   - pip install -r requirements.opt.txt
 install:
@@ -66,7 +64,7 @@ env:
 matrix:
   include:
     - env: LINT_CHECK
-      python: "2.7"
+      python: "3.5"
       install: pip install flake8 pep8-naming==0.7.0
       script: flake8
     - python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
       - sox
 before_install:
   # Install CPU version of PyTorch.
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pip install https://download.pytorch.org/whl/cpu/torch-1.2.0-cp35-cp35m-linux_x86_64.whl; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.5 ]]; then pip install torch==1.2.0+cpu -f https://download.pytorch.org/whl/torch_stable.html; fi
   - pip install -r requirements.txt
   - pip install -r requirements.opt.txt
 install:

--- a/README.md
+++ b/README.md
@@ -34,14 +34,15 @@ All dependencies can be installed via:
 pip install -r requirements.txt
 ```
 
-NOTE: If you have MemoryError in the install try to use: 
+Note: If you have MemoryError in the install try to use: 
 
 ```bash
 pip install -r requirements.txt --no-cache-dir
 ```
-Note
-some features require Python 3.5 and after (eg: Distributed multigpu, entmax)
-we currently only support PyTorch 1.2 (should work with 1.0/1.1)
+Note:
+
+- some features require Python 3.5 and after (eg: Distributed multigpu, entmax)
+- we currently only support PyTorch 1.2 (should work with 1.1)
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ NOTE: If you have MemoryError in the install try to use:
 ```bash
 pip install -r requirements.txt --no-cache-dir
 ```
-Note that we currently only support PyTorch 1.1 (should work with 1.0)
+Note
+some features require Python 3.5 and after (eg: Distributed multigpu, entmax)
+we currently only support PyTorch 1.2 (should work with 1.0/1.1)
 
 ## Features
 


### PR DESCRIPTION
Python2 will go out of support by year end, we remove it from Travis tests.

NB: Distributed (multigpu requires Python 3 anyway)

Some new PR may not support Python2.

Switch to Pytorch 1.2