### PR TITLE
fix multiply SummaryWriter in multi-gpu case

### DIFF
--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -142,5 +142,5 @@ def main(opt, device_id, batch_queue=None, semaphore=None):
         valid_iter=valid_iter,
         valid_steps=opt.valid_steps)
 
-    if opt.tensorboard:
+    if trainer.report_manager.tensorboard_writer is not None:
         trainer.report_manager.tensorboard_writer.close()

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -58,7 +58,7 @@ def build_trainer(opt, device_id, model, fields, optim, model_saver=None):
         opt.early_stopping, scorers=onmt.utils.scorers_from_opts(opt)) \
         if opt.early_stopping > 0 else None
 
-    report_manager = onmt.utils.build_report_manager(opt)
+    report_manager = onmt.utils.build_report_manager(opt, gpu_rank)
     trainer = onmt.Trainer(model, train_loss, valid_loss, optim, trunc_size,
                            shard_size, norm_method,
                            accum_count, accum_steps,

--- a/onmt/utils/report_manager.py
+++ b/onmt/utils/report_manager.py
@@ -8,16 +8,15 @@ import onmt
 from onmt.utils.logging import logger
 
 
-def build_report_manager(opt):
-    if opt.tensorboard:
+def build_report_manager(opt, gpu_rank):
+    if opt.tensorboard and gpu_rank == 0:
         from torch.utils.tensorboard import SummaryWriter
         tensorboard_log_dir = opt.tensorboard_log_dir
 
         if not opt.train_from:
             tensorboard_log_dir += datetime.now().strftime("/%b-%d_%H-%M-%S")
 
-        writer = SummaryWriter(tensorboard_log_dir,
-                               comment="Unmt")
+        writer = SummaryWriter(tensorboard_log_dir, comment="Unmt")
     else:
         writer = None
 


### PR DESCRIPTION
In multiprocess mode, we create one Summary writer for each process which will result in multiple tensorboard log files with torch.utils.tensorboard.
Fix this issue by making only the first GPU to handle the tensorboard logging.