### PR TITLE
FP16 training fix

### DIFF
--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -230,7 +230,8 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None, gpu_id=None):
 
     model.generator = generator
     model.to(device)
-
+    if model_opt.model_dtype == 'fp16' and model_opt.optim == 'fusedadam':
+        model.half()
     return model
 
 

--- a/onmt/models/model_saver.py
+++ b/onmt/models/model_saver.py
@@ -1,6 +1,5 @@
 import os
 import torch
-import torch.nn as nn
 
 from collections import deque
 from onmt.utils.logging import logger
@@ -97,17 +96,10 @@ class ModelSaver(ModelSaverBase):
     """Simple model saver to filesystem"""
 
     def _save(self, step, model):
-        real_model = (model.module
-                      if isinstance(model, nn.DataParallel)
-                      else model)
-        real_generator = (real_model.generator.module
-                          if isinstance(real_model.generator, nn.DataParallel)
-                          else real_model.generator)
-
-        model_state_dict = real_model.state_dict()
+        model_state_dict = model.state_dict()
         model_state_dict = {k: v for k, v in model_state_dict.items()
                             if 'generator' not in k}
-        generator_state_dict = real_generator.state_dict()
+        generator_state_dict = model.generator.state_dict()
 
         # NOTE: We need to trim the vocab to remove any unk tokens that
         # were not originally here.

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -181,7 +181,7 @@ def model_opts(parser):
     group.add('--loss_scale', '-loss_scale', type=float, default=0,
               help="For FP16 training, the static loss scale to use. If not "
                    "set, the loss scale is dynamically computed.")
-    group.add('--apex_opt_level', '-apex_opt_level', type=str, default="O2",
+    group.add('--apex_opt_level', '-apex_opt_level', type=str, default="O1",
               choices=["O0", "O1", "O2", "O3"],
               help="For FP16 training, the opt_level to use."
                    "See https://nvidia.github.io/apex/amp.html#opt-levels.")

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -294,7 +294,8 @@ class Trainer(object):
             valid_model = deepcopy(self.model)
             for avg, param in zip(self.moving_average,
                                   valid_model.parameters()):
-                param.data = avg.data
+                param.data = avg.data.half() if self.optim._fp16 == "legacy" \
+                    else avg.data
         else:
             valid_model = self.model
 

--- a/onmt/utils/optimizers.py
+++ b/onmt/utils/optimizers.py
@@ -352,12 +352,7 @@ class Optimizer(object):
             if hasattr(self._optimizer, "clip_master_grads") and \
                self._max_grad_norm > 0:
                 self._optimizer.clip_master_grads(self._max_grad_norm)
-        elif self._fp16 == "amp":
-            if self._max_grad_norm > 0:
-                import apex
-                torch.nn.utils.clip_grad_norm_(
-                    apex.amp.master_params(self._optimizer),
-                    self._max_grad_norm)
+        
         for group in self._optimizer.param_groups:
             group['lr'] = learning_rate
             if self._fp16 is None and self._max_grad_norm > 0:

--- a/onmt/utils/optimizers.py
+++ b/onmt/utils/optimizers.py
@@ -352,7 +352,7 @@ class Optimizer(object):
             if hasattr(self._optimizer, "clip_master_grads") and \
                self._max_grad_norm > 0:
                 self._optimizer.clip_master_grads(self._max_grad_norm)
-        
+
         for group in self._optimizer.param_groups:
             group['lr'] = learning_rate
             if self._fp16 is None and self._max_grad_norm > 0:

--- a/onmt/utils/optimizers.py
+++ b/onmt/utils/optimizers.py
@@ -563,7 +563,7 @@ class FusedAdam(torch.optim.Optimizer):
             adds eps to the bias-corrected second moment estimate before
             evaluating square root instead of adding it to the square root of
             second moment estimate as in the original paper. (default: False)
-    .. _Adam\: A Method for Stochastic Optimization:
+    .. _Adam: A Method for Stochastic Optimization:
         https://arxiv.org/abs/1412.6980
     .. _On the Convergence of Adam and Beyond:
         https://openreview.net/forum?id=ryQu7f-RZ

--- a/onmt/utils/optimizers.py
+++ b/onmt/utils/optimizers.py
@@ -6,6 +6,9 @@ import operator
 import functools
 from copy import copy
 from math import sqrt
+import types
+import importlib
+from onmt.utils.misc import fn_args
 
 
 def build_torch_optimizer(model, opt):
@@ -76,7 +79,8 @@ def build_torch_optimizer(model, opt):
                  eps=1e-8)])
     elif opt.optim == 'fusedadam':
         import apex
-        optimizer = apex.optimizers.FusedAdam(
+        # we copied an old version of FusedAdam since the new one is not working
+        optimizer = FusedAdam(
             params,
             lr=opt.learning_rate,
             betas=betas)
@@ -85,14 +89,18 @@ def build_torch_optimizer(model, opt):
 
     if opt.model_dtype == 'fp16':
         import apex
-        loss_scale = "dynamic" if opt.loss_scale == 0 else opt.loss_scale
-        model, optimizer = apex.amp.initialize(
-            [model, model.generator],
+        static_loss_scale = opt.loss_scale
+        dynamic_loss_scale = opt.loss_scale == 0
+        # TODO: clean this up when APEX unify its optimizer API.
+        if opt.optim.startswith('fused'):
+            namespace = apex.optimizers  # Faster wrapper.
+        else:
+            #namespace = apex.fp16_utils
+            namespace = apex.optimizers
+        optimizer = namespace.FP16_Optimizer(
             optimizer,
-            opt_level=opt.apex_opt_level,
-            loss_scale=loss_scale,
-            keep_batchnorm_fp32=False if opt.optim == "fusedadam" else None)
-
+            static_loss_scale=static_loss_scale,
+            dynamic_loss_scale=dynamic_loss_scale)
     return optimizer
 
 
@@ -272,6 +280,7 @@ class Optimizer(object):
             optim_opt.learning_rate,
             learning_rate_decay_fn=make_learning_rate_decay_fn(optim_opt),
             max_grad_norm=optim_opt.max_grad_norm)
+        
         optimizer._fp16 = (opt.model_dtype == "fp16")
         if optim_state_dict:
             optimizer.load_state_dict(optim_state_dict)
@@ -312,9 +321,10 @@ class Optimizer(object):
         """Wrapper for backward pass. Some optimizer requires ownership of the
         backward pass."""
         if self._fp16:
-            import apex
-            with apex.amp.scale_loss(loss, self._optimizer) as scaled_loss:
-                scaled_loss.backward()
+            kwargs = {}
+            if "update_master_grads" in fn_args(self._optimizer.backward):
+                kwargs["update_master_grads"] = True
+            self._optimizer.backward(loss, **kwargs)
         else:
             loss.backward()
 
@@ -330,9 +340,7 @@ class Optimizer(object):
                 self._optimizer.update_master_grads()
             if hasattr(self._optimizer, "clip_master_grads") and \
                self._max_grad_norm > 0:
-                import apex
-                torch.nn.utils.clip_grad_norm_(
-                    apex.amp.master_params(self), self._max_grad_norm)
+                self._optimizer.clip_master_grads(self._max_grad_norm)
         for group in self._optimizer.param_groups:
             group['lr'] = learning_rate
             if not self._fp16 and self._max_grad_norm > 0:
@@ -513,3 +521,147 @@ class AdaFactor(torch.optim.Optimizer):
                     p.data.add_(-group['weight_decay'] * lr_t, p.data)
 
         return loss
+
+
+class FusedAdam(torch.optim.Optimizer):
+
+    """Implements Adam algorithm. Currently GPU-only.  Requires Apex to be installed via
+    ``python setup.py install --cuda_ext --cpp_ext``.
+    It has been proposed in `Adam: A Method for Stochastic Optimization`_.
+    Arguments:
+        params (iterable): iterable of parameters to optimize or dicts defining
+            parameter groups.
+        lr (float, optional): learning rate. (default: 1e-3)
+        betas (Tuple[float, float], optional): coefficients used for computing
+            running averages of gradient and its square. (default: (0.9, 0.999))
+        eps (float, optional): term added to the denominator to improve
+            numerical stability. (default: 1e-8)
+        weight_decay (float, optional): weight decay (L2 penalty) (default: 0)
+        amsgrad (boolean, optional): whether to use the AMSGrad variant of this
+            algorithm from the paper `On the Convergence of Adam and Beyond`_
+            (default: False) NOT SUPPORTED in FusedAdam!
+        eps_inside_sqrt (boolean, optional): in the 'update parameters' step,
+            adds eps to the bias-corrected second moment estimate before
+            evaluating square root instead of adding it to the square root of
+            second moment estimate as in the original paper. (default: False)
+    .. _Adam\: A Method for Stochastic Optimization:
+        https://arxiv.org/abs/1412.6980
+    .. _On the Convergence of Adam and Beyond:
+        https://openreview.net/forum?id=ryQu7f-RZ
+    """
+
+    def __init__(self, params,
+                 lr=1e-3, bias_correction = True,
+                 betas=(0.9, 0.999), eps=1e-8, eps_inside_sqrt = False,
+                 weight_decay=0., max_grad_norm=0., amsgrad=False):
+        global fused_adam_cuda
+        fused_adam_cuda = importlib.import_module("fused_adam_cuda")
+
+        if amsgrad:
+            raise RuntimeError('FusedAdam does not support the AMSGrad variant.')
+        defaults = dict(lr=lr, bias_correction=bias_correction,
+                        betas=betas, eps=eps, weight_decay=weight_decay,
+                        max_grad_norm=max_grad_norm)
+        super(FusedAdam, self).__init__(params, defaults)
+        self.eps_mode = 0 if  eps_inside_sqrt else 1
+
+    def step(self, closure=None, grads=None, output_params=None, scale=1., grad_norms=None):
+        """Performs a single optimization step.
+        Arguments:
+            closure (callable, optional): A closure that reevaluates the model
+                and returns the loss.
+            grads (list of tensors, optional): weight gradient to use for the
+                optimizer update. If gradients have type torch.half, parameters
+                are expected to be in type torch.float. (default: None)
+            output params (list of tensors, optional): A reduced precision copy
+                of the updated weights written out in addition to the regular
+                updated weights. Have to be of same type as gradients. (default: None)
+            scale (float, optional): factor to divide gradient tensor values
+                by before applying to weights. (default: 1)
+        """
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        if grads is None:
+            grads_group = [None]*len(self.param_groups)
+        # backward compatibility
+        # assuming a list/generator of parameter means single group
+        elif isinstance(grads, types.GeneratorType):
+            grads_group = [grads]
+        elif type(grads[0])!=list:
+            grads_group = [grads]
+        else:
+            grads_group = grads
+
+        if output_params is None:
+            output_params_group = [None]*len(self.param_groups)
+        elif isinstance(output_params, types.GeneratorType):
+            output_params_group = [output_params]
+        elif type(output_params[0])!=list:
+            output_params_group = [output_params]
+        else:
+            output_params_group = output_params
+
+        if grad_norms is None:
+            grad_norms = [None]*len(self.param_groups)
+
+        for group, grads_this_group, output_params_this_group, grad_norm in zip(self.param_groups, grads_group, output_params_group, grad_norms):
+            if grads_this_group is None:
+               grads_this_group = [None]*len(group['params'])
+            if output_params_this_group is None:
+               output_params_this_group = [None]*len(group['params'])
+
+            # compute combined scale factor for this group
+            combined_scale = scale
+            if group['max_grad_norm'] > 0:
+                # norm is in fact norm*scale
+                clip = ((grad_norm / scale) + 1e-6) / group['max_grad_norm']
+                if clip > 1:
+                    combined_scale = clip * scale
+
+            bias_correction = 1 if group['bias_correction'] else 0
+
+            for p, grad, output_param in zip(group['params'], grads_this_group, output_params_this_group):
+                #note: p.grad should not ever be set for correct operation of mixed precision optimizer that sometimes sends None gradients
+                if p.grad is None and grad is None:
+                    continue
+                if grad is None:
+                    grad = p.grad.data
+                if grad.is_sparse:
+                    raise RuntimeError('FusedAdam does not support sparse gradients, please consider SparseAdam instead')
+
+                state = self.state[p]
+
+                # State initialization
+                if len(state) == 0:
+                    state['step'] = 0
+                    # Exponential moving average of gradient values
+                    state['exp_avg'] = torch.zeros_like(p.data)
+                    # Exponential moving average of squared gradient values
+                    state['exp_avg_sq'] = torch.zeros_like(p.data)
+
+                exp_avg, exp_avg_sq = state['exp_avg'], state['exp_avg_sq']
+                beta1, beta2 = group['betas']
+
+                state['step'] += 1
+
+                out_p = torch.tensor([], dtype = torch.float) if output_param is None else output_param
+                fused_adam_cuda.adam(p.data,
+                                     out_p,
+                                     exp_avg,
+                                     exp_avg_sq,
+                                     grad,
+                                     group['lr'],
+                                     beta1,
+                                     beta2,
+                                     group['eps'],
+                                     combined_scale,
+                                     state['step'],
+                                     self.eps_mode,
+                                     bias_correction,
+                                     group['weight_decay'])
+        return loss
+
+
+


### PR DESCRIPTION
Here is the issue:

For FP16 training, we use Nvidia/apex.
They changed the API to something called AMP and we adapted to this new API on June 13.

However, a few things are broken in this new API when it comes to handle FusedAdam.

On Aug 8 they included FusedAdam in the AMP new API but I realized that:

O2 level does not work at all for both Adam and FuseAdam (O2 was our Default level).
see https://github.com/NVIDIA/apex/issues/475
O1 level works fine for Adam but does work (unstable) with FusedAdam.

This PR will:
1) Default to O1 with Adam/AMP (FP16 training only)
2) Use the Legacy FusedAdam code that we have included in optimizer.py

This solution should be temporary since Nvidia works on including AMP directly in Pytorch.

As of this PR, Accuracy/PPL are ok for Adam FP32, Adam FP16, FusedAdam FP16








