### PR TITLE
[WIP] Source Word Features in Translation

### DIFF
--- a/onmt/modules/embeddings.py
+++ b/onmt/modules/embeddings.py
@@ -156,8 +156,11 @@ class Embeddings(nn.Module):
         # (these have no effect if feat_vocab_sizes is empty)
         if feat_merge == 'sum':
             feat_dims = [word_vec_size] * len(feat_vocab_sizes)
-        elif feat_vec_size > 0:
-            feat_dims = [feat_vec_size] * len(feat_vocab_sizes)
+        elif len(feat_vec_size) != 0:
+	    if len(feat_vocab_sizes)==0:
+	        feat_dims=[]
+            else:
+	        feat_dims=feat_vec_size
         else:
             feat_dims = [int(vocab ** feat_vec_exponent)
                          for vocab in feat_vocab_sizes]
@@ -209,10 +212,10 @@ class Embeddings(nn.Module):
             if feat_vec_exponent != 0.7:
                 warnings.warn("Merging with sum, but got non-default "
                               "feat_vec_exponent. It will be unused.")
-            if feat_vec_size != -1:
+            if len(feat_vec_size) != 0:
                 warnings.warn("Merging with sum, but got non-default "
                               "feat_vec_size. It will be unused.")
-        elif feat_vec_size > 0:
+        elif len(feat_vec_size) != 0:
             # features will use feat_vec_size
             if feat_vec_exponent != -1:
                 warnings.warn("Not merging with sum and positive "

--- a/onmt/modules/embeddings.py
+++ b/onmt/modules/embeddings.py
@@ -157,10 +157,10 @@ class Embeddings(nn.Module):
         if feat_merge == 'sum':
             feat_dims = [word_vec_size] * len(feat_vocab_sizes)
         elif len(feat_vec_size) != 0:
-	    if len(feat_vocab_sizes)==0:
-	        feat_dims=[]
+            if len(feat_vocab_sizes) == 0:
+	        feat_dims = []
             else:
-	        feat_dims=feat_vec_size
+	        feat_dims = feat_vec_size
         else:
             feat_dims = [int(vocab ** feat_vec_exponent)
                          for vocab in feat_vocab_sizes]

--- a/onmt/modules/embeddings.py
+++ b/onmt/modules/embeddings.py
@@ -158,9 +158,9 @@ class Embeddings(nn.Module):
             feat_dims = [word_vec_size] * len(feat_vocab_sizes)
         elif len(feat_vec_size) != 0:
             if len(feat_vocab_sizes) == 0:
-	        feat_dims = []
+                feat_dims = []
             else:
-	        feat_dims = feat_vec_size
+                feat_dims = feat_vec_size
         else:
             feat_dims = [int(vocab ** feat_vec_exponent)
                          for vocab in feat_vocab_sizes]

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -47,7 +47,7 @@ def model_opts(parser):
               choices=['concat', 'sum', 'mlp'],
               help="Merge action for incorporating features embeddings. "
                    "Options [concat|sum|mlp].")
-    group.add('--feat_vec_size', '-feat_vec_size', type=int, default=-1,
+    group.add('--feat_vec_size', '-feat_vec_size', type=int, default=[], nargs='*',
               help="If specified, feature embedding sizes "
                    "will be set to this. Otherwise, feat_vec_exponent "
                    "will be used.")

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -47,7 +47,8 @@ def model_opts(parser):
               choices=['concat', 'sum', 'mlp'],
               help="Merge action for incorporating features embeddings. "
                    "Options [concat|sum|mlp].")
-    group.add('--feat_vec_size', '-feat_vec_size', type=int, default=[], nargs='*',
+    group.add('--feat_vec_size', '-feat_vec_size', type=int,
+              default=[], nargs='*',
               help="If specified, feature embedding sizes "
                    "will be set to this. Otherwise, feat_vec_exponent "
                    "will be used.")


### PR DESCRIPTION
This PR addresses the issue of different feature vector sizes for different word level features (#1534 ).
Now the user can pass a list of "feat_vec_size"  so as to use these feature dimensions for word level features. This feature is missing in OpenNMT-py.
