### PR TITLE
Use multiprocessing to speed up preprocessing

### DIFF
--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -224,12 +224,8 @@ def preprocess_opts(parser):
                    "shard_size>0 means segment dataset into multiple shards, "
                    "each shard has shard_size samples")
 
-    group.add('--corpus_threads', '-corpus_threads', type=int, default=1,
-              help="Number of corpora to handle in parallel "
-                   "when preprocessing multiple corpora.")
-    group.add('--shards_threads', '-shards_threads', type=int, default=1,
-              help="Number of shards to build in parallel "
-                   "for a single corpus.")
+    group.add('--num_threads', '-num_threads', type=int, default=1,
+              help="Number of shards to build in parallel.")
 
     group.add('--overwrite', '-overwrite', action="store_true",
               help="Overwrite existing shards if any.")

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -224,6 +224,13 @@ def preprocess_opts(parser):
                    "shard_size>0 means segment dataset into multiple shards, "
                    "each shard has shard_size samples")
 
+    group.add('--corpus_threads', '-corpus_threads', type=int, default=1,
+              help="Number of corpora to handle in parallel "
+                   "when preprocessing multiple corpora.")
+    group.add('--shards_threads', '-shards_threads', type=int, default=1,
+              help="Number of shards to build in parallel "
+                   "for a single corpus.")
+
     group.add('--overwrite', '-overwrite', action="store_true",
               help="Overwrite existing shards if any.")
 

--- a/preprocess.py
+++ b/preprocess.py
@@ -55,6 +55,8 @@ def process_one_shard(corpus_params, params):
     if corpus_type == "train" and existing_fields is None:
         for ex in dataset.examples:
             for name, field in fields.items():
+                if ((opt.data_type == "audio") and
+                   (name == "src")): continue
                 try:
                     f_iter = iter(field)
                 except TypeError:

--- a/preprocess.py
+++ b/preprocess.py
@@ -8,7 +8,6 @@ import glob
 import sys
 import gc
 import torch
-from functools import partial
 from collections import Counter, defaultdict
 
 from onmt.utils.logging import init_logger, logger
@@ -19,8 +18,8 @@ from onmt.utils.parse import ArgumentParser
 from onmt.inputters.inputter import _build_fields_vocab,\
                                     _load_vocab
 
-from multiprocessing.pool import Pool, ThreadPool
 from functools import partial
+from multiprocessing.pool import Pool, ThreadPool
 
 
 def check_existing_pt_files(opt):
@@ -36,7 +35,7 @@ def check_existing_pt_files(opt):
 
 def process_one_shard(corpus_params, params):
     corpus_type, fields, src_reader, tgt_reader, opt, existing_fields,\
-    src_vocab, tgt_vocab, filter_pred, maybe_id = corpus_params
+        src_vocab, tgt_vocab, filter_pred, maybe_id = corpus_params
     i, (src_shard, tgt_shard) = params
     # create one counter per shard
     sub_sub_counter = defaultdict(Counter)
@@ -92,9 +91,10 @@ def process_one_shard(corpus_params, params):
 
     return sub_sub_counter
 
+
 def build_save_one_corpus(dataset_params, params):
     corpus_type, fields, src_reader, tgt_reader,\
-    opt, existing_fields, src_vocab, tgt_vocab = dataset_params
+        opt, existing_fields, src_vocab, tgt_vocab = dataset_params
     src, tgt, maybe_id = params
     logger.info("Reading source and target files: %s %s." % (src, tgt))
 
@@ -114,12 +114,13 @@ def build_save_one_corpus(dataset_params, params):
 
     with Pool(opt.shards_threads) as p:
         corpus_params = (process_one_shard, corpus_type, fields,
-            src_reader, tgt_reader, opt, existing_fields,
-            src_vocab, tgt_vocab, filter_pred, maybe_id)
+                         src_reader, tgt_reader, opt, existing_fields,
+                         src_vocab, tgt_vocab, filter_pred, maybe_id)
         func = partial(corpus_params)
         for sub_sub_counter in p.imap(func, enumerate(shard_pairs)):
             for key, value in sub_sub_counter.items():
-                this_counter[key].update(value)
+                sub_counter[key].update(value)
+
     return sub_counter
 
 
@@ -159,12 +160,11 @@ def build_save_dataset(corpus_type, fields, src_reader, tgt_reader, opt):
 
     with ThreadPool(opt.corpus_threads) as p:
         dataset_params = (corpus_type, fields, src_reader, tgt_reader,
-            opt, existing_fields, src_vocab, tgt_vocab)
+                          opt, existing_fields, src_vocab, tgt_vocab)
         func = partial(build_save_one_corpus, dataset_params)
         for sub_counter in p.imap(func, zip(srcs, tgts, ids)):
             for key, value in sub_counter.items():
                 counters[key].update(value)
-
 
     if corpus_type == "train":
         vocab_path = opt.save_data + '.vocab.pt'

--- a/preprocess.py
+++ b/preprocess.py
@@ -159,7 +159,8 @@ def build_save_dataset(corpus_type, fields, src_reader, tgt_reader, opt):
         tgts = [opt.valid_tgt]
         ids = [None]
 
-    src_vocab, tgt_vocab, existing_fields = maybe_load_vocab(corpus_type, counters, opt)
+    src_vocab, tgt_vocab, existing_fields = maybe_load_vocab(
+        corpus_type, counters, opt)
 
     with ThreadPool(opt.corpus_threads) as p:
         dataset_params = (corpus_type, fields, src_reader, tgt_reader,

--- a/preprocess.py
+++ b/preprocess.py
@@ -18,7 +18,7 @@ from onmt.inputters.inputter import _build_fields_vocab,\
                                     _load_vocab
 
 from functools import partial
-from multiprocessing.pool import Pool, ThreadPool
+from multiprocessing import Pool
 
 
 def check_existing_pt_files(opt, corpus_type, ids, existing_fields):
@@ -184,7 +184,7 @@ def build_save_dataset(corpus_type, fields, src_reader, tgt_reader, opt):
                 yield (i, (ss, ts, maybe_id, filter_pred))
 
     shard_iter = shard_iterator(srcs, tgts, ids, existing_shards,
-                               existing_fields, corpus_type, opt)
+                                existing_fields, corpus_type, opt)
 
     with Pool(opt.num_threads) as p:
         dataset_params = (corpus_type, fields, src_reader, tgt_reader,

--- a/preprocess.py
+++ b/preprocess.py
@@ -137,8 +137,8 @@ def build_save_dataset(corpus_type, fields, src_reader, tgt_reader, opt):
         tgts = [opt.valid_tgt]
         ids = [None]
 
+    existing_fields = None
     if corpus_type == "train":
-        existing_fields = None
         if opt.src_vocab != "":
             try:
                 logger.info("Using existing vocabulary...")

--- a/preprocess.py
+++ b/preprocess.py
@@ -33,7 +33,7 @@ def check_existing_pt_files(opt, corpus_type, ids, existing_fields):
         if glob.glob(pattern):
             if opt.overwrite:
                 maybe_overwrite = ("will be overwritten because "
-                                  "`-overwrite` option is set.")
+                                   "`-overwrite` option is set.")
             else:
                 maybe_overwrite = ("won't be overwritten, pass the "
                                    "`-overwrite` option if you want to.")

--- a/preprocess.py
+++ b/preprocess.py
@@ -124,9 +124,10 @@ def build_save_one_corpus(dataset_params, params):
     return sub_counter
 
 
-def maybe_load_vocab(corpus_type, opt):
+def maybe_load_vocab(corpus_type, counters, opt):
     src_vocab = None
     tgt_vocab = None
+    existing_fields = None
     if corpus_type == "train":
         if opt.src_vocab != "":
             try:
@@ -141,7 +142,8 @@ def maybe_load_vocab(corpus_type, opt):
             tgt_vocab, tgt_vocab_size = _load_vocab(
                 opt.tgt_vocab, "tgt", counters,
                 opt.tgt_words_min_frequency)
-    return src_vocab, tgt_vocab
+    return src_vocab, tgt_vocab, existing_fields
+
 
 def build_save_dataset(corpus_type, fields, src_reader, tgt_reader, opt):
     assert corpus_type in ['train', 'valid']
@@ -152,12 +154,12 @@ def build_save_dataset(corpus_type, fields, src_reader, tgt_reader, opt):
         tgts = opt.train_tgt
         ids = opt.train_ids
     else:
+        counters = None
         srcs = [opt.valid_src]
         tgts = [opt.valid_tgt]
         ids = [None]
 
-    existing_fields = None
-    src_vocab, tgt_vocab = maybe_load_vocab(corpus_type, opt)
+    src_vocab, tgt_vocab, existing_fields = maybe_load_vocab(corpus_type, counters, opt)
 
     with ThreadPool(opt.corpus_threads) as p:
         dataset_params = (corpus_type, fields, src_reader, tgt_reader,

--- a/preprocess.py
+++ b/preprocess.py
@@ -116,7 +116,7 @@ def build_save_one_corpus(dataset_params, params):
         corpus_params = (process_one_shard, corpus_type, fields,
                          src_reader, tgt_reader, opt, existing_fields,
                          src_vocab, tgt_vocab, filter_pred, maybe_id)
-        func = partial(corpus_params)
+        func = partial(build_save_one_shard, corpus_params)
         for sub_sub_counter in p.imap(func, enumerate(shard_pairs)):
             for key, value in sub_sub_counter.items():
                 sub_counter[key].update(value)

--- a/preprocess.py
+++ b/preprocess.py
@@ -55,8 +55,8 @@ def process_one_shard(corpus_params, params):
     if corpus_type == "train" and existing_fields is None:
         for ex in dataset.examples:
             for name, field in fields.items():
-                if ((opt.data_type == "audio") and
-                   (name == "src")): continue
+                if ((opt.data_type == "audio") and (name == "src")):
+                    continue
                 try:
                     f_iter = iter(field)
                 except TypeError:

--- a/preprocess.py
+++ b/preprocess.py
@@ -5,7 +5,6 @@
 """
 import codecs
 import glob
-import sys
 import gc
 import torch
 from collections import Counter, defaultdict
@@ -33,8 +32,8 @@ def check_existing_pt_files(opt, corpus_type, ids, existing_fields):
         pattern = opt.save_data + '.{}.*.pt'.format(shard_base)
         if glob.glob(pattern):
             logger.warning("Shards for corpus {} already exist, "
-                "may be overwritten if `overwrite` option is set."
-                .format(shard_base))
+                           "may be overwritten if `overwrite` "
+                           "option is set.".format(shard_base))
             existing_shards += [maybe_id]
             if corpus_type == "train":
                 assert existing_fields is not None,\

--- a/preprocess.py
+++ b/preprocess.py
@@ -113,7 +113,7 @@ def build_save_one_corpus(dataset_params, params):
         filter_pred = None
 
     with Pool(opt.shards_threads) as p:
-        corpus_params = (process_one_shard, corpus_type, fields,
+        corpus_params = (corpus_type, fields,
                          src_reader, tgt_reader, opt, existing_fields,
                          src_vocab, tgt_vocab, filter_pred, maybe_id)
         func = partial(process_one_shard, corpus_params)

--- a/preprocess.py
+++ b/preprocess.py
@@ -116,7 +116,7 @@ def build_save_one_corpus(dataset_params, params):
         corpus_params = (process_one_shard, corpus_type, fields,
                          src_reader, tgt_reader, opt, existing_fields,
                          src_vocab, tgt_vocab, filter_pred, maybe_id)
-        func = partial(build_save_one_shard, corpus_params)
+        func = partial(process_one_shard, corpus_params)
         for sub_sub_counter in p.imap(func, enumerate(shard_pairs)):
             for key, value in sub_sub_counter.items():
                 sub_counter[key].update(value)


### PR DESCRIPTION
This PR is following #1413 .

_This was simplified from the initial proposition._

We build a single iterator `shard_iterator` that yields everything required to build a shard, and call a `multiprocessing.Pool.imap` over it to process shards and build the vocab counters in parallel (`opt.num_threads`).

The shard processing is done in `process_one_shard`.

Depending on the configuration, we can achieve up to 10x speed up.

Note: it is not advised to use this option for image or audio tasks, as feature computation is already mostly multi-threaded (and close to maxing out CPU resources).

Note 2: this should also fix an issue when preprocessing audio (some counter of src features was being built when building vocab). #1576