### PR TITLE
Add long description to `setup.py` (for pypi)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
 from setuptools import setup, find_packages
+from os import path
 
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
 
 setup(
     name='OpenNMT-py',
     description='A python implementation of OpenNMT',
+    long_description=long_description,
+    long_description_content_type='text/markdown',
     version='1.0.0.rc1',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
We set the project `README.md` as the long description, which is what PyPi is using for the package page (see example: https://test.pypi.org/project/OpenNMT-py/1.0.0rc10/ ) 

---
NOTE: I had to bump the version (1.0.0rc10) for PyPi test upload for test reasons (even on test versions are unique...)