### PR TITLE
Remove Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,0 @@
-FROM pytorch/pytorch:latest
-RUN git clone https://github.com/OpenNMT/OpenNMT-py.git && cd OpenNMT-py && pip install -r requirements.txt && python setup.py install


### PR DESCRIPTION
I suggest removing the Dockerfile.

The OpenNMT-py installation procedure is no longer valid and the file does not provide much value.