### PR TITLE
[docs] Add note about producer/consumer in FAQ

### DIFF
--- a/docs/source/FAQ.md
+++ b/docs/source/FAQ.md
@@ -91,22 +91,22 @@ Here are what each of the parameters mean:
 
 ## Do you support multi-gpu?
 
-Multi GPU settings
+First you need to make sure you `export CUDA_VISIBLE_DEVICES=0,1,2,3`.
 
-First you need to make sure you export CUDA_VISIBLE_DEVICES=0,1,2,3
-If you want to use GPU id 1 and 3 of your OS, you will need to export CUDA_VISIBLE_DEVICES=1,3
-* `world_size 4 gpu_ranks 0 1 2 3`: This will use 4 GPU on this node only.
+If you want to use GPU id 1 and 3 of your OS, you will need to `export CUDA_VISIBLE_DEVICES=1,3`
 
-If you want to use 2 nodes with 2 GPU each, you need to set -master_ip and master_port, and
-* `world_size 4 gpu_ranks 0 1`: on the first node
-* `world_size 4 gpu_ranks 2 3`: on the second node
-* `accum_count 2`: This will accumulate over 2 batches before updating parameters.
+Both `-world_size` and `-gpu_ranks` need to be set. E.g. `-world_size 4 -gpu_ranks 0 1 2 3` will use 4 GPU on this node only.
 
-if you use a regular network card (1 Gbps) then we suggest to use a higher accum_count to minimize the inter-node communication.
+If you want to use 2 nodes with 2 GPU each, you need to set `-master_ip` and `-master_port`, and
+* `-world_size 4 -gpu_ranks 0 1`: on the first node
+* `-world_size 4 -gpu_ranks 2 3`: on the second node
+* `-accum_count 2`: This will accumulate over 2 batches before updating parameters.
+
+if you use a regular network card (1 Gbps) then we suggest to use a higher `-accum_count` to minimize the inter-node communication.
 
 **Note:**
 
-When training on several GPUs, you can't have them in 'Exclusive' compute mode (nvidia-smi -c 3).
+When training on several GPUs, you can't have them in 'Exclusive' compute mode (`nvidia-smi -c 3`).
 
 The multi-gpu setup relies on a Producer/Consumer setup. This setup means there will be `2<n_gpu> + 1` processes spawned, with 2 processes per GPU, one for model training and one (Consumer) that hosts a `Queue` of batches that will be processed next. The additional process is the Producer, creating batches and sending them to the Consumers. This setup is beneficial for both wall time and memory, since it loads data shards 'in advance', and does not require to load it for each GPU process.
 

--- a/docs/source/FAQ.md
+++ b/docs/source/FAQ.md
@@ -62,7 +62,7 @@ onmt_train -save_model data/model \
 ```
 
 
-## How do I use the Transformer model? Do you support multi-gpu?
+## How do I use the Transformer model?
 
 The transformer model is very sensitive to hyperparameters. To run it
 effectively you need to set a bunch of different options that mimic the Google
@@ -88,7 +88,11 @@ Here are what each of the parameters mean:
 * `batch_type tokens`, `normalization tokens`, `accum_count 4`: batch and normalize based on number of tokens and not sentences. Compute gradients based on four batches. 
 - `label_smoothing 0.1`: use label smoothing loss. 
 
+
+## Do you support multi-gpu?
+
 Multi GPU settings
+
 First you need to make sure you export CUDA_VISIBLE_DEVICES=0,1,2,3
 If you want to use GPU id 1 and 3 of your OS, you will need to export CUDA_VISIBLE_DEVICES=1,3
 * `world_size 4 gpu_ranks 0 1 2 3`: This will use 4 GPU on this node only.
@@ -99,6 +103,12 @@ If you want to use 2 nodes with 2 GPU each, you need to set -master_ip and maste
 * `accum_count 2`: This will accumulate over 2 batches before updating parameters.
 
 if you use a regular network card (1 Gbps) then we suggest to use a higher accum_count to minimize the inter-node communication.
+
+**Note:**
+
+When training on several GPUs, you can't have them in 'Exclusive' compute mode (nvidia-smi -c 3).
+
+The multi-gpu setup relies on a Producer/Consumer setup. This setup means there will be `2<n_gpu> + 1` processes spawned, with 2 processes per GPU, one for model training and one (Consumer) that hosts a `Queue` of batches that will be processed next. The additional process is the Producer, creating batches and sending them to the Consumers. This setup is beneficial for both wall time and memory, since it loads data shards 'in advance', and does not require to load it for each GPU process.
 
 ## How can I ensemble Models at inference?
 


### PR DESCRIPTION
This separates the "multi-gpu" question in the FAQ, adds a note about producer/consumer setup and explains why we can't have GPUs in exclusive mode.