### PR TITLE
Fix _decode_and_generate for gold scoring w/ copy

### DIFF
--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -598,7 +598,8 @@ class Translator(object):
                                           src_map)
             # here we have scores [tgt_lenxbatch, vocab] or [beamxbatch, vocab]
             if batch_offset is None:
-                scores = scores.view(batch.batch_size, -1, scores.size(-1))
+                scores = scores.view(-1, batch.batch_size, scores.size(-1))
+                scores = scores.transpose(0, 1).contiguous()
             else:
                 scores = scores.view(-1, self.beam_size, scores.size(-1))
             scores = collapse_copy_scores(


### PR DESCRIPTION
In copy generator, `copy_prob` is `[batch, tl, cvocab]` right after `bmm`, then become `[tl, batch, cvocab]` after transposition, and get "flattened"(`tlen` first) at line 131, `[tl*batch, cvocab]`.

In [translator line 601](https://github.com/OpenNMT/OpenNMT-py/blob/master/onmt/translate/translator.py#L601), we try to view it as `batch, tl, scores.size(-1)`(batch first), which is inconsistent with previous flattening. 

I reproduced the error by looking at values right after `bmm` (before transpose), and right after line 601. Because `scores` has same dimensions at both points, values should be the same, but it's not.

--- 
fixes: https://github.com/OpenNMT/OpenNMT-py/issues/1607