### PR TITLE
do not deepcopy during validation w/ moving_average

### DIFF
--- a/onmt/models/model_saver.py
+++ b/onmt/models/model_saver.py
@@ -47,18 +47,20 @@ class ModelSaverBase(object):
         if self.keep_checkpoint == 0 or step == self.last_saved_step:
             return
 
+        save_model = self.model
         if moving_average:
-            save_model = deepcopy(self.model)
+            model_params_data = []
             for avg, param in zip(moving_average, save_model.parameters()):
-                param.data.copy_(avg.data)
-        else:
-            save_model = self.model
+                model_params_data.append(param.data)
+                param.data = avg.data
 
         chkpt, chkpt_name = self._save(step, save_model)
         self.last_saved_step = step
 
         if moving_average:
-            del save_model
+            for param_data, param in zip(model_params_data,
+                                         save_model.parameters()):
+                param.data = param_data
 
         if self.keep_checkpoint > 0:
             if len(self.checkpoint_queue) == self.checkpoint_queue.maxlen:

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -9,7 +9,6 @@
           users of this library) for the strategy things we do.
 """
 
-from copy import deepcopy
 import torch
 import traceback
 

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -290,14 +290,16 @@ class Trainer(object):
         Returns:
             :obj:`nmt.Statistics`: validation loss statistics
         """
+        valid_model = self.model
         if moving_average:
-            valid_model = deepcopy(self.model)
+            # swap model params w/ moving average
+            # (and keep the original parameters)
+            model_params_data = []
             for avg, param in zip(self.moving_average,
                                   valid_model.parameters()):
+                model_params_data.append(param.data)
                 param.data = avg.data.half() if self.optim._fp16 == "legacy" \
                     else avg.data
-        else:
-            valid_model = self.model
 
         # Set model in validating mode.
         valid_model.eval()
@@ -318,12 +320,13 @@ class Trainer(object):
 
                 # Update statistics.
                 stats.update(batch_stats)
-
         if moving_average:
-            del valid_model
-        else:
-            # Set model back to training mode.
-            valid_model.train()
+            for param_data, param in zip(model_params_data,
+                                         self.model.parameters()):
+                param.data = param_data
+
+        # Set model back to training mode.
+        valid_model.train()
 
         return stats
 


### PR DESCRIPTION
Deepcopy isn't mandatory here, we just need to keep the original parameters somewhere, and put it back after validation.

This is probably more efficient in term of speed and memory.

---
**EDIT:** Current training ran validation and saved checkpoint without issues. I'll check if performance are affected. 

Cannot really compare speed/memory impact as I never trained using older version.