### PR TITLE
support server for nbest translation

### DIFF
--- a/onmt/bin/server.py
+++ b/onmt/bin/server.py
@@ -75,14 +75,15 @@ def start(config_file,
         inputs = request.get_json(force=True)
         out = {}
         try:
-            translation, scores, n_best, times = translation_server.run(inputs)
-            assert len(translation) == len(inputs)
-            assert len(scores) == len(inputs)
+            trans, scores, n_best, times = translation_server.run(inputs)
+            assert len(trans) == len(inputs) * n_best
+            assert len(scores) == len(inputs) * n_best
 
-            out = [[{"src": inputs[i]['src'], "tgt": translation[i],
-                     "n_best": n_best,
-                     "pred_score": scores[i]}
-                    for i in range(len(translation))]]
+            out = [[] for _ in range(n_best)]
+            for i in range(len(trans)):
+                response = {"src": inputs[i // n_best]['src'], "tgt": trans[i],
+                            "n_best": n_best, "pred_score": scores[i]}
+                out[i % n_best].append(response)
         except ServerModelError as e:
             out['error'] = str(e)
             out['status'] = STATUS_ERROR

--- a/onmt/tests/test_translation_server.py
+++ b/onmt/tests/test_translation_server.py
@@ -120,18 +120,10 @@ class TestServerModel(unittest.TestCase):
         for elem in scores:
             self.assertIsInstance(elem, float)
         self.assertEqual(len(results), len(scores))
-        self.assertEqual(len(scores), len(inp))
-        self.assertEqual(n_best, 1)
+        self.assertEqual(len(scores), len(inp) * n_best)
         self.assertEqual(len(time), 1)
         self.assertIsInstance(time, dict)
         self.assertIn("translation", time)
-
-    def test_nbest_init_fails(self):
-        model_id = 0
-        opt = {"models": ["test_model.pt"], "n_best": 2}
-        model_root = TEST_DIR
-        with self.assertRaises(ValueError):
-            ServerModel(opt, model_id, model_root=model_root, load=True)
 
 
 class TestTranslationServer(unittest.TestCase):


### PR DESCRIPTION
Solve issus  #1614. Support server output n_best translation.
With this PR, server will output translation as:

```json
[
  [
    {
      "n_best": 2, 
      "pred_score": -0.15397775173187256, 
      "src": "text to translate 1.", 
      "tgt": "translation 1 - 1_best."
    }, 
    {
      "n_best": 2, 
      "pred_score": -0.2884165942668915, 
      "src": "text to translate 2.", 
      "tgt": "translation 2 - 1_best."
    }
  ],
  [
    {
      "n_best": 2, 
      "pred_score": -0.5973197817802429, 
      "src": "text to translate 1.", 
      "tgt": "translation 1 - 2_best."
    }, 
    {
      "n_best": 2, 
      "pred_score": -0.5908429622650146, 
      "src": "text to translate 2.", 
      "tgt": "translation 2 - 2_best."
    }
  ]
]
```