### PR TITLE
fix vanilla coverage penalty with FP16 model

### DIFF
--- a/onmt/translate/beam_search.py
+++ b/onmt/translate/beam_search.py
@@ -220,7 +220,7 @@ class BeamSearch(DecodeStrategy):
             cov_penalty = self.global_scorer.cov_penalty(
                 self._coverage,
                 beta=self.global_scorer.beta)
-            self.topk_scores -= cov_penalty.view(_B, self.beam_size)
+            self.topk_scores -= cov_penalty.view(_B, self.beam_size).float()
 
         self.is_finished = self.topk_ids.eq(self.eos)
         self.ensure_max_length()


### PR DESCRIPTION
This PR is intended to fix beam search with vanilla coverage penalty (`-coverage_penalty` set other than 'none' while not set `-stepwise_penalty`) in the case of FP16 model (and not set `-fp32`).

Without this PR, the this.topk_scores is in float32 dtype, while cov_penalty calculated based on attention is float16 dtype (for transformer), this will raise `RuntimeError: expected device cuda:0 and dtype Float but got device cuda:0 and dtype Half`.