### PR TITLE
[fix] Add missing seed init

### DIFF
--- a/onmt/bin/train.py
+++ b/onmt/bin/train.py
@@ -22,6 +22,8 @@ def train(opt):
     ArgumentParser.update_model_opts(opt)
     ArgumentParser.validate_model_opts(opt)
 
+    set_random_seed(opt.seed, False)
+
     # Load checkpoint if we resume from a previous training.
     if opt.train_from:
         logger.info('Loading checkpoint from %s' % opt.train_from)


### PR DESCRIPTION
This fixes a case when training with multiple datasets on multiple GPUs, the iterator does not use the proper seed.
`MultipleDatasetIterator` initialises its `random_shuffler` in the main process, whereas in the case of a single dataset, `DatasetLazyIterator` initialises it on the first iteration, which happens in the `batch_producer` process, where the torch seed is properly initialized.