### PR TITLE
Fix #1674

### DIFF
--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -731,7 +731,7 @@ class Translator(object):
             msg = "%s No words predicted" % (name,)
         else:
             avg_score = score_total / words_total
-            ppl = np.exp(-score_total / words_total)
+            ppl = np.exp(-score_total.item() / words_total)
             msg = ("%s AVG SCORE: %.4f, %s PPL: %.4f" % (
                 name, avg_score,
                 name, ppl))


### PR DESCRIPTION
#1674 introduced `np.exp` to prevent overflow, but it breaks with CUDA tensors. We need to call`.item()` on the tensor.