### PR TITLE
fix the use of joint alignment model in emsemble

### DIFF
--- a/onmt/decoders/ensemble.py
+++ b/onmt/decoders/ensemble.py
@@ -61,7 +61,7 @@ class EnsembleDecoder(DecoderBase):
         dec_outs, attns = zip(*[
             model_decoder(
                 tgt, memory_bank[i],
-                memory_lengths=memory_lengths, step=step)
+                memory_lengths=memory_lengths, step=step, **kwargs)
             for i, model_decoder in enumerate(self.model_decoders)])
         mean_attns = self.combine_attns(attns)
         return EnsembleDecoderOutput(dec_outs), mean_attns


### PR DESCRIPTION
This PR fixes the use of joint alignment models in ensemble decoding by:
* Add the forgotten additional argument pass for EnsembleDecoder.