### PR TITLE
Use attention dropout for self attention, not context

### DIFF
--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -56,7 +56,7 @@ class TransformerDecoderLayer(nn.Module):
 
         if self_attn_type == "scaled-dot":
             self.self_attn = MultiHeadedAttention(
-                heads, d_model, dropout=dropout,
+                heads, d_model, dropout=attention_dropout,
                 max_relative_positions=max_relative_positions)
         elif self_attn_type == "average":
             self.self_attn = AverageAttention(d_model,
@@ -64,7 +64,7 @@ class TransformerDecoderLayer(nn.Module):
                                               aan_useffn=aan_useffn)
 
         self.context_attn = MultiHeadedAttention(
-            heads, d_model, dropout=attention_dropout)
+            heads, d_model, dropout=dropout)
         self.feed_forward = PositionwiseFeedForward(d_model, d_ff, dropout)
         self.layer_norm_1 = nn.LayerNorm(d_model, eps=1e-6)
         self.layer_norm_2 = nn.LayerNorm(d_model, eps=1e-6)

--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -64,7 +64,7 @@ class TransformerDecoderLayer(nn.Module):
                                               aan_useffn=aan_useffn)
 
         self.context_attn = MultiHeadedAttention(
-            heads, d_model, dropout=dropout)
+            heads, d_model, dropout=attention_dropout)
         self.feed_forward = PositionwiseFeedForward(d_model, d_ff, dropout)
         self.layer_norm_1 = nn.LayerNorm(d_model, eps=1e-6)
         self.layer_norm_2 = nn.LayerNorm(d_model, eps=1e-6)


### PR DESCRIPTION
I've been inverstigating about differences between [Ziegler's fork](https://github.com/harvardnlp/encoder-agnostic-adaptation) and ONMT-py.

Turns out the attention dropout isn't used the same way i.e. using attn_dropout for the self attention (which make sense) and not for the context attention (less clear to me if it should be), see https://github.com/harvardnlp/encoder-agnostic-adaptation/blob/master/onmt/decoders/transformer.py#L274 .

I'm currently training summarization models with this variant, since I observed a performance gap between our and Ziegler's implementation.