### PR TITLE
move tok/preproc/postproc init to ServerModel init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
       - sox
 before_install:
   # Install CPU version of PyTorch.
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install torch==1.3.1 -f https://download.pytorch.org/whl/cpu/torch_stable.html; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install torch==1.4.0 -f https://download.pytorch.org/whl/cpu/torch_stable.html; fi
   - pip install --upgrade setuptools
   - pip install -r requirements.opt.txt
   - python setup.py install   

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
 before_install:
   # Install CPU version of PyTorch.
   - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install torch==1.3.1 -f https://download.pytorch.org/whl/cpu/torch_stable.html; fi
+  - pip install --upgrade setuptools
   - pip install -r requirements.opt.txt
   - python setup.py install   
 env:

--- a/requirements.opt.txt
+++ b/requirements.opt.txt
@@ -2,7 +2,7 @@ cffi
 torchvision
 joblib
 librosa
-Pillow<7
+Pillow
 git+git://github.com/pytorch/audio.git@d92de5b97fc6204db4b1e3ed20c03ac06f5d53f0
 pyrouge
 opencv-python

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=[
         "six",
         "tqdm~=4.30.0",
-        "torch>=1.3.1",
+        "torch>=1.4.0",
         "torchtext==0.4.0",
         "future",
         "configargparse",


### PR DESCRIPTION
A memory leak was flagged when rebuilding `pyonmttok.Tokenizer` objects (https://github.com/OpenNMT/Tokenizer/issues/130).
We move the tokenizer initialization in the `ServerModel` constructor, as well as the eventual preprocess/postprocess. Everything is built once when 'preloading' the models.

+ Update requirements to pytorch 1.4 (1.3.1 was breaking travis - https://github.com/pytorch/vision/issues/1675).
+ Remove Pillow pin to <7 (torchaudio 0.5 released along with pytorch 1.4)