### PR TITLE
[fix] Check if checkpoint exists before removing

### DIFF
--- a/onmt/models/model_saver.py
+++ b/onmt/models/model_saver.py
@@ -131,4 +131,5 @@ class ModelSaver(ModelSaverBase):
         return checkpoint, checkpoint_path
 
     def _rm_checkpoint(self, name):
-        os.remove(name)
+        if os.path.exists(name):
+            os.remove(name)


### PR DESCRIPTION
Without this check, the training would stop if some checkpoints were removed manually before they are removed based on the `-keep_checkpoint` opt.