### PR TITLE
Make "Training data not found" a bit more explicit

### DIFF
--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -822,11 +822,12 @@ def build_dataset_iter(corpus_type, fields, opt, is_train=True, multi=False):
     to iterate over. We implement simple ordered iterator strategy here,
     but more sophisticated strategy like curriculum learning is ok too.
     """
+    dataset_glob = opt.data + '.' + corpus_type + '.[0-9]*.pt'
     dataset_paths = list(sorted(
-        glob.glob(opt.data + '.' + corpus_type + '.[0-9]*.pt')))
+        glob.glob(dataset_glob)))
     if not dataset_paths:
         if is_train:
-            raise ValueError('Training data %s not found' % opt.data)
+            raise ValueError('Training data %s not found' % dataset_glob)
         else:
             return None
     if multi:


### PR DESCRIPTION
I found it more practical to log the glob since `opt.data` only contain the prefix, i.e. without corpus type / corpus ids