### PR TITLE
lower default batch producer queue size

### DIFF
--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -375,7 +375,7 @@ def train_opts(parser):
               help="IP of master for torch.distributed training.")
     group.add('--master_port', '-master_port', default=10000, type=int,
               help="Port of master for torch.distributed training.")
-    group.add('--queue_size', '-queue_size', default=400, type=int,
+    group.add('--queue_size', '-queue_size', default=40, type=int,
               help="Size of queue for each process in producer/consumer")
 
     group.add('--seed', '-seed', type=int, default=-1,


### PR DESCRIPTION
Not sure why the queue size is *that* big. It seems pretty useless to me (I may miss something) and actually lowering it helped it avoid out of memory during training without loss of performance.

For the context, I regularly face some OOM, only right after (or before) validation.
I don't really understand why, but since I considered this big queue to be a waste of memory I reduced it and eventually fix the issue (it may just be random, but anyway queue size 400 does not really make sense to me).

