### PR TITLE
default replace_unk to alignment if exist for transformer

### DIFF
--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -96,7 +96,8 @@ class TranslationBuilder(object):
             pred_sents = [self._build_target_tokens(
                 src[:, b] if src is not None else None,
                 src_vocab, src_raw,
-                preds[b][n], attn[b][n])
+                preds[b][n],
+                align[b][n] if align[b] is not None else attn[b][n])
                 for n in range(self.n_best)]
             gold_sent = None
             if tgt is not None:


### PR DESCRIPTION
In this PR, We default the use of alignment to do `--replace_unk`, This is only valid for Transformer if we set the `--report_align`.
This feature will benefit a lot for those Transformer trained with guided alignments. And should also help (but less accurate compare to guided alignment) for any Transformer model as we'll default to average the second last layer's attention rather than the top head of the last decoder layer if we set `--report_align` during translate.