### PR TITLE
Use return_dict in REST server for more flexibility

### DIFF
--- a/onmt/bin/server.py
+++ b/onmt/bin/server.py
@@ -99,7 +99,7 @@ def start(config_file,
             for i in range(len(trans)):
                 response = {"src": inputs[i // n_best]['src'], "tgt": trans[i],
                             "n_best": n_best, "pred_score": scores[i]}
-                if aligns[i] is not None:
+                if aligns[i][0] is not None:
                     response["align"] = aligns[i]
                 out[i % n_best].append(response)
         except ServerModelError as e:

--- a/onmt/tests/test_translation_server.py
+++ b/onmt/tests/test_translation_server.py
@@ -120,9 +120,10 @@ class TestServerModel(unittest.TestCase):
         for elem in scores:
             self.assertIsInstance(elem, float)
         self.assertIsInstance(aligns, list)
-        for align_string in aligns:
-            if align_string is not None:
-                self.assertIsInstance(align_string, string_types)
+        for align_list in aligns:
+            for align_string in align_list:
+                if align_string is not None:
+                    self.assertIsInstance(align_string, string_types)
         self.assertEqual(len(results), len(scores))
         self.assertEqual(len(scores), len(inp) * n_best)
         self.assertEqual(len(time), 1)

--- a/onmt/translate/process_zh.py
+++ b/onmt/translate/process_zh.py
@@ -3,44 +3,47 @@ from snownlp import SnowNLP
 import pkuseg
 
 
-def update_seg(func):
-    def wrapper(line):
-        line["seg"] = [func(item) for item in line["seg"]]
-        return line
+def wrap_str_func(func):
+    """
+    Wrapper to apply str function to the proper key of return_dict.
+    """
+    def wrapper(some_dict):
+        some_dict["seg"] = [func(item) for item in some_dict["seg"]]
+        return some_dict
     return wrapper
 
 
 # Chinese segmentation
-@update_seg
+@wrap_str_func
 def zh_segmentator(line):
     return " ".join(pkuseg.pkuseg().cut(line))
 
 
 # Chinese simplify -> Chinese traditional standard
-@update_seg
+@wrap_str_func
 def zh_traditional_standard(line):
     return HanLP.convertToTraditionalChinese(line)
 
 
 # Chinese simplify -> Chinese traditional (HongKong)
-@update_seg
+@wrap_str_func
 def zh_traditional_hk(line):
     return HanLP.s2hk(line)
 
 
 # Chinese simplify -> Chinese traditional (Taiwan)
-@update_seg
+@wrap_str_func
 def zh_traditional_tw(line):
     return HanLP.s2tw(line)
 
 
 # Chinese traditional -> Chinese simplify (v1)
-@update_seg
+@wrap_str_func
 def zh_simplify(line):
     return HanLP.convertToSimplifiedChinese(line)
 
 
 # Chinese traditional -> Chinese simplify (v2)
-@update_seg
+@wrap_str_func
 def zh_simplify_v2(line):
     return SnowNLP(line).han

--- a/onmt/translate/process_zh.py
+++ b/onmt/translate/process_zh.py
@@ -4,10 +4,10 @@ import pkuseg
 
 
 def update_seg(func):
-	def wrapper(line):
-		line["seg"] = [func(item) for item in line["seg"]]
-		return line
-	return wrapper
+    def wrapper(line):
+        line["seg"] = [func(item) for item in line["seg"]]
+        return line
+    return wrapper
 
 
 # Chinese segmentation

--- a/onmt/translate/process_zh.py
+++ b/onmt/translate/process_zh.py
@@ -3,40 +3,46 @@ from snownlp import SnowNLP
 import pkuseg
 
 
+def update_seg(func):
+	def wrapper(line):
+		print("IN WRAPPER")
+		line["seg"] = [func(item) for item in line["seg"]]
+		return line
+	print("OUT WRAPPER")
+	return wrapper
+
+
 # Chinese segmentation
+@update_seg
 def zh_segmentator(line):
-	line["seg"] = [" ".join(pkuseg.pkuseg().cut(item))
-	               for item in line["seg"]]
-    return line
+    return " ".join(pkuseg.pkuseg().cut(line))
 
 
 # Chinese simplify -> Chinese traditional standard
+@update_seg
 def zh_traditional_standard(line):
-	line["seg"] = [HanLP.convertToTraditionalChinese(item)
-				   for item in line["seg"]]
-    return line
+    return HanLP.convertToTraditionalChinese(line)
 
 
 # Chinese simplify -> Chinese traditional (HongKong)
+@update_seg
 def zh_traditional_hk(line):
-	line["seg"] = [HanLP.s2hk(item) for item in line["seg"]]
-    return line
+    return HanLP.s2hk(line)
 
 
 # Chinese simplify -> Chinese traditional (Taiwan)
+@update_seg
 def zh_traditional_tw(line):
-	line["seg"] = [HanLP.s2tw(item) for item in line["seg"]]
     return HanLP.s2tw(line)
 
 
 # Chinese traditional -> Chinese simplify (v1)
+@update_seg
 def zh_simplify(line):
-	line["seg"] = [HanLP.convertToSimplifiedChinese(item)
-	               for item in line["seg"]]
-    return line
+    return HanLP.convertToSimplifiedChinese(line)
 
 
 # Chinese traditional -> Chinese simplify (v2)
+@update_seg
 def zh_simplify_v2(line):
-	line["seg"] = [SnowNLP(item).han for item in line["seg"]]
-    return line
+    return SnowNLP(line).han

--- a/onmt/translate/process_zh.py
+++ b/onmt/translate/process_zh.py
@@ -5,29 +5,38 @@ import pkuseg
 
 # Chinese segmentation
 def zh_segmentator(line):
-    return " ".join(pkuseg.pkuseg().cut(line))
+	line["seg"] = [" ".join(pkuseg.pkuseg().cut(item))
+	               for item in line["seg"]]
+    return line
 
 
 # Chinese simplify -> Chinese traditional standard
 def zh_traditional_standard(line):
-    return HanLP.convertToTraditionalChinese(line)
+	line["seg"] = [HanLP.convertToTraditionalChinese(item)
+				   for item in line["seg"]]
+    return line
 
 
 # Chinese simplify -> Chinese traditional (HongKong)
 def zh_traditional_hk(line):
-    return HanLP.s2hk(line)
+	line["seg"] = [HanLP.s2hk(item) for item in line["seg"]]
+    return line
 
 
 # Chinese simplify -> Chinese traditional (Taiwan)
 def zh_traditional_tw(line):
+	line["seg"] = [HanLP.s2tw(item) for item in line["seg"]]
     return HanLP.s2tw(line)
 
 
 # Chinese traditional -> Chinese simplify (v1)
 def zh_simplify(line):
-    return HanLP.convertToSimplifiedChinese(line)
+	line["seg"] = [HanLP.convertToSimplifiedChinese(item)
+	               for item in line["seg"]]
+    return line
 
 
 # Chinese traditional -> Chinese simplify (v2)
 def zh_simplify_v2(line):
-    return SnowNLP(line).han
+	line["seg"] = [SnowNLP(item).han for item in line["seg"]]
+    return line

--- a/onmt/translate/process_zh.py
+++ b/onmt/translate/process_zh.py
@@ -5,10 +5,8 @@ import pkuseg
 
 def update_seg(func):
 	def wrapper(line):
-		print("IN WRAPPER")
 		line["seg"] = [func(item) for item in line["seg"]]
 		return line
-	print("OUT WRAPPER")
 	return wrapper
 
 

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -387,7 +387,6 @@ class ServerModel(object):
                 self.to_gpu()
                 timer.tick(name="to_gpu")
 
-
         texts = []
         head_spaces = []
         tail_spaces = []
@@ -408,6 +407,7 @@ class ServerModel(object):
                 if match_after is not None:
                     whitespaces_after = match_after.group(0)
                 head_spaces.append(whitespaces_before)
+                # every segment becomes a dict for flexibility purposes
                 return_dict = self.maybe_preprocess(src.strip())
                 all_preprocessed.append(return_dict)
                 for seg in return_dict["seg"]:
@@ -457,7 +457,6 @@ class ServerModel(object):
                    for result, src in zip(results, tiled_texts)]
 
         aligns = [align for _, align in results] 
-
         rebuilt_segs, scores, aligns = self.rebuild_seg_packages(
             all_preprocessed, results, scores, aligns)
         results = [self.maybe_postprocess(seg) for seg in rebuilt_segs]
@@ -478,11 +477,15 @@ class ServerModel(object):
         return results, scores, self.opt.n_best, timer.times, aligns
 
     def rebuild_seg_packages(self, all_preprocessed, results, scores, aligns):
+        """
+        Rebuild proper segment packages based on initial n_seg.
+        """
         offset = 0
         rebuilt_segs = []
         avg_scores = []
         merged_aligns = []
         for some_dict in all_preprocessed:
+            #TODO: make this more readable
             some_dict["seg"] = list(list(zip(*results))[0][offset:offset+some_dict["n_seg"]])
             rebuilt_segs.append(some_dict)
             avg_scores.append(sum(scores[offset:offset+some_dict["n_seg"]])/some_dict["n_seg"])

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -456,11 +456,11 @@ class ServerModel(object):
         results = [self.maybe_detokenize_with_align(result, src)
                    for result, src in zip(results, tiled_texts)]
 
-        aligns = [align for _, align in results] 
+        aligns = [align for _, align in results]
         rebuilt_segs, scores, aligns = self.rebuild_seg_packages(
             all_preprocessed, results, scores, aligns)
         results = [self.maybe_postprocess(seg) for seg in rebuilt_segs]
-        
+
         # build back results with empty texts
         for i in empty_indices:
             j = i * self.opt.n_best
@@ -485,10 +485,12 @@ class ServerModel(object):
         avg_scores = []
         merged_aligns = []
         for some_dict in all_preprocessed:
-            #TODO: make this more readable
-            some_dict["seg"] = list(list(zip(*results))[0][offset:offset+some_dict["n_seg"]])
+            # TODO: make this more readable
+            some_dict["seg"] = list(
+                list(zip(*results))[0][offset:offset+some_dict["n_seg"]])
             rebuilt_segs.append(some_dict)
-            avg_scores.append(sum(scores[offset:offset+some_dict["n_seg"]])/some_dict["n_seg"])
+            avg_scores.append(sum(
+                scores[offset:offset+some_dict["n_seg"]])/some_dict["n_seg"])
             merged_aligns.append(aligns[offset:offset+some_dict["n_seg"]])
             offset += some_dict["n_seg"]
         return rebuilt_segs, avg_scores, merged_aligns
@@ -562,7 +564,7 @@ class ServerModel(object):
             sequence = {
                 "seg": [sequence],
                 "n_seg": 1
-            }            
+            }
         if self.preprocess_opt is not None:
             return self.preprocess(sequence)
         return sequence

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -408,9 +408,9 @@ class ServerModel(object):
                     whitespaces_after = match_after.group(0)
                 head_spaces.append(whitespaces_before)
                 # every segment becomes a dict for flexibility purposes
-                return_dict = self.maybe_preprocess(src.strip())
-                all_preprocessed.append(return_dict)
-                for seg in return_dict["seg"]:
+                seg_dict = self.maybe_preprocess(src.strip())
+                all_preprocessed.append(seg_dict)
+                for seg in seg_dict["seg"]:
                     tok = self.maybe_tokenize(seg)
                     texts.append(tok)
                 sslength.append(len(tok.split()))
@@ -484,15 +484,14 @@ class ServerModel(object):
         rebuilt_segs = []
         avg_scores = []
         merged_aligns = []
-        for some_dict in all_preprocessed:
-            # TODO: make this more readable
-            some_dict["seg"] = list(
-                list(zip(*results))[0][offset:offset+some_dict["n_seg"]])
-            rebuilt_segs.append(some_dict)
+        for seg_dict in all_preprocessed:
+            seg_dict["seg"] = list(
+                list(zip(*results))[0][offset:offset+seg_dict["n_seg"]])
+            rebuilt_segs.append(seg_dict)
             avg_scores.append(sum(
-                scores[offset:offset+some_dict["n_seg"]])/some_dict["n_seg"])
-            merged_aligns.append(aligns[offset:offset+some_dict["n_seg"]])
-            offset += some_dict["n_seg"]
+                scores[offset:offset+seg_dict["n_seg"]])/seg_dict["n_seg"])
+            merged_aligns.append(aligns[offset:offset+seg_dict["n_seg"]])
+            offset += seg_dict["n_seg"]
         return rebuilt_segs, avg_scores, merged_aligns
 
     def do_timeout(self):
@@ -698,8 +697,7 @@ class ServerModel(object):
         if self.postprocess_opt is not None:
             return self.postprocess(sequence)
         else:
-            sequence = sequence["seg"][0]
-        return sequence
+            return sequence["seg"][0]
 
     def postprocess(self, sequence):
         """Preprocess a single sequence.


### PR DESCRIPTION
This PR introduces a change in the way segments are handled in the REST server.
Originally being only strings, segments will now be handled as a dict, to allow more flexibility for custom preprocessing/postprocessing functions.