### PR TITLE
Add support of CTranslate2 models in REST server

### DIFF
--- a/onmt/bin/server.py
+++ b/onmt/bin/server.py
@@ -103,6 +103,11 @@ def start(config_file,
                     response["align"] = aligns[i]
                 out[i % n_best].append(response)
         except ServerModelError as e:
+            model_id = inputs[0].get("id")
+            if debug:
+                logger.warning("Unload model #{} "
+                               "because of an error".format(model_id))
+            translation_server.models[model_id].unload()
             out['error'] = str(e)
             out['status'] = STATUS_ERROR
         if debug:

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -503,10 +503,9 @@ class ServerModel(object):
                        for _ in range(self.opt.n_best)]
         results = flatten_list(predictions)
 
-        scores = [score_tensor
+        def maybe_item(x): return x.item() if type(x) is torch.Tensor else x
+        scores = [maybe_item(score_tensor)
                   for score_tensor in flatten_list(scores)]
-        if type(scores[0]) == torch.Tensor:
-            scores = [score.item() for score in scores]
 
         results = [self.maybe_detokenize_with_align(result, src)
                    for result, src in zip(results, tiled_texts)]

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -82,8 +82,6 @@ class CTranslate2Translator(object):
     def __init__(self, model_path, device, device_index,
                  batch_size, beam_size, n_best):
         import ctranslate2
-        import time
-        beg = time.time()
         self.translator = ctranslate2.Translator(
             model_path,
             device=device,
@@ -91,8 +89,6 @@ class CTranslate2Translator(object):
             inter_threads=1,
             intra_threads=1,
             compute_type="default")
-        duration = time.time() - beg
-        print("########## LOADING TIME", duration)
         self.batch_size = batch_size
         self.beam_size = beam_size
         self.n_best = n_best
@@ -391,9 +387,6 @@ class ServerModel(object):
 
         try:
             if self.ct2_model is not None:
-                print("Load CT2 model")
-                print(self.ct2_model)
-                print(os.path.exists(self.ct2_model))
                 self.translator = CTranslate2Translator(
                     self.ct2_model,
                     device="cuda",

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -257,7 +257,8 @@ class ServerModel(object):
         self.timeout = timeout
         self.on_timeout = on_timeout
 
-        self.ct2_model = os.path.join(model_root, ct2_model)
+        self.ct2_model = os.path.join(model_root, ct2_model) \
+                         if ct2_model is not None else None
 
         self.unload_timer = None
         self.user_opt = opt

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -76,7 +76,8 @@ class ServerModelError(Exception):
 
 class CTranslate2Translator(object):
     """
-    This should reproduce the onmt.translate.translator API.
+    This class wraps the ctranslate2.Translator object to
+    reproduce the onmt.translate.translator API.
     """
 
     def __init__(self, model_path, device, device_index,
@@ -93,9 +94,10 @@ class CTranslate2Translator(object):
         self.beam_size = beam_size
         self.n_best = n_best
         if preload:
-            # perform a first request to initialize stuff
+            # perform a first request to initialize everything
             dummy_translation = self.translate(["a"])
-            print("#####", dummy_translation)
+            print("Performed a dummy translation to initialize the model",
+                  dummy_translation)
             time.sleep(1)
             self.translator.unload_model(to_cpu=True)
 
@@ -585,7 +587,6 @@ class ServerModel(object):
     @critical
     def unload(self):
         self.logger.info("Unloading model %d" % self.model_id)
-        # TODO: adapt this for CT2
         del self.translator
         if self.opt.cuda:
             torch.cuda.empty_cache()

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -79,7 +79,8 @@ class CTranslate2Translator(object):
     This should reproduce the onmt.translate.translator API.
     """
 
-    def __init__(self, model_path, device, device_index, beam_size, n_best):
+    def __init__(self, model_path, device, device_index,
+                 batch_size, beam_size, n_best):
         import ctranslate2
         import time
         beg = time.time()
@@ -92,6 +93,7 @@ class CTranslate2Translator(object):
             compute_type="default")
         duration = time.time() - beg
         print("########## LOADING TIME", duration)
+        self.batch_size = batch_size
         self.beam_size = beam_size
         self.n_best = n_best
 
@@ -99,6 +101,7 @@ class CTranslate2Translator(object):
         batch = [item.split(" ") for item in texts_to_translate]
         preds = self.translator.translate_batch(
             batch,
+            max_batch_size=self.batch_size,
             beam_size=self.beam_size,
             num_hypotheses=self.n_best
         )
@@ -395,6 +398,7 @@ class ServerModel(object):
                     self.ct2_model,
                     device="cuda",
                     device_index=self.opt.gpu,
+                    batch_size=self.opt.batch_size,
                     beam_size=self.opt.beam_size,
                     n_best=self.opt.n_best)
             else:

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -337,6 +337,7 @@ class ServerModel(object):
 
         if load:
             self.load(preload=True)
+            self.stop_unload_timer()
 
     def parse_opt(self, opt):
         """Parse the option set passed by the user using `onmt.opts`

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -258,7 +258,7 @@ class ServerModel(object):
         self.on_timeout = on_timeout
 
         self.ct2_model = os.path.join(model_root, ct2_model) \
-                         if ct2_model is not None else None
+            if ct2_model is not None else None
 
         self.unload_timer = None
         self.user_opt = opt

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -70,6 +70,7 @@ class Timer:
 class ServerModelError(Exception):
     pass
 
+
 class CTranslate2Translator(object):
     """
     This should reproduce the onmt.translate.translator API.
@@ -99,7 +100,8 @@ class CTranslate2Translator(object):
             num_hypotheses=self.n_best
         )
         scores = [[item["score"] for item in ex] for ex in preds]
-        predictions = [[" ".join(item["tokens"]) for item in ex] for ex in preds]
+        predictions = [[" ".join(item["tokens"]) for item in ex]
+                       for ex in preds]
         return scores, predictions
 
     def to_cpu(self):
@@ -392,10 +394,9 @@ class ServerModel(object):
                     beam_size=self.opt.beam_size,
                     n_best=self.opt.n_best)
             else:
-                self.translator = build_translator(self.opt,
-                                               report_score=False,
-                                               out_file=codecs.open(
-                                                   os.devnull, "w", "utf-8"))
+                self.translator = build_translator(
+                    self.opt, report_score=False,
+                    out_file=codecs.open(os.devnull, "w", "utf-8"))
         except RuntimeError as e:
             raise ServerModelError("Runtime Error: %s" % str(e))
 
@@ -501,7 +502,7 @@ class ServerModel(object):
         scores = [score_tensor
                   for score_tensor in flatten_list(scores)]
         if type(scores[0]) == torch.Tensor:
-            scores = [x.item() for score in scores]
+            scores = [score.item() for score in scores]
 
         results = [self.maybe_detokenize_with_align(result, src)
                    for result, src in zip(results, tiled_texts)]

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -89,11 +89,15 @@ class CTranslate2Translator(object):
             inter_threads=1,
             intra_threads=1,
             compute_type="default")
-        if preload:
-            self.translator.unload_model(to_cpu=True)
         self.batch_size = batch_size
         self.beam_size = beam_size
         self.n_best = n_best
+        if preload:
+            # perform a first request to initialize stuff
+            dummy_translation = self.translate(["a"])
+            print("#####", dummy_translation)
+            time.sleep(1)
+            self.translator.unload_model(to_cpu=True)
 
     def translate(self, texts_to_translate, batch_size=8):
         batch = [item.split(" ") for item in texts_to_translate]


### PR DESCRIPTION
This PR adds the support of CTranslate2 models via the `ctranslate2.Translator` python class.
For now, if a model has a `"ct2_model`" defined, then it will be used, else it will fall back to the pytorch one.
We could probably add a `"model_format"` parameter if ever there were more formats to come in the future.

Note: when preloading a model at startup, it will perform a dummy translation to initialize everything. Without this, preloading is fairly useless as there are some time consuming initialization steps performed on the first inference.