### PR TITLE
Update translation.py

### DIFF
--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -53,7 +53,7 @@ class TranslationBuilder(object):
                     if self.phrase_table != "":
                         with open(self.phrase_table, "r") as f:
                             for line in f:
-                                if line.startswith(src_raw[max_index.item()]):
+                                if line.startswith(src_raw[max_index.item()]+"|||"):
                                     tokens[i] = line.split('|||')[1].strip()
         return tokens
 

--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -1,6 +1,7 @@
 """ Translation main class """
 from __future__ import unicode_literals, print_function
 
+import os
 import torch
 from onmt.inputters.text_dataset import TextMultiField
 from onmt.utils.alignment import build_align_pharaoh
@@ -32,8 +33,8 @@ class TranslationBuilder(object):
         self.replace_unk = replace_unk
         self.phrase_table_dict = {}
         if phrase_table !="" and os.path.exists(phrase_table):
-            with fd as open(phrase_table):
-                for line in fd:
+            with open(phrase_table) as phrase_table_fd:
+                for line in phrase_table_fd:
                     phrase_src, phrase_trg = line.rstrip("\n").split("|||")
                     self.phrase_table_dict[phrase_src] = phrase_trg
         self.has_tgt = has_tgt

--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -32,7 +32,7 @@ class TranslationBuilder(object):
         self.n_best = n_best
         self.replace_unk = replace_unk
         self.phrase_table_dict = {}
-        if phrase_table !="" and os.path.exists(phrase_table):
+        if phrase_table != "" and os.path.exists(phrase_table):
             with open(phrase_table) as phrase_table_fd:
                 for line in phrase_table_fd:
                     phrase_src, phrase_trg = line.rstrip("\n").split("|||")


### PR DESCRIPTION
Fixing a problem with tokens matching only a prefix of a source word in the phrase table.

Let's assume we have the following line in the phrase table:
orkstadt|||goblin-town

Then, when OpenNMT looks for a replacement for the word "orks", it will pick "goblin-town" since the line starts with "orks", even though it only constitutes the prefix of the source word.

The pull request fixes this problem. Also, the phrase table is now stored as a dictionary. This means that we don't have to read the phrase table file every single time a <UNK> token appears.