### PR TITLE
Fix alignment error when prediction have no valid token

### DIFF
--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -657,7 +657,8 @@ class ServerModel(object):
         if self.opt.report_align:
             # output contain alignment
             sequence, align = sequence.split(' ||| ')
-            align = self.maybe_convert_align(src, sequence, align)
+            if align != '':
+                align = self.maybe_convert_align(src, sequence, align)
         sequence = self.maybe_detokenize(sequence)
         return (sequence, align)
 


### PR DESCRIPTION
This PR fixes the error when extract alignment from a prediction with no valid tokens.
This rarely happens only when src has only a few special tokens while its prediction early stops with no valid token other than `<bos>`, `<eos>`, and `<pad>`.