### PR TITLE
dump input encoding feature added

### DIFF
--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -645,6 +645,8 @@ def translate_opts(parser):
               help="Report alignment for each translation.")
     group.add('--report_time', '-report_time', action='store_true',
               help="Report some translation time metrics")
+    group.add('--dump_input_encoding', '-dump_input_encoding', action='store_true',
+              help="Dump sentence encodings to a file")
 
     # Options most relevant to summarization.
     group.add('--dynamic_dict', '-dynamic_dict', action='store_true',


### PR DESCRIPTION
Added dump input encoding feature, which dumps sentence encodings (from a trained encoder model) to a text file.  

Python translation of [the corresponding OpenNMT-Lua feature](https://github.com/OpenNMT/OpenNMT/pull/176)