### PR TITLE
A bit more flexibility to REST server pre/postprocess functions

### DIFF
--- a/onmt/translate/process_zh.py
+++ b/onmt/translate/process_zh.py
@@ -15,35 +15,35 @@ def wrap_str_func(func):
 
 # Chinese segmentation
 @wrap_str_func
-def zh_segmentator(line):
+def zh_segmentator(line, server_model):
     return " ".join(pkuseg.pkuseg().cut(line))
 
 
 # Chinese simplify -> Chinese traditional standard
 @wrap_str_func
-def zh_traditional_standard(line):
+def zh_traditional_standard(line, server_model):
     return HanLP.convertToTraditionalChinese(line)
 
 
 # Chinese simplify -> Chinese traditional (HongKong)
 @wrap_str_func
-def zh_traditional_hk(line):
+def zh_traditional_hk(line, server_model):
     return HanLP.s2hk(line)
 
 
 # Chinese simplify -> Chinese traditional (Taiwan)
 @wrap_str_func
-def zh_traditional_tw(line):
+def zh_traditional_tw(line, server_model):
     return HanLP.s2tw(line)
 
 
 # Chinese traditional -> Chinese simplify (v1)
 @wrap_str_func
-def zh_simplify(line):
+def zh_simplify(line, server_model):
     return HanLP.convertToSimplifiedChinese(line)
 
 
 # Chinese traditional -> Chinese simplify (v2)
 @wrap_str_func
-def zh_simplify_v2(line):
+def zh_simplify_v2(line, server_model):
     return SnowNLP(line).han

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -592,7 +592,7 @@ class ServerModel(object):
         if self.preprocessor is None:
             raise ValueError("No preprocessor loaded")
         for function in self.preprocessor:
-            sequence = function(sequence)
+            sequence = function(sequence, self)
         return sequence
 
     def maybe_tokenize(self, sequence):
@@ -723,7 +723,7 @@ class ServerModel(object):
         if self.postprocessor is None:
             raise ValueError("No postprocessor loaded")
         for function in self.postprocessor:
-            sequence = function(sequence)
+            sequence = function(sequence, self)
         return sequence
 
 


### PR DESCRIPTION
We just pass the `self` `ServerModel` object to any preprocessing or postprocessing function.
This allows more flexibility for potential custom functions.