### PR TITLE
fix sequence_mask with None lengths

### DIFF
--- a/onmt/utils/misc.py
+++ b/onmt/utils/misc.py
@@ -45,6 +45,8 @@ def sequence_mask(lengths, max_len=None):
     """
     Creates a boolean mask from sequence lengths.
     """
+    if lengths is None:
+        return None
     batch_size = lengths.numel()
     max_len = max_len or lengths.max()
     return (torch.arange(0, max_len, device=lengths.device)


### PR DESCRIPTION
the code location: `encoders/transformer.py`:

```python
class TransformerEncoder(EncoderBase):
    ...
    def forward(self, src, lengths=None):
        """See :func:`EncoderBase.forward()`"""
        self._check_args(src, lengths)

        emb = self.embeddings(src)

        out = emb.transpose(0, 1).contiguous()
        mask = ~sequence_mask(lengths).unsqueeze(1)
        # Run the forward pass of every layer of the tranformer.
        for layer in self.transformer:
            out = layer(out, mask)
        out = self.layer_norm(out)
```

here when `lengths` is None, `mask = ~sequence_mask(lengths).unsqueeze(1)`  will return a 
`AttributeError: 'NoneType' object has no attribute 'numel'`, so it means that I should always need to pass a `lengths` here to replace the default `None`.