### PR TITLE
[fix] Filter out datasets with weight <=0 in MultipleDatasetIterator

### DIFF
--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -716,11 +716,14 @@ class MultipleDatasetIterator(object):
                  opt):
         self.index = -1
         self.iterables = []
-        for shard in train_shards:
-            self.iterables.append(
-                build_dataset_iter(shard, fields, opt, multi=True))
+        self.weights = []
+        for shard, weight in zip(train_shards, opt.data_weights):
+            if weight > 0:
+                self.iterables.append(
+                    build_dataset_iter(shard, fields, opt, multi=True))
+                self.weights.append(weight)
         self.init_iterators = True
-        self.weights = opt.data_weights
+        # self.weights = opt.data_weights
         self.batch_size = opt.batch_size
         self.batch_size_fn = max_tok_len \
             if opt.batch_type == "tokens" else None


### PR DESCRIPTION
1. Useless to have such datasets be initialised.
2. May cause some issues in this hack where we take the `.dataset` of the first item in the list:
https://github.com/OpenNMT/OpenNMT-py/blob/c20dbeac02688918607637f5f30ec73c0f17d817/onmt/inputters/inputter.py#L760-L762

Thanks @Zenglinxiao for noticing!