### PR TITLE
fix indexerror for guided alignment model 

### DIFF
--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -401,10 +401,7 @@ class Translator(object):
                         os.write(1, output.encode('utf-8'))
 
                 if align_debug:
-                    if trans.gold_sent is not None:
-                        tgts = trans.gold_sent
-                    else:
-                        tgts = trans.pred_sents[0]
+                    tgts = trans.pred_sents[0]
                     align = trans.word_aligns[0].tolist()
                     if self.data_type == 'text':
                         srcs = trans.src_raw
@@ -474,11 +471,8 @@ class Translator(object):
         alignment src indice Tensor in size ``(batch, n_best,)``.
         """
         # (0) add BOS and padding to tgt prediction
-        if hasattr(batch, 'tgt'):
-            batch_tgt_idxs = batch.tgt.transpose(1, 2).transpose(0, 2)
-        else:
-            batch_tgt_idxs = self._align_pad_prediction(
-                predictions, bos=self._tgt_bos_idx, pad=self._tgt_pad_idx)
+        batch_tgt_idxs = self._align_pad_prediction(
+            predictions, bos=self._tgt_bos_idx, pad=self._tgt_pad_idx)
         tgt_mask = (batch_tgt_idxs.eq(self._tgt_pad_idx) |
                     batch_tgt_idxs.eq(self._tgt_eos_idx) |
                     batch_tgt_idxs.eq(self._tgt_bos_idx))


### PR DESCRIPTION
Fix IndexError appears for the guided alignment model in the condition of passing -tgt with -replace_token option on as indicated in #1787 .

Previously, before we enable the option `-replace_unk` for the guided alignment model, we intend to get the alignment between `-src` and `-tgt` if golden tgt is passed as a way to debug and test the performance of alignment. This will not raise conflicts the time when we haven't enable the alignment for unknown token replacement. But becoming an issue as we now enable the alignment matrix to be used to align the correct src token if an unknown token is detected in the prediction. This implicit handling makes the replacement inconsistent as the alignment matrix used in the replace_unk is actually the alignment between src and golden tgt rather than the prediction.

In this PR, we, therefore, remove this implicit handling, if one would like to just verify the alignment quality, they can always add these lines on and set -replace_unk to false to avoid this conflict.