### PR TITLE
[docs] Fix docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx==2.4.4
 sphinxcontrib.bibtex
 sphinxcontrib.mermaid
 sphinx-rtd-theme

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,7 @@ Contents
       im2text.md
       speech2text.md
       vid2text.rst
+      ggnn.md
 
 
 .. toctree::


### PR DESCRIPTION
This PR was originally made to try and understand why some pages are missing from the docs.

It seems sphinx 3.0.3 is at fault here. Staying with 2.4.4 for now.