### PR TITLE
add target_prefix decoding feature

### DIFF
--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -651,6 +651,8 @@ def translate_opts(parser):
               help='Source directory for image or audio files')
     group.add('--tgt', '-tgt',
               help='True target sequence (optional)')
+    group.add('--tgt_prefix', '-tgt_prefix', action='store_true',
+              help='Generate predictions using provided `-tgt` as prefix.')
     group.add('--shard_size', '-shard_size', type=int, default=10000,
               help="Divide src and tgt (if applicable) into "
                    "smaller multiple src and tgt files, then "

--- a/onmt/translate/greedy_search.py
+++ b/onmt/translate/greedy_search.py
@@ -91,7 +91,8 @@ class GreedySearch(DecodeStrategy):
         self.keep_topk = keep_topk
         self.topk_scores = None
 
-    def initialize(self, memory_bank, src_lengths, src_map=None, device=None):
+    def initialize(self, memory_bank, src_lengths, src_map=None, device=None,
+                   target_prefix=None):
         """Initialize for decoding."""
         fn_map_state = None
 
@@ -104,7 +105,7 @@ class GreedySearch(DecodeStrategy):
 
         self.memory_lengths = src_lengths
         super(GreedySearch, self).initialize(
-            memory_bank, src_lengths, src_map, device)
+            memory_bank, src_lengths, src_map, device, target_prefix)
         self.select_indices = torch.arange(
             self.batch_size, dtype=torch.long, device=device)
         self.original_batch_idx = torch.arange(
@@ -118,6 +119,18 @@ class GreedySearch(DecodeStrategy):
     @property
     def batch_offset(self):
         return self.select_indices
+
+    def _pick(self, log_probs):
+        """Function used to pick next tokens.
+
+        Args:
+            log_probs (FloatTensor): ``(batch_size, vocab_size)``.
+        """
+        # maybe fix some prediction at this step by modifying log_probs
+        log_probs = self.target_prefixing(log_probs)
+        topk_ids, topk_scores = sample_with_temperature(
+            log_probs, self.sampling_temp, self.keep_topk)
+        return topk_ids, topk_scores
 
     def advance(self, log_probs, attn):
         """Select next tokens randomly from the top k possible next tokens.
@@ -134,8 +147,8 @@ class GreedySearch(DecodeStrategy):
 
         self.ensure_min_length(log_probs)
         self.block_ngram_repeats(log_probs)
-        topk_ids, self.topk_scores = sample_with_temperature(
-            log_probs, self.sampling_temp, self.keep_topk)
+
+        topk_ids, self.topk_scores = self._pick(log_probs)
 
         self.is_finished = topk_ids.eq(self.eos)
 
@@ -167,3 +180,4 @@ class GreedySearch(DecodeStrategy):
             self.alive_attn = self.alive_attn[:, is_alive]
         self.select_indices = is_alive.nonzero().view(-1)
         self.original_batch_idx = self.original_batch_idx[is_alive]
+        self.maybe_update_target_prefix(self.select_indices)

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -90,6 +90,7 @@ class Translator(object):
         ignore_when_blocking (set or frozenset): See
             :class:`onmt.translate.decode_strategy.DecodeStrategy`.
         replace_unk (bool): Replace unknown token.
+        tgt_prefix (bool): Force the predictions begin with provided -tgt.
         data_type (str): Source data type.
         verbose (bool): Print/log every translation.
         report_time (bool): Print/log total time/frequency.
@@ -120,6 +121,7 @@ class Translator(object):
             block_ngram_repeat=0,
             ignore_when_blocking=frozenset(),
             replace_unk=False,
+            tgt_prefix=False,
             phrase_table="",
             data_type="text",
             verbose=False,
@@ -167,6 +169,7 @@ class Translator(object):
         if self.replace_unk and not self.model.decoder.attentional:
             raise ValueError(
                 "replace_unk requires an attentional decoder.")
+        self.tgt_prefix = tgt_prefix
         self.phrase_table = phrase_table
         self.data_type = data_type
         self.verbose = verbose
@@ -249,6 +252,7 @@ class Translator(object):
             block_ngram_repeat=opt.block_ngram_repeat,
             ignore_when_blocking=set(opt.ignore_when_blocking),
             replace_unk=opt.replace_unk,
+            tgt_prefix=opt.tgt_prefix,
             phrase_table=opt.phrase_table,
             data_type=opt.data_type,
             verbose=opt.verbose,
@@ -652,8 +656,10 @@ class Translator(object):
 
         # (2) prep decode_strategy. Possibly repeat src objects.
         src_map = batch.src_map if use_src_map else None
+        target_prefix = batch.tgt if self.tgt_prefix else None
         fn_map_state, memory_bank, memory_lengths, src_map = \
-            decode_strategy.initialize(memory_bank, src_lengths, src_map)
+            decode_strategy.initialize(memory_bank, src_lengths, src_map,
+                                       target_prefix=target_prefix)
         if fn_map_state is not None:
             self.model.decoder.map_state(fn_map_state)
 

--- a/onmt/utils/parse.py
+++ b/onmt/utils/parse.py
@@ -124,6 +124,8 @@ class ArgumentParser(cfargparse.ArgumentParser):
     def validate_translate_opts(cls, opt):
         if opt.beam_size != 1 and opt.random_sampling_topk != 1:
             raise ValueError('Can either do beam search OR random sampling.')
+        if opt.tgt_prefix and opt.tgt is None:
+            raise ValueError('Prefix should be feed by -tgt if -tgt_prefix.')
 
     @classmethod
     def validate_preprocess_args(cls, opt):


### PR DESCRIPTION
In this PR, the prefix decoding feature is added, enable us to generate the prediction begin with provided lines as prefix.
To use this feature, we need to pass the prefix file as `-tgt`, and specify `-tgt_prefix` to enable this feature.