### PR TITLE
Removed version freeze from tqdm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     },
     install_requires=[
         "six",
-        "tqdm~=4.30.0",
+        "tqdm",
         "torch>=1.4.0",
         "torchtext==0.4.0",
         "future",


### PR DESCRIPTION
The version of the dependency tqdm was frozen due to some problems connected with travis, see #1278 
I verified that the current version of tqdm works with travis, see https://travis-ci.org/github/akreuzer/OpenNMT-py/builds/692003183
Therefore, one should unfreeze the version. This will help to avoid some decency conflicts this may have caused.