### PR TITLE
Add flag to override batch_size_multiple

### DIFF
--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -727,7 +727,10 @@ class MultipleDatasetIterator(object):
         self.batch_size = opt.batch_size
         self.batch_size_fn = max_tok_len \
             if opt.batch_type == "tokens" else None
-        self.batch_size_multiple = 8 if opt.model_dtype == "fp16" else 1
+        if opt.batch_size_multiple is not None:
+            self.batch_size_multiple = opt.batch_size_multiple
+        else:
+            self.batch_size_multiple = 8 if opt.model_dtype == "fp16" else 1
         self.device = device
         # Temporarily load one shard to retrieve sort_key for data_type
         temp_dataset = torch.load(self.iterables[0]._paths[0])

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -454,6 +454,9 @@ def train_opts(parser):
     group = parser.add_argument_group('Optimization- Type')
     group.add('--batch_size', '-batch_size', type=int, default=64,
               help='Maximum batch size for training')
+    group.add('--batch_size_multiple', '-batch_size_multiple',
+              type=int, default=None,
+              help='Batch size multiple for token batches.')
     group.add('--batch_type', '-batch_type', default='sents',
               choices=["sents", "tokens"],
               help="Batch grouping for batch_size. Standard "


### PR DESCRIPTION
For now when `-model_dtype` is `fp16`, `batch_size_multiple` is automatically set to 8 in `onmt.inputters.inputter` (to optimize usage of tensor cores). Though, in some cases it may cause more harm than good and it can be useful to disable it.

Hence, this PR introduces the `-batch_size_multiple` flag to override with a specific value.