### PR TITLE
add custom_opt in REST server

### DIFF
--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -151,6 +151,7 @@ class TranslationServer(object):
                       'preprocess_opt': conf.get('preprocess', None),
                       'tokenizer_opt': conf.get('tokenizer', None),
                       'postprocess_opt': conf.get('postprocess', None),
+                      'custom_opt': conf.get('custom_opt', None),
                       'on_timeout': conf.get('on_timeout', None),
                       'model_root': conf.get('model_root', self.models_root),
                       'ct2_model': conf.get('ct2_model', None)
@@ -245,10 +246,10 @@ class ServerModel(object):
         opt (dict): Options for the Translator
         model_id (int): Model ID
         preprocess_opt (list): Options for preprocess processus or None
-                               (extend for CJK)
         tokenizer_opt (dict): Options for the tokenizer or None
         postprocess_opt (list): Options for postprocess processus or None
-                                (extend for CJK)
+        custom_opt (dict): Custom options, can be used within preprocess or
+            postprocess, default None
         load (bool): whether to load the model during :func:`__init__()`
         timeout (int): Seconds before running :func:`do_timeout()`
             Negative values means no timeout
@@ -259,10 +260,11 @@ class ServerModel(object):
     """
 
     def __init__(self, opt, model_id, preprocess_opt=None, tokenizer_opt=None,
-                 postprocess_opt=None, load=False, timeout=-1,
+                 postprocess_opt=None, custom_opt=None, load=False, timeout=-1,
                  on_timeout="to_cpu", model_root="./", ct2_model=None):
         self.model_root = model_root
         self.opt = self.parse_opt(opt)
+        self.custom_opt = custom_opt
 
         self.model_id = model_id
         self.preprocess_opt = preprocess_opt

--- a/requirements.opt.txt
+++ b/requirements.opt.txt
@@ -1,7 +1,7 @@
 cffi
 torchvision
 joblib
-librosa
+librosa<0.8
 Pillow
 git+git://github.com/pytorch/audio.git@d92de5b97fc6204db4b1e3ed20c03ac06f5d53f0
 pyrouge

--- a/requirements.opt.txt
+++ b/requirements.opt.txt
@@ -1,7 +1,9 @@
 cffi
 torchvision
 joblib
-librosa<0.8
+librosa
+numba==0.43.0
+llvmlite==0.32.1
 Pillow
 git+git://github.com/pytorch/audio.git@d92de5b97fc6204db4b1e3ed20c03ac06f5d53f0
 pyrouge


### PR DESCRIPTION
In this PR, we add a `custom_opt` in `ServerModel` so that external function like `preprocess`/`postprocess` can be configurable.

Note: we also pin `numba==0.43.0` and `llvmlite==0.32.1` in `requirements.opt.txt` to allow travis to run (https://github.com/librosa/librosa/issues/1160 // https://github.com/deezer/spleeter/issues/419)