### PR TITLE
Better warning for batch_size_multiple overflow

### DIFF
--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -605,7 +605,7 @@ def batch_iter(data, batch_size, batch_size_fn=None, batch_size_multiple=1):
                 if overflowed == len(minibatch):
                     logger.warning(
                         "The batch will be filled until we reach %d,"
-                        "its size may go over %d tokens" % (batch_size_multiple, batch_size)
+                        "its size may exceed %d tokens" % (batch_size_multiple, batch_size)
                         )
                 else:
                     yield minibatch[:-overflowed]

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -605,7 +605,8 @@ def batch_iter(data, batch_size, batch_size_fn=None, batch_size_multiple=1):
                 if overflowed == len(minibatch):
                     logger.warning(
                         "The batch will be filled until we reach %d,"
-                        "its size may exceed %d tokens" % (batch_size_multiple, batch_size)
+                        "its size may exceed %d tokens"
+                        % (batch_size_multiple, batch_size)
                         )
                 else:
                     yield minibatch[:-overflowed]

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -604,8 +604,9 @@ def batch_iter(data, batch_size, batch_size_fn=None, batch_size_multiple=1):
             else:
                 if overflowed == len(minibatch):
                     logger.warning(
-                        "An example was ignored, more tokens"
-                        " than allowed by tokens batch_size")
+                        "The batch will be filled until we reach %d,"
+                        "its size may go over %d tokens" % (batch_size_multiple, batch_size)
+                        )
                 else:
                     yield minibatch[:-overflowed]
                     minibatch = minibatch[-overflowed:]


### PR DESCRIPTION
Warning was quite misleading. No example is ignored, the only issue is that final batch size may exceed the set value.