### PR TITLE
Fix --data_type vec to not build vocabulary with tensors as keys.

### DIFF
--- a/onmt/bin/preprocess.py
+++ b/onmt/bin/preprocess.py
@@ -71,7 +71,7 @@ def process_one_shard(corpus_params, params):
             sub_sub_counter['corpus_id'].update(
                 ["train" if maybe_id is None else maybe_id])
             for name, field in fields.items():
-                if (opt.data_type  in ["audio", "vec"]) and name == "src":
+                if (opt.data_type in ["audio", "vec"]) and name == "src":
                     continue
                 try:
                     f_iter = iter(field)

--- a/onmt/bin/preprocess.py
+++ b/onmt/bin/preprocess.py
@@ -71,7 +71,7 @@ def process_one_shard(corpus_params, params):
             sub_sub_counter['corpus_id'].update(
                 ["train" if maybe_id is None else maybe_id])
             for name, field in fields.items():
-                if ((opt.data_type == "audio") and (name == "src")):
+                if (opt.data_type  in ["audio", "vec"]) and name == "src":
                     continue
                 try:
                     f_iter = iter(field)
@@ -87,8 +87,7 @@ def process_one_shard(corpus_params, params):
                                 (sub_n == 'tgt' and
                                  tgt_vocab is not None)
                     if (hasattr(sub_f, 'sequential')
-                            and sub_f.sequential and not has_vocab
-                            and not (sub_n == 'src' and opt.data_type == 'vec')):
+                            and sub_f.sequential and not has_vocab):
                         val = fd
                         sub_sub_counter[sub_n].update(val)
     if maybe_id:

--- a/onmt/bin/preprocess.py
+++ b/onmt/bin/preprocess.py
@@ -87,7 +87,8 @@ def process_one_shard(corpus_params, params):
                                 (sub_n == 'tgt' and
                                  tgt_vocab is not None)
                     if (hasattr(sub_f, 'sequential')
-                            and sub_f.sequential and not has_vocab):
+                            and sub_f.sequential and not has_vocab
+                            and not (sub_n == 'src' and opt.data_type == 'vec')):
                         val = fd
                         sub_sub_counter[sub_n].update(val)
     if maybe_id:


### PR DESCRIPTION
When using --data_type vec, the logic in `process_one_shard` in onmt/bin/preprocess.py adds each feature vector into the source vocabulary. Besides being unnecessary (I think it's not finally saved in the vocabulary file), this causes the preprocessing to fail if there are enough vectors because the torch.multiprocessing worker assigns each of them a shared memory segment and a file handle, which are fairly limited resources, when sending the vocabulary to a different thread:

```
$ onmt_preprocess --data_type vec --train_src nt/vec_files.txt --train_tgt nt/tokens.txt --valid_src ot/vec_files.txt --valid_tgt ot/tokens.txt --save_data data --shard_size 10240
[2020-07-21 01:45:40,163 INFO] Extracting features...
[2020-07-21 01:45:40,163 INFO]  * number of source features: 0.
[2020-07-21 01:45:40,163 INFO]  * number of target features: 0.
[2020-07-21 01:45:40,163 INFO] Building `Fields` object...
[2020-07-21 01:45:40,163 INFO] Building & saving training data...
[2020-07-21 01:45:40,176 INFO] Building shard 0.
[2020-07-21 01:45:43,329 INFO]  * saving 0th train data shard to data.train.0.pt.
Traceback (most recent call last):
  File "/home/sliedes/.virtualenvs/torch/bin/onmt_preprocess", line 11, in <module>
    load_entry_point('OpenNMT-py==1.1.1', 'console_scripts', 'onmt_preprocess')()
  File "/home/sliedes/.virtualenvs/torch/lib/python3.7/site-packages/OpenNMT_py-1.1.1-py3.7.egg/onmt/bin/preprocess.py", line 318, in main
    preprocess(opt)
  File "/home/sliedes/.virtualenvs/torch/lib/python3.7/site-packages/OpenNMT_py-1.1.1-py3.7.egg/onmt/bin/preprocess.py", line 298, in preprocess
    'train', fields, src_reader, tgt_reader, align_reader, opt)
  File "/home/sliedes/.virtualenvs/torch/lib/python3.7/site-packages/OpenNMT_py-1.1.1-py3.7.egg/onmt/bin/preprocess.py", line 205, in build_save_dataset
    for sub_counter in p.imap(func, shard_iter):
  File "/usr/lib64/python3.7/multiprocessing/pool.py", line 748, in next
    raise value
multiprocessing.pool.MaybeEncodingError: Error sending result: 'defaultdict(<class 'collections.Counter'>, {'corpus_id': Counter({'train': 7792}), 'src': Counter({tensor([[-0.6644, -0.9650, -0.2900,  ...,  0.3563,  0.1208,  0.7932]]): 1, tensor([[ 0.6627,  0.0143, -0.0535,  ...,  0.2826,  0.0892, -0.1179]]): 1, <<<...16M characters removed...>>>'. Reason: 'RuntimeError('unable to open shared memory object </torch_2455337_591996840> in read-write mode')'
```

This PR is a minimal fix for this problem.