### PR TITLE
Add patience to tensorboard logging

### DIFF
--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -204,7 +204,7 @@ class Trainer(object):
             self.moving_average = copy_params
         else:
             average_decay = max(self.average_decay,
-                                1 - (step + 1)/(step + 10))
+                                1 - (step + 1) / (step + 10))
             for (i, avg), cpt in zip(enumerate(self.moving_average),
                                      self.model.parameters()):
                 self.moving_average[i] = \
@@ -295,8 +295,8 @@ class Trainer(object):
                         break
 
             if (self.model_saver is not None
-                and (save_checkpoint_steps != 0
-                     and step % save_checkpoint_steps == 0)):
+                    and (save_checkpoint_steps != 0
+                         and step % save_checkpoint_steps == 0)):
                 self.model_saver.save(step, moving_average=self.moving_average)
 
             if train_steps > 0 and step >= train_steps:
@@ -331,7 +331,7 @@ class Trainer(object):
 
             for batch in valid_iter:
                 src, src_lengths = batch.src if isinstance(batch.src, tuple) \
-                                   else (batch.src, None)
+                    else (batch.src, None)
                 tgt = batch.tgt
 
                 # F-prop through the model.
@@ -376,7 +376,7 @@ class Trainer(object):
             tgt_outer = batch.tgt
 
             bptt = False
-            for j in range(0, target_size-1, trunc_size):
+            for j in range(0, target_size - 1, trunc_size):
                 # 1. Create truncated target.
                 tgt = tgt_outer[j: j + trunc_size]
 
@@ -472,7 +472,12 @@ class Trainer(object):
         """
         if self.report_manager is not None:
             return self.report_manager.report_training(
-                step, num_steps, learning_rate, report_stats,
+                step,
+                num_steps,
+                learning_rate,
+                None if self.earlystopper is None
+                else self.earlystopper.current_tolerance,
+                report_stats,
                 multigpu=self.n_gpu > 1)
 
     def _report_step(self, learning_rate, step, train_stats=None,
@@ -484,7 +489,8 @@ class Trainer(object):
         if self.report_manager is not None:
             return self.report_manager.report_step(
                 learning_rate,
-                None if self.earlystopper is None else self.earlystopper.current_tolerance,
+                None if self.earlystopper is None
+                else self.earlystopper.current_tolerance,
                 step, train_stats=train_stats,
                 valid_stats=valid_stats)
 

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -483,7 +483,9 @@ class Trainer(object):
         """
         if self.report_manager is not None:
             return self.report_manager.report_step(
-                learning_rate, step, train_stats=train_stats,
+                learning_rate,
+                None if self.earlystopper is None else self.earlystopper.current_tolerance,
+                step, train_stats=train_stats,
                 valid_stats=valid_stats)
 
     def maybe_noise_source(self, batch):

--- a/onmt/utils/report_manager.py
+++ b/onmt/utils/report_manager.py
@@ -49,7 +49,7 @@ class ReportMgrBase(object):
     def log(self, *args, **kwargs):
         logger.info(*args, **kwargs)
 
-    def report_training(self, step, num_steps, learning_rate,
+    def report_training(self, step, num_steps, learning_rate, patience,
                         report_stats, multigpu=False):
         """
         This is the user-defined batch-level traing progress
@@ -72,7 +72,7 @@ class ReportMgrBase(object):
                 report_stats = \
                     onmt.utils.Statistics.all_gather_stats(report_stats)
             self._report_training(
-                step, num_steps, learning_rate, report_stats)
+                step, num_steps, learning_rate, patience, report_stats)
             return onmt.utils.Statistics()
         else:
             return report_stats
@@ -81,7 +81,8 @@ class ReportMgrBase(object):
         """ To be overridden """
         raise NotImplementedError()
 
-    def report_step(self, lr, patience, step, train_stats=None, valid_stats=None):
+    def report_step(self, lr, patience, step, train_stats=None,
+                    valid_stats=None):
         """
         Report stats of a step
 
@@ -93,7 +94,9 @@ class ReportMgrBase(object):
             valid_stats(Statistics): validation stats
         """
         self._report_step(
-            lr, patience, step, train_stats=train_stats, valid_stats=valid_stats)
+            lr, patience, step,
+            train_stats=train_stats,
+            valid_stats=valid_stats)
 
     def _report_step(self, *args, **kwargs):
         raise NotImplementedError()
@@ -113,12 +116,13 @@ class ReportMgr(ReportMgrBase):
         super(ReportMgr, self).__init__(report_every, start_time)
         self.tensorboard_writer = tensorboard_writer
 
-    def maybe_log_tensorboard(self, stats, prefix, learning_rate, patience, step):
+    def maybe_log_tensorboard(self, stats, prefix, learning_rate,
+                              patience, step):
         if self.tensorboard_writer is not None:
             stats.log_tensorboard(
                 prefix, self.tensorboard_writer, learning_rate, patience, step)
 
-    def _report_training(self, step, num_steps, learning_rate,
+    def _report_training(self, step, num_steps, learning_rate, patience,
                          report_stats):
         """
         See base class method `ReportMgrBase.report_training`.
@@ -135,7 +139,9 @@ class ReportMgr(ReportMgrBase):
 
         return report_stats
 
-    def _report_step(self, lr, patience, step, train_stats=None, valid_stats=None):
+    def _report_step(self, lr, patience, step,
+                     train_stats=None,
+                     valid_stats=None):
         """
         See base class method `ReportMgrBase.report_step`.
         """

--- a/onmt/utils/report_manager.py
+++ b/onmt/utils/report_manager.py
@@ -81,17 +81,19 @@ class ReportMgrBase(object):
         """ To be overridden """
         raise NotImplementedError()
 
-    def report_step(self, lr, step, train_stats=None, valid_stats=None):
+    def report_step(self, lr, patience, step, train_stats=None, valid_stats=None):
         """
         Report stats of a step
 
         Args:
+            lr(float): current learning rate
+            patience(int): current patience
+            step(int): current step
             train_stats(Statistics): training stats
             valid_stats(Statistics): validation stats
-            lr(float): current learning rate
         """
         self._report_step(
-            lr, step, train_stats=train_stats, valid_stats=valid_stats)
+            lr, patience, step, train_stats=train_stats, valid_stats=valid_stats)
 
     def _report_step(self, *args, **kwargs):
         raise NotImplementedError()
@@ -111,10 +113,10 @@ class ReportMgr(ReportMgrBase):
         super(ReportMgr, self).__init__(report_every, start_time)
         self.tensorboard_writer = tensorboard_writer
 
-    def maybe_log_tensorboard(self, stats, prefix, learning_rate, step):
+    def maybe_log_tensorboard(self, stats, prefix, learning_rate, patience, step):
         if self.tensorboard_writer is not None:
             stats.log_tensorboard(
-                prefix, self.tensorboard_writer, learning_rate, step)
+                prefix, self.tensorboard_writer, learning_rate, patience, step)
 
     def _report_training(self, step, num_steps, learning_rate,
                          report_stats):
@@ -127,12 +129,13 @@ class ReportMgr(ReportMgrBase):
         self.maybe_log_tensorboard(report_stats,
                                    "progress",
                                    learning_rate,
+                                   patience,
                                    step)
         report_stats = onmt.utils.Statistics()
 
         return report_stats
 
-    def _report_step(self, lr, step, train_stats=None, valid_stats=None):
+    def _report_step(self, lr, patience, step, train_stats=None, valid_stats=None):
         """
         See base class method `ReportMgrBase.report_step`.
         """
@@ -143,6 +146,7 @@ class ReportMgr(ReportMgrBase):
             self.maybe_log_tensorboard(train_stats,
                                        "train",
                                        lr,
+                                       patience,
                                        step)
 
         if valid_stats is not None:
@@ -152,4 +156,5 @@ class ReportMgr(ReportMgrBase):
             self.maybe_log_tensorboard(valid_stats,
                                        "valid",
                                        lr,
+                                       patience,
                                        step)

--- a/onmt/utils/statistics.py
+++ b/onmt/utils/statistics.py
@@ -126,7 +126,7 @@ class Statistics(object):
                time.time() - start))
         sys.stdout.flush()
 
-    def log_tensorboard(self, prefix, writer, learning_rate, step):
+    def log_tensorboard(self, prefix, writer, learning_rate, patience, step):
         """ display statistics to tensorboard """
         t = self.elapsed_time()
         writer.add_scalar(prefix + "/xent", self.xent(), step)
@@ -134,3 +134,5 @@ class Statistics(object):
         writer.add_scalar(prefix + "/accuracy", self.accuracy(), step)
         writer.add_scalar(prefix + "/tgtper", self.n_words / t, step)
         writer.add_scalar(prefix + "/lr", learning_rate, step)
+        if patience is not None:
+            writer.add_scalar(prefix + "/patience", patience, step)


### PR DESCRIPTION
If early stopping is used, a separate scalar will be added to the tensorboard logger. This will show the patience, particularly the current tolerance that is left at each training step.

Not sure if this should be logged during training or evaluation or both. Currently it is logged in both. If this needs to change; `self.maybe_log_tensorboard` inside `ReportMgr._report_step` should take `None` as patience value.

closes https://github.com/OpenNMT/OpenNMT-py/issues/1834