### PR TITLE
fix relate to torch1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
       - sox
 before_install:
   # Install CPU version of PyTorch.
-  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install torch==1.5.0 -f https://download.pytorch.org/whl/cpu/torch_stable.html; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then pip install torch==1.6.0 -f https://download.pytorch.org/whl/cpu/torch_stable.html; fi
   - pip install --upgrade setuptools
   - pip install -r requirements.opt.txt
   - python setup.py install   

--- a/onmt/inputters/audio_dataset.py
+++ b/onmt/inputters/audio_dataset.py
@@ -172,7 +172,8 @@ class AudioSeqField(Field):
         lengths = [x.size(1) for x in minibatch]
         max_len = max(lengths)
         nfft = minibatch[0].size(0)
-        sounds = torch.full((len(minibatch), 1, nfft, max_len), self.pad_token)
+        sounds = torch.full((len(minibatch), 1, nfft, max_len),
+                            self.pad_token, dtype=self.dtype)
         for i, (spect, len_) in enumerate(zip(minibatch, lengths)):
             sounds[i, :, :, 0:len_] = spect
         if self.include_lengths:

--- a/onmt/inputters/vec_dataset.py
+++ b/onmt/inputters/vec_dataset.py
@@ -102,7 +102,7 @@ class VecSeqField(Field):
         nfeats = minibatch[0].size(1)
         feat_dim = minibatch[0].size(2)
         feats = torch.full((len(minibatch), max_len, nfeats, feat_dim),
-                           self.pad_token)
+                           self.pad_token, dtype=self.dtype)
         for i, (feat, len_) in enumerate(zip(minibatch, lengths)):
             feats[i, 0:len_, :, :] = feat
         if self.include_lengths:

--- a/onmt/modules/source_noise.py
+++ b/onmt/modules/source_noise.py
@@ -111,7 +111,8 @@ class SenShufflingNoise(NoiseBase):
         full_stops[-1] = 1
 
         # Tokens that are full stops, where the previous token is not
-        sentence_ends = (full_stops[1:] * ~full_stops[:-1]).nonzero() + 2
+        sentence_ends = (full_stops[1:] * ~full_stops[:-1]).nonzero(
+            as_tuple=False) + 2
         result = source.clone()
 
         num_sentences = sentence_ends.size(0)
@@ -220,7 +221,7 @@ class InfillingNoise(NoiseBase):
             raise ValueError("Not supposed to be there")
             lengths = torch.ones((num_to_mask,), device=source.device).long()
         # assert is_word_start[-1] == 0
-        word_starts = is_word_start.nonzero()
+        word_starts = is_word_start.nonzero(as_tuple=False)
         indices = word_starts[torch.randperm(word_starts.size(0))[
             :num_to_mask]].squeeze(1)
 

--- a/onmt/tests/test_audio_dataset.py
+++ b/onmt/tests/test_audio_dataset.py
@@ -48,7 +48,7 @@ class TestAudioField(unittest.TestCase):
         lengths[params["full_length_seq"]] = max_len
         nfeats = params["nfeats"]
         fake_input = torch.full(
-            (bs, 1, nfeats, max_len), init_case["pad_index"])
+            (bs, 1, nfeats, max_len), float(init_case["pad_index"]))
         for b in range(bs):
             fake_input[b, :, :, :lengths[b]] = torch.randn(
                 (1, nfeats, lengths[b]))

--- a/onmt/tests/test_beam_search.py
+++ b/onmt/tests/test_beam_search.py
@@ -446,7 +446,7 @@ class TestBeamSearchAgainstReferenceCase(unittest.TestCase):
         expected_beam_scores, unreduced_preds = new_scores\
             .view(self.BATCH_SZ, self.BEAM_SZ * self.N_WORDS)\
             .topk(self.BEAM_SZ, -1)
-        expected_bptr_1 = unreduced_preds / self.N_WORDS
+        expected_bptr_1 = unreduced_preds // self.N_WORDS
         # [5, 3, 2, 6, 0], so beam 2 predicts EOS!
         expected_preds_1 = unreduced_preds - expected_bptr_1 * self.N_WORDS
         self.assertTrue(beam.topk_log_probs.allclose(expected_beam_scores))

--- a/onmt/tests/test_beam_search.py
+++ b/onmt/tests/test_beam_search.py
@@ -480,7 +480,7 @@ class TestBeamSearchAgainstReferenceCase(unittest.TestCase):
         expected_beam_scores, unreduced_preds = new_scores\
             .view(self.BATCH_SZ, self.BEAM_SZ * self.N_WORDS)\
             .topk(self.BEAM_SZ, -1)
-        expected_bptr_2 = unreduced_preds / self.N_WORDS
+        expected_bptr_2 = unreduced_preds // self.N_WORDS
         # [2, 5, 3, 6, 0] repeat self.BATCH_SZ, so beam 0 predicts EOS!
         expected_preds_2 = unreduced_preds - expected_bptr_2 * self.N_WORDS
         # [-2.4879, -3.8910, -4.1010, -4.2010, -4.4010] repeat self.BATCH_SZ
@@ -518,7 +518,7 @@ class TestBeamSearchAgainstReferenceCase(unittest.TestCase):
         expected_beam_scores, unreduced_preds = new_scores\
             .view(self.BATCH_SZ, self.BEAM_SZ * self.N_WORDS)\
             .topk(self.BEAM_SZ, -1)
-        expected_bptr_3 = unreduced_preds / self.N_WORDS
+        expected_bptr_3 = unreduced_preds // self.N_WORDS
         # [5, 2, 6, 1, 0] repeat self.BATCH_SZ, so beam 1 predicts EOS!
         expected_preds_3 = unreduced_preds - expected_bptr_3 * self.N_WORDS
         self.assertTrue(beam.topk_log_probs.allclose(

--- a/onmt/tests/test_copy_generator.py
+++ b/onmt/tests/test_copy_generator.py
@@ -123,7 +123,8 @@ class TestCopyGeneratorLoss(unittest.TestCase):
             loss = CopyGeneratorLoss(**init_case)
             scores, align, target = self.dummy_inputs(params, init_case)
             res = loss(scores, align, target)
-            should_be_ignored = (target == init_case["ignore_index"]).nonzero()
+            should_be_ignored = (target == init_case["ignore_index"]).nonzero(
+                as_tuple=False)
             assert len(should_be_ignored) > 0  # otherwise not testing anything
             self.assertTrue(res[should_be_ignored].allclose(torch.tensor(0.0)))
 

--- a/onmt/translate/beam_search.py
+++ b/onmt/translate/beam_search.py
@@ -209,7 +209,7 @@ class BeamSearch(DecodeStrategy):
         torch.mul(self.topk_scores, length_penalty, out=self.topk_log_probs)
 
         # Resolve beam origin and map to batch index flat representation.
-        torch.div(self.topk_ids, vocab_size, out=self._batch_index)
+        self._batch_index = self.topk_ids // vocab_size
         self._batch_index += self._beam_offset[:_B].unsqueeze(1)
         self.select_indices = self._batch_index.view(_B * self.beam_size)
         self.topk_ids.fmod_(vocab_size)  # resolve true word ids
@@ -269,7 +269,7 @@ class BeamSearch(DecodeStrategy):
         non_finished_batch = []
         for i in range(self.is_finished.size(0)):  # Batch level
             b = self._batch_offset[i]
-            finished_hyp = self.is_finished[i].nonzero().view(-1)
+            finished_hyp = self.is_finished[i].nonzero(as_tuple=False).view(-1)
             # Store finished hypotheses for this batch.
             for j in finished_hyp:  # Beam level: finished beam j in batch i
                 if self.ratio > 0:

--- a/onmt/translate/greedy_search.py
+++ b/onmt/translate/greedy_search.py
@@ -163,7 +163,7 @@ class GreedySearch(DecodeStrategy):
     def update_finished(self):
         """Finalize scores and predictions."""
         # shape: (sum(~ self.is_finished), 1)
-        finished_batches = self.is_finished.view(-1).nonzero()
+        finished_batches = self.is_finished.view(-1).nonzero(as_tuple=False)
         for b in finished_batches.view(-1):
             b_orig = self.original_batch_idx[b]
             self.scores[b_orig].append(self.topk_scores[b, 0])
@@ -178,6 +178,6 @@ class GreedySearch(DecodeStrategy):
         self.alive_seq = self.alive_seq[is_alive]
         if self.alive_attn is not None:
             self.alive_attn = self.alive_attn[:, is_alive]
-        self.select_indices = is_alive.nonzero().view(-1)
+        self.select_indices = is_alive.nonzero(as_tuple=False).view(-1)
         self.original_batch_idx = self.original_batch_idx[is_alive]
         self.maybe_update_target_prefix(self.select_indices)

--- a/requirements.opt.txt
+++ b/requirements.opt.txt
@@ -1,5 +1,5 @@
 cffi
-torchvision==0.4.0
+torchvision
 joblib
 librosa
 numba==0.43.0


### PR DESCRIPTION
This PR fixes some BC break changes and deprecations made by torch1.6:
* ` // ` replace `torch.div` for float division;
* specify dtype for `torch.full` if fill value is int/bool;
* missing argument for `torch.nonzero(as_tuple=bool)`.

Fix #1838