### PR TITLE
Solved: No such file or directory

### DIFF
--- a/docs/source/ggnn.md
+++ b/docs/source/ggnn.md
@@ -19,8 +19,9 @@ To get started, we provide a toy graph-to-sequence example. We assume that the w
 ```
 cd ..
 git clone https://github.com/SteveKommrusch/OpenNMT-py-ggnn-example
-source OpenNMT-py-ggnn-example/env.sh
-cd OpenNMT-py
+cd OpenNMT-py-ggnn-example
+source env.sh
+cd ../OpenNMT-py
 ```
 
 


### PR DESCRIPTION
Error: 
-bash: A/B/OpenNMT-py-ggnn-example/preprocess.out: No such file or directory

Reason:
If "A/B/C" is the current working directory, `dirname $PWD` outputs "A/B".