### PR TITLE
Update help string for `fix_word_vecs_*`

### DIFF
--- a/docs/source/FAQ.md
+++ b/docs/source/FAQ.md
@@ -47,7 +47,7 @@ onmt_train -config <your_config>.yaml
 
 Notes:
 - the matched embeddings will be saved at `<save_data>.enc_embeddings.pt` and `<save_data>.dec_embeddings.pt`;
-- additional flags `fix_word_vecs_enc` and `fix_word_vecs_dec` are available to freeze the embeddings.
+- additional flags `freeze_word_vecs_enc` and `freeze_word_vecs_dec` are available to freeze the embeddings.
 
 ## How do I use the Transformer model?
 

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -34,8 +34,8 @@ def build_embeddings(opt, text_field, for_encoder=True):
     num_embs = [len(f.vocab) for _, f in text_field]
     num_word_embeddings, num_feat_embeddings = num_embs[0], num_embs[1:]
 
-    fix_word_vecs = opt.fix_word_vecs_enc if for_encoder \
-        else opt.fix_word_vecs_dec
+    freeze_word_vecs = opt.freeze_word_vecs_enc if for_encoder \
+        else opt.freeze_word_vecs_dec
 
     emb = Embeddings(
         word_vec_size=emb_dim,
@@ -49,7 +49,7 @@ def build_embeddings(opt, text_field, for_encoder=True):
         word_vocab_size=num_word_embeddings,
         feat_vocab_sizes=num_feat_embeddings,
         sparse=opt.optim == "sparseadam",
-        fix_word_vecs=fix_word_vecs
+        freeze_word_vecs=freeze_word_vecs
     )
     return emb
 

--- a/onmt/modules/embeddings.py
+++ b/onmt/modules/embeddings.py
@@ -94,6 +94,7 @@ class Embeddings(nn.Module):
         feat_vec_size (int): embedding dimension for features when using
             `-feat_merge mlp`
         dropout (float): dropout probability.
+        freeze_word_vecs (bool): freeze weights of word vectors.
     """
 
     def __init__(self, word_vec_size,
@@ -107,7 +108,7 @@ class Embeddings(nn.Module):
                  feat_vocab_sizes=[],
                  dropout=0,
                  sparse=False,
-                 fix_word_vecs=False):
+                 freeze_word_vecs=False):
         self._validate_args(feat_merge, feat_vocab_sizes, feat_vec_exponent,
                             feat_vec_size, feat_padding_idx)
 
@@ -169,7 +170,7 @@ class Embeddings(nn.Module):
             pe = PositionalEncoding(dropout, self.embedding_size)
             self.make_embedding.add_module('pe', pe)
 
-        if fix_word_vecs:
+        if freeze_word_vecs:
             self.word_lut.weight.requires_grad = False
 
     def _validate_args(self, feat_merge, feat_vocab_sizes, feat_vec_exponent,

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -449,10 +449,10 @@ def _add_train_general_opts(parser):
     # Fixed word vectors
     group.add('--fix_word_vecs_enc', '-fix_word_vecs_enc',
               action='store_true',
-              help="Fix word embeddings on the encoder side.")
+              help="Freeze word embeddings on the encoder side.")
     group.add('--fix_word_vecs_dec', '-fix_word_vecs_dec',
               action='store_true',
-              help="Fix word embeddings on the decoder side.")
+              help="Freeze word embeddings on the decoder side.")
 
     # Optimization options
     group = parser.add_argument_group('Optimization- Type')

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -446,11 +446,11 @@ def _add_train_general_opts(parser):
               help="If a valid path is specified, then this will load "
                    "pretrained word embeddings on the decoder side. "
                    "See README for specific formatting instructions.")
-    # Fixed word vectors
-    group.add('--fix_word_vecs_enc', '-fix_word_vecs_enc',
+    # Freeze word vectors
+    group.add('--freeze_word_vecs_enc', '-freeze_word_vecs_enc',
               action='store_true',
               help="Freeze word embeddings on the encoder side.")
-    group.add('--fix_word_vecs_dec', '-fix_word_vecs_dec',
+    group.add('--freeze_word_vecs_dec', '-freeze_word_vecs_dec',
               action='store_true',
               help="Freeze word embeddings on the decoder side.")
 

--- a/onmt/tests/test_embeddings.py
+++ b/onmt/tests/test_embeddings.py
@@ -21,7 +21,7 @@ class TestEmbeddings(unittest.TestCase):
         feat_padding_idx=[[], [29], [0, 1]],
         feat_vocab_sizes=[[], [39], [401, 39]],
         dropout=[0, 0.5],
-        fix_word_vecs=[False, True]
+        freeze_word_vecs=[False, True]
     ))
     PARAMS = list(product_dict(
         batch_size=[1, 14],
@@ -105,9 +105,9 @@ class TestEmbeddings(unittest.TestCase):
             for key in emb.state_dict():
                 if key not in trainable_params:
                     if key.endswith("emb_luts.0.weight") and \
-                            init_case["fix_word_vecs"]:
+                            init_case["freeze_word_vecs"]:
                         # ok: word embeddings shouldn't be trainable
-                        # if word vecs are fixed
+                        # if word vecs are freezed
                         continue
                     if key.endswith(".pe.pe"):
                         # ok: positional encodings shouldn't be trainable
@@ -117,11 +117,11 @@ class TestEmbeddings(unittest.TestCase):
                         self.fail("Param {:s} is unexpectedly not "
                                   "trainable.".format(key))
             # then check nothing unexpectedly trainable
-            if init_case["fix_word_vecs"]:
+            if init_case["freeze_word_vecs"]:
                 self.assertFalse(
                     any(trainable_param.endswith("emb_luts.0.weight")
                         for trainable_param in trainable_params),
-                    "Word embedding is trainable but word vecs are fixed.")
+                    "Word embedding is trainable but word vecs are freezed.")
             if init_case["position_encoding"]:
                 self.assertFalse(
                     any(trainable_p.endswith(".pe.pe")

--- a/onmt/utils/parse.py
+++ b/onmt/utils/parse.py
@@ -158,6 +158,12 @@ class ArgumentParser(cfargparse.ArgumentParser, DataOptsCheckerMixin):
             model_opt.src_word_vec_size = model_opt.word_vec_size
             model_opt.tgt_word_vec_size = model_opt.word_vec_size
 
+        # Backward compatibility with "fix_word_vecs_*" opts
+        if hasattr(model_opt, 'fix_word_vecs_enc'):
+            model_opt.freeze_word_vecs_enc = model_opt.fix_word_vecs_enc
+        if hasattr(model_opt, 'fix_word_vecs_dec'):
+            model_opt.freeze_word_vecs_dec = model_opt.fix_word_vecs_dec
+
         if model_opt.layers > 0:
             model_opt.enc_layers = model_opt.layers
             model_opt.dec_layers = model_opt.layers

--- a/tools/extract_embeddings.py
+++ b/tools/extract_embeddings.py
@@ -4,6 +4,8 @@ import torch
 
 import onmt
 import onmt.model_builder
+
+from onmt.utils.parse import ArgumentParser
 import onmt.opts
 
 from onmt.utils.misc import use_gpu

--- a/tools/extract_embeddings.py
+++ b/tools/extract_embeddings.py
@@ -4,6 +4,8 @@ import torch
 
 import onmt
 import onmt.model_builder
+
+from onmt.utils.parse import ArgumentParser
 import onmt.opts
 
 from onmt.utils.misc import use_gpu
@@ -32,6 +34,7 @@ def main():
     dummy_parser = argparse.ArgumentParser(description='train.py')
     onmt.opts.model_opts(dummy_parser)
     dummy_opt = dummy_parser.parse_known_args([])[0]
+
     opt = parser.parse_args()
     opt.cuda = opt.gpu > -1
     if opt.cuda:
@@ -50,6 +53,10 @@ def main():
     for arg in dummy_opt.__dict__:
         if arg not in model_opt:
             model_opt.__dict__[arg] = dummy_opt.__dict__[arg]
+
+    # build_base_model expects updated and validated opts
+    ArgumentParser.update_model_opts(model_opt)
+    ArgumentParser.validate_model_opts(model_opt)
 
     model = onmt.model_builder.build_base_model(
         model_opt, fields, use_gpu(opt), checkpoint)

--- a/tools/extract_embeddings.py
+++ b/tools/extract_embeddings.py
@@ -4,8 +4,6 @@ import torch
 
 import onmt
 import onmt.model_builder
-
-from onmt.utils.parse import ArgumentParser
 import onmt.opts
 
 from onmt.utils.misc import use_gpu
@@ -34,7 +32,6 @@ def main():
     dummy_parser = argparse.ArgumentParser(description='train.py')
     onmt.opts.model_opts(dummy_parser)
     dummy_opt = dummy_parser.parse_known_args([])[0]
-
     opt = parser.parse_args()
     opt.cuda = opt.gpu > -1
     if opt.cuda:


### PR DESCRIPTION
Hi, according to #1866 I changed the help string for the `fix_word_vecs_*` to be clearer about what it does.
I wonder whether it is necessary to change the variable names using this option as well ?
I think just changing the help is enough string will help user understand what this does.

The 3 files using this option:
- [onmt/model_builder.py](https://github.com/OpenNMT/OpenNMT-py/blob/2c63a535c8c85ba77eeac2e179cfa0e70d0a90fe/onmt/model_builder.py#L37)
- [onmt/modules/embeddings.py](https://github.com/OpenNMT/OpenNMT-py/blob/2c63a535c8c85ba77eeac2e179cfa0e70d0a90fe/onmt/modules/embeddings.py#L110)
- [onmt/tests/test_embeddings.py](https://github.com/OpenNMT/OpenNMT-py/blob/2c63a535c8c85ba77eeac2e179cfa0e70d0a90fe/onmt/tests/test_embeddings.py#L24)

This file explains what the option does more explicitly: [docs/source/FAQ.md](https://github.com/OpenNMT/OpenNMT-py/blob/master/docs/source/FAQ.md#example)