### PR TITLE
Add float16 to CTranslate2 export types

### DIFF
--- a/onmt/bin/release_model.py
+++ b/onmt/bin/release_model.py
@@ -34,7 +34,7 @@ def main():
                         default="pytorch",
                         help="The format of the released model")
     parser.add_argument("--quantization", "-q",
-                        choices=["int8", "int16"],
+                        choices=["int8", "int16", "float16"],
                         default=None,
                         help="Quantization type for CT2 model.")
     opt = parser.parse_args()


### PR DESCRIPTION
Model conversion to float16 is supported since CTranslate2 1.12.0.