### PR TITLE
Return full torchtext vocabs in get_vocabs instead of only itos

### DIFF
--- a/onmt/inputters/fields.py
+++ b/onmt/inputters/fields.py
@@ -54,9 +54,9 @@ def build_dynamic_fields(opts, src_specials=None, tgt_specials=None):
 
 
 def get_vocabs(fields):
-    """Get a dict contain src & tgt vocab list extracted from fields."""
-    src_vocab = fields['src'].base_field.vocab.itos
-    tgt_vocab = fields['tgt'].base_field.vocab.itos
+    """Get a dict contain src & tgt vocab extracted from fields."""
+    src_vocab = fields['src'].base_field.vocab
+    tgt_vocab = fields['tgt'].base_field.vocab
     vocabs = {'src': src_vocab, 'tgt': tgt_vocab}
     return vocabs
 

--- a/onmt/transforms/sampling.py
+++ b/onmt/transforms/sampling.py
@@ -84,8 +84,8 @@ class SwitchOutTransform(Transform, HammingDistanceSampling):
     def apply(self, example, is_train=False, stats=None, **kwargs):
         """Apply switchout to both src and tgt side tokens."""
         if is_train and self.vocab is not None:
-            src = self._switchout(example['src'], self.vocab['src'], stats)
-            tgt = self._switchout(example['tgt'], self.vocab['tgt'], stats)
+            src = self._switchout(example['src'], self.vocab['src'].itos, stats)
+            tgt = self._switchout(example['tgt'], self.vocab['tgt'].itos, stats)
             example['src'], example['tgt'] = src, tgt
         return example
 

--- a/onmt/transforms/sampling.py
+++ b/onmt/transforms/sampling.py
@@ -84,8 +84,10 @@ class SwitchOutTransform(Transform, HammingDistanceSampling):
     def apply(self, example, is_train=False, stats=None, **kwargs):
         """Apply switchout to both src and tgt side tokens."""
         if is_train and self.vocab is not None:
-            src = self._switchout(example['src'], self.vocab['src'].itos, stats)
-            tgt = self._switchout(example['tgt'], self.vocab['tgt'].itos, stats)
+            src = self._switchout(
+                example['src'], self.vocab['src'].itos, stats)
+            tgt = self._switchout(
+                example['tgt'], self.vocab['tgt'].itos, stats)
             example['src'], example['tgt'] = src, tgt
         return example
 


### PR DESCRIPTION
May be useful to have the full vocab object in some transforms (to have the `freqs` for instance).