### PR TITLE
remove bias parameter from generator linear

### DIFF
--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -162,7 +162,8 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None, gpu_id=None):
             gen_func = nn.LogSoftmax(dim=-1)
         generator = nn.Sequential(
             nn.Linear(model_opt.dec_rnn_size,
-                      len(fields["tgt"].base_field.vocab)),
+                      len(fields["tgt"].base_field.vocab),
+                      bias=False),
             Cast(torch.float32),
             gen_func
         )

--- a/onmt/modules/copy_generator.py
+++ b/onmt/modules/copy_generator.py
@@ -88,7 +88,7 @@ class CopyGenerator(nn.Module):
 
     def __init__(self, input_size, output_size, pad_idx):
         super(CopyGenerator, self).__init__()
-        self.linear = nn.Linear(input_size, output_size)
+        self.linear = nn.Linear(input_size, output_size, bias=False)
         self.linear_copy = nn.Linear(input_size, 1)
         self.pad_idx = pad_idx
 


### PR DESCRIPTION
The Linear layer of the generator which intended to mapping hidden states to word vector space is the reverse operation of Embeddings, thus should not have the bias parameter. Adding bias will break the intention of `share_decoder_embeddings`.
This PR fixes this issue.