### PR TITLE
ensure reproducibility for data transforms

### DIFF
--- a/onmt/transforms/misc.py
+++ b/onmt/transforms/misc.py
@@ -9,8 +9,6 @@ class FilterTooLongTransform(Transform):
 
     def __init__(self, opts):
         super().__init__(opts)
-        self.src_seq_length = opts.src_seq_length
-        self.tgt_seq_length = opts.tgt_seq_length
 
     @classmethod
     def add_options(cls, parser):
@@ -20,6 +18,10 @@ class FilterTooLongTransform(Transform):
                   help="Maximum source sequence length.")
         group.add("--tgt_seq_length", "-tgt_seq_length", type=int, default=200,
                   help="Maximum target sequence length.")
+
+    def _parse_opts(self):
+        self.src_seq_length = self.opts.src_seq_length
+        self.tgt_seq_length = self.opts.tgt_seq_length
 
     def apply(self, example, is_train=False, stats=None, **kwargs):
         """Return None if too long else return as is."""
@@ -45,7 +47,6 @@ class PrefixTransform(Transform):
 
     def __init__(self, opts):
         super().__init__(opts)
-        self.prefix_dict = self.get_prefix_dict(self.opts)
 
     @staticmethod
     def _get_prefix(corpus):
@@ -79,6 +80,11 @@ class PrefixTransform(Transform):
             src_specials.update(prefix['src'].split())
             tgt_specials.update(prefix['tgt'].split())
         return (src_specials, tgt_specials)
+
+    def warm_up(self, vocabs=None):
+        """Warm up to get prefix dictionary."""
+        super().warm_up(None)
+        self.prefix_dict = self.get_prefix_dict(self.opts)
 
     def _prepend(self, example, prefix):
         """Prepend `prefix` to `tokens`."""


### PR DESCRIPTION
Previously, we can't actually guarantee the reproducibility for sampling/tokenize transforms.
For tokenize related transforms, it was not possible for setting the seed for `sentencepiece` & `pyonmttok` until recently, see OpenNMT/Tokenizer#168 or google/sentencepiece#540. For sampling, as we've used `random` module in the transform, we can not depend on the already exist `set_random_seed` utils, as `random` not depend on RandomState as `numpy` or `torch`, see numpy/numpy#9650.
To adress these issues, we added `_set_seed` method in the `Transform` to ensure set the seed when initilize / load every transform instance.

This PR changes:
  1. `_set_seed` method in the `Transform` base class for override in order to make the transform process reproducible;
  2. add support for subword tokenize reproducibility and also sampling reproducible;
  3. Move `__getstate__`, `__setstate__` from `TokenizerTransform` to `Transform`, as transform instance need to reset the seed when they are passed in multiprocessing;
  4. Move all instance attribute assignment to `_parse_opts` followed by the change 3;
  5. Relate change is required for `vocabs` in `warm_up` followed by the change 3.
