### PR TITLE
fix keyword arg error

### DIFF
--- a/onmt/transforms/tokenize.py
+++ b/onmt/transforms/tokenize.py
@@ -362,7 +362,7 @@ class ONMTTokenizerTransform(TokenizerTransform):
             kwopts['vocabulary_threshold'] = vocabulary_threshold
         return kwopts
 
-    def warm_up(self, vocab=None):
+    def warm_up(self, vocabs=None):
         """Initialize Tokenizer models."""
         super().warm_up(None)
         import pyonmttok


### PR DESCRIPTION
keyword argument `vocabs` in warm_up() not match base class, will raise TypeError when run.