### PR TITLE
fix missing vocabs in Transform.warm_up

### DIFF
--- a/onmt/transforms/bart.py
+++ b/onmt/transforms/bart.py
@@ -350,6 +350,7 @@ class BARTNoiseTransform(Transform):
     def warm_up(self, vocabs):
         super().warm_up(None)
         if vocabs is None:
+            self.bart_noise = None
             return
         self.vocabs = vocabs
 

--- a/onmt/transforms/transform.py
+++ b/onmt/transforms/transform.py
@@ -53,7 +53,10 @@ class Transform(object):
 
     def __getstate__(self):
         """Pickling following for rebuild."""
-        return self.opts
+        state = {"opts": self.opts}
+        if hasattr(self, 'vocabs'):
+            state['vocabs'] = self.vocabs
+        return state
 
     def _parse_opts(self):
         """Parse opts to set/reset instance's attributes.
@@ -65,11 +68,11 @@ class Transform(object):
         """
         pass
 
-    def __setstate__(self, opts):
+    def __setstate__(self, state):
         """Reload when unpickling from save file."""
-        self.opts = opts
+        self.opts = state["opts"]
         self._parse_opts()
-        vocabs = self.vocabs if hasattr(self, 'vocabs') else None
+        vocabs = state.get('vocabs', None)
         self.warm_up(vocabs=vocabs)
 
     def stats(self):


### PR DESCRIPTION
Currently, vocabs added in `Transform.warm_up()` is not properly pickled/unpickled which will introduce Exception when using BART or SwitchOut transform in multi-gpu training. This PR fixes this issue by pickling a dict as state info.
This closes #1923.