### PR TITLE
Build CopyGenerator with bias if parameters in checkpoint

### DIFF
--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -180,7 +180,8 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None, gpu_id=None):
         pad_idx = tgt_base_field.vocab.stoi[tgt_base_field.pad_token]
         generator = CopyGenerator(
             model_opt.dec_rnn_size, vocab_size, pad_idx,
-            bias="linear.bias" in checkpoint.get("generator", {}).keys())
+            bias=("linear.bias" in checkpoint.get("generator", {}).keys())
+                 if checkpoint is not None else None)
         if model_opt.share_decoder_embeddings:
             generator.linear.weight = decoder.embeddings.word_lut.weight
 

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -168,7 +168,8 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None, gpu_id=None):
         generator = nn.Sequential(
             nn.Linear(model_opt.dec_rnn_size,
                       len(fields["tgt"].base_field.vocab),
-                      bias=False),
+                      bias="0.bias" in checkpoint.get("generator", {}).keys()
+                           if checkpoint is not None else None),
             Cast(torch.float32),
             gen_func
         )
@@ -180,7 +181,7 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None, gpu_id=None):
         pad_idx = tgt_base_field.vocab.stoi[tgt_base_field.pad_token]
         generator = CopyGenerator(
             model_opt.dec_rnn_size, vocab_size, pad_idx,
-            bias=("linear.bias" in checkpoint.get("generator", {}).keys())
+            bias="linear.bias" in checkpoint.get("generator", {}).keys()
                  if checkpoint is not None else None)
         if model_opt.share_decoder_embeddings:
             generator.linear.weight = decoder.embeddings.word_lut.weight

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -178,7 +178,9 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None, gpu_id=None):
         tgt_base_field = fields["tgt"].base_field
         vocab_size = len(tgt_base_field.vocab)
         pad_idx = tgt_base_field.vocab.stoi[tgt_base_field.pad_token]
-        generator = CopyGenerator(model_opt.dec_rnn_size, vocab_size, pad_idx)
+        generator = CopyGenerator(
+            model_opt.dec_rnn_size, vocab_size, pad_idx,
+            bias="linear.bias" in checkpoint.get("generator", {}).keys())
         if model_opt.share_decoder_embeddings:
             generator.linear.weight = decoder.embeddings.word_lut.weight
 

--- a/onmt/modules/copy_generator.py
+++ b/onmt/modules/copy_generator.py
@@ -86,9 +86,9 @@ class CopyGenerator(nn.Module):
        pad_idx (int)
     """
 
-    def __init__(self, input_size, output_size, pad_idx):
+    def __init__(self, input_size, output_size, pad_idx, bias=False):
         super(CopyGenerator, self).__init__()
-        self.linear = nn.Linear(input_size, output_size, bias=False)
+        self.linear = nn.Linear(input_size, output_size, bias=bias)
         self.linear_copy = nn.Linear(input_size, 1)
         self.pad_idx = pad_idx
 


### PR DESCRIPTION
Restore back-compatibility with models trained with copy attention and shared parameters prior to #1903 .