### PR TITLE
Added GPT2 as decoder layer and a utility function to load its weights

### DIFF
--- a/onmt/decoders/__init__.py
+++ b/onmt/decoders/__init__.py
@@ -3,10 +3,11 @@ from onmt.decoders.decoder import DecoderBase, InputFeedRNNDecoder, \
     StdRNNDecoder
 from onmt.decoders.transformer import TransformerDecoder
 from onmt.decoders.cnn_decoder import CNNDecoder
-
+from onmt.decoders.gpt2_decoder import GPT2Decoder
 
 str2dec = {"rnn": StdRNNDecoder, "ifrnn": InputFeedRNNDecoder,
-           "cnn": CNNDecoder, "transformer": TransformerDecoder}
+           "cnn": CNNDecoder, "transformer": TransformerDecoder,
+           "gpt2_decoder": GPT2Decoder}
 
 __all__ = ["DecoderBase", "TransformerDecoder", "StdRNNDecoder", "CNNDecoder",
-           "InputFeedRNNDecoder", "str2dec"]
+           "InputFeedRNNDecoder", "GPT2Decoder", "str2dec"]

--- a/onmt/decoders/gpt2_decoder.py
+++ b/onmt/decoders/gpt2_decoder.py
@@ -8,67 +8,11 @@ from torch.autograd import Variable
 import numpy as np
 
 import onmt
-from onmt.Models import EncoderBase
 from onmt.Models import DecoderState
 from onmt.Utils import aeq
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 MAX_SIZE = 5000
-
-def prune_conv1d_layer(layer: Conv1D, index: torch.LongTensor, dim: int = 1) -> Conv1D:
-    """
-    Prune a Conv1D layer to keep only entries in index. A Conv1D work as a Linear layer (see e.g. BERT) but the weights
-    are transposed.
-    Used to remove heads.
-    Args:
-        layer (:class:`~transformers.modeling_utils.Conv1D`): The layer to prune.
-        index (:obj:`torch.LongTensor`): The indices to keep in the layer.
-        dim (:obj:`int`, `optional`, defaults to 1): The dimension on which to keep the indices.
-    Returns:
-        :class:`~transformers.modeling_utils.Conv1D`: The pruned layer as a new layer with :obj:`requires_grad=True`.
-    """
-    index = index.to(layer.weight.device)
-    W = layer.weight.index_select(dim, index).clone().detach()
-    if dim == 0:
-        b = layer.bias.clone().detach()
-    else:
-        b = layer.bias[index].clone().detach()
-    new_size = list(layer.weight.size())
-    new_size[dim] = len(index)
-    new_layer = Conv1D(new_size[1], new_size[0]).to(layer.weight.device)
-    new_layer.weight.requires_grad = False
-    new_layer.weight.copy_(W.contiguous())
-    new_layer.weight.requires_grad = True
-    new_layer.bias.requires_grad = False
-    new_layer.bias.copy_(b.contiguous())
-    new_layer.bias.requires_grad = True
-    return new_layer
-
-def find_pruneable_heads_and_indices(
-    heads: List[int], n_heads: int, head_size: int, already_pruned_heads: Set[int]
-) -> Tuple[Set[int], torch.LongTensor]:
-    """
-    Finds the heads and their indices taking :obj:`already_pruned_heads` into account.
-    Args:
-        heads (:obj:`List[int]`): List of the indices of heads to prune.
-        n_heads (:obj:`int`): The number of heads in the model.
-        head_size (:obj:`int`): The size of each head.
-        already_pruned_heads (:obj:`Set[int]`): A set of already pruned heads.
-    Returns:
-        :obj:`Tuple[Set[int], torch.LongTensor]`: A tuple with the remaining heads and their corresponding indices.
-    """
-    mask = torch.ones(n_heads, head_size)
-    heads = set(heads) - already_pruned_heads  # Convert to set and remove already pruned heads
-    for head in heads:
-        # Compute how many pruned heads are before the head and move the index accordingly
-        head = head - sum(1 if h < head else 0 for h in already_pruned_heads)
-        mask[head] = 0
-    mask = mask.view(-1).contiguous().eq(1)
-    index: torch.LongTensor = torch.arange(len(mask))[mask].long()
-    return heads, index
-
-
-
 
 class Conv1D(nn.Module):
     """
@@ -246,6 +190,57 @@ class Conv1DAttention(nn.Module):
 
         return outputs, top  # a, present, (attentions)
 
+def prune_conv1d_layer(layer: Conv1D, index: torch.LongTensor, dim: int = 1) -> Conv1D:
+    """
+    Prune a Conv1D layer to keep only entries in index. A Conv1D work as a Linear layer (see e.g. BERT) but the weights
+    are transposed.
+    Used to remove heads.
+    Args:
+        layer (:class:`~transformers.modeling_utils.Conv1D`): The layer to prune.
+        index (:obj:`torch.LongTensor`): The indices to keep in the layer.
+        dim (:obj:`int`, `optional`, defaults to 1): The dimension on which to keep the indices.
+    Returns:
+        :class:`~transformers.modeling_utils.Conv1D`: The pruned layer as a new layer with :obj:`requires_grad=True`.
+    """
+    index = index.to(layer.weight.device)
+    W = layer.weight.index_select(dim, index).clone().detach()
+    if dim == 0:
+        b = layer.bias.clone().detach()
+    else:
+        b = layer.bias[index].clone().detach()
+    new_size = list(layer.weight.size())
+    new_size[dim] = len(index)
+    new_layer = Conv1D(new_size[1], new_size[0]).to(layer.weight.device)
+    new_layer.weight.requires_grad = False
+    new_layer.weight.copy_(W.contiguous())
+    new_layer.weight.requires_grad = True
+    new_layer.bias.requires_grad = False
+    new_layer.bias.copy_(b.contiguous())
+    new_layer.bias.requires_grad = True
+    return new_layer
+
+def find_pruneable_heads_and_indices(
+    heads: List[int], n_heads: int, head_size: int, already_pruned_heads: Set[int]
+) -> Tuple[Set[int], torch.LongTensor]:
+    """
+    Finds the heads and their indices taking :obj:`already_pruned_heads` into account.
+    Args:
+        heads (:obj:`List[int]`): List of the indices of heads to prune.
+        n_heads (:obj:`int`): The number of heads in the model.
+        head_size (:obj:`int`): The size of each head.
+        already_pruned_heads (:obj:`Set[int]`): A set of already pruned heads.
+    Returns:
+        :obj:`Tuple[Set[int], torch.LongTensor]`: A tuple with the remaining heads and their corresponding indices.
+    """
+    mask = torch.ones(n_heads, head_size)
+    heads = set(heads) - already_pruned_heads  # Convert to set and remove already pruned heads
+    for head in heads:
+        # Compute how many pruned heads are before the head and move the index accordingly
+        head = head - sum(1 if h < head else 0 for h in already_pruned_heads)
+        mask[head] = 0
+    mask = mask.view(-1).contiguous().eq(1)
+    index: torch.LongTensor = torch.arange(len(mask))[mask].long()
+    return heads, index
 
 class GPT2DecoderLayer(nn.Module):
     """

--- a/onmt/decoders/gpt2_decoder.py
+++ b/onmt/decoders/gpt2_decoder.py
@@ -1,0 +1,498 @@
+"""
+Implementation of "Attention is All You Need"
+"""
+
+import torch
+import torch.nn as nn
+from torch.autograd import Variable
+import numpy as np
+
+import onmt
+from onmt.Models import EncoderBase
+from onmt.Models import DecoderState
+from onmt.Utils import aeq
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
+
+MAX_SIZE = 5000
+
+def prune_conv1d_layer(layer: Conv1D, index: torch.LongTensor, dim: int = 1) -> Conv1D:
+    """
+    Prune a Conv1D layer to keep only entries in index. A Conv1D work as a Linear layer (see e.g. BERT) but the weights
+    are transposed.
+    Used to remove heads.
+    Args:
+        layer (:class:`~transformers.modeling_utils.Conv1D`): The layer to prune.
+        index (:obj:`torch.LongTensor`): The indices to keep in the layer.
+        dim (:obj:`int`, `optional`, defaults to 1): The dimension on which to keep the indices.
+    Returns:
+        :class:`~transformers.modeling_utils.Conv1D`: The pruned layer as a new layer with :obj:`requires_grad=True`.
+    """
+    index = index.to(layer.weight.device)
+    W = layer.weight.index_select(dim, index).clone().detach()
+    if dim == 0:
+        b = layer.bias.clone().detach()
+    else:
+        b = layer.bias[index].clone().detach()
+    new_size = list(layer.weight.size())
+    new_size[dim] = len(index)
+    new_layer = Conv1D(new_size[1], new_size[0]).to(layer.weight.device)
+    new_layer.weight.requires_grad = False
+    new_layer.weight.copy_(W.contiguous())
+    new_layer.weight.requires_grad = True
+    new_layer.bias.requires_grad = False
+    new_layer.bias.copy_(b.contiguous())
+    new_layer.bias.requires_grad = True
+    return new_layer
+
+def find_pruneable_heads_and_indices(
+    heads: List[int], n_heads: int, head_size: int, already_pruned_heads: Set[int]
+) -> Tuple[Set[int], torch.LongTensor]:
+    """
+    Finds the heads and their indices taking :obj:`already_pruned_heads` into account.
+    Args:
+        heads (:obj:`List[int]`): List of the indices of heads to prune.
+        n_heads (:obj:`int`): The number of heads in the model.
+        head_size (:obj:`int`): The size of each head.
+        already_pruned_heads (:obj:`Set[int]`): A set of already pruned heads.
+    Returns:
+        :obj:`Tuple[Set[int], torch.LongTensor]`: A tuple with the remaining heads and their corresponding indices.
+    """
+    mask = torch.ones(n_heads, head_size)
+    heads = set(heads) - already_pruned_heads  # Convert to set and remove already pruned heads
+    for head in heads:
+        # Compute how many pruned heads are before the head and move the index accordingly
+        head = head - sum(1 if h < head else 0 for h in already_pruned_heads)
+        mask[head] = 0
+    mask = mask.view(-1).contiguous().eq(1)
+    index: torch.LongTensor = torch.arange(len(mask))[mask].long()
+    return heads, index
+
+
+
+
+class Conv1D(nn.Module):
+    """
+    1D-convolutional layer as defined by Radford et al. for OpenAI GPT (and also used in GPT-2).
+    Basically works like a linear layer but the weights are transposed.
+    Args:
+        nf (:obj:`int`): The number of output features.
+        nx (:obj:`int`): The number of input features.
+    """
+
+    def __init__(self, nf, nx):
+        super().__init__()
+        self.nf = nf
+        w = torch.empty(nx, nf)
+        nn.init.normal_(w, std=0.02)
+        self.weight = nn.Parameter(w)
+        self.bias = nn.Parameter(torch.zeros(nf))
+
+    def forward(self, x):
+        size_out = x.size()[:-1] + (self.nf,)
+        x = torch.addmm(self.bias, x.view(-1, x.size(-1)), self.weight)
+        x = x.view(*size_out)
+        return x
+
+class MLP(nn.Module):
+    def __init__(self, n_state=3072):  # in MLP: n_state=3072 (4 * n_embd)
+        super().__init__()
+        # nx = config.n_embd
+        nx = 768
+        self.c_fc = Conv1D(n_state, nx)
+        self.c_proj = Conv1D(nx, n_state)
+        # self.act = ACT2FN[config.activation_function]
+        self.act = nn.GELU()
+        self.dropout = nn.Dropout(0.1)
+
+    def forward(self, x):
+        h = self.act(self.c_fc(x))
+        h2 = self.c_proj(h)
+        return self.dropout(h2)
+
+
+class Conv1DAttention(nn.Module):
+    def __init__(self, nx=768, n_ctx=1024, n_head=12, scale=False, is_cross_attention=False):
+        super().__init__()
+
+        n_state = nx  # in Attention: n_state=768 (nx=n_embd)
+        # [switch nx => n_state from Block to Attention to keep identical to TF implem]
+        # assert n_state % config.n_head == 0
+        assert n_state % n_head == 0
+        self.register_buffer(
+            "bias", torch.tril(torch.ones((n_ctx, n_ctx), dtype=torch.uint8)).view(1, 1, n_ctx, n_ctx)
+        )
+        self.register_buffer("masked_bias", torch.tensor(-1e4))
+        self.n_head = n_head
+        self.split_size = n_state
+        self.scale = scale
+        self.is_cross_attention = is_cross_attention
+        if self.is_cross_attention:
+            self.c_attn = Conv1D(2 * n_state, nx)
+            self.q_attn = Conv1D(n_state, nx)
+        else:
+            self.c_attn = Conv1D(3 * n_state, nx)
+        self.c_proj = Conv1D(n_state, nx)
+        self.attn_dropout = nn.Dropout(0.1)
+        self.resid_dropout = nn.Dropout(0.1)
+        self.pruned_heads = set()
+
+    def prune_heads(self, heads):
+        if len(heads) == 0:
+            return
+        heads, index = find_pruneable_heads_and_indices(
+            heads, self.n_head, self.split_size // self.n_head, self.pruned_heads
+        )
+        index_attn = torch.cat([index, index + self.split_size, index + (2 * self.split_size)])
+
+        # Prune conv1d layers
+        self.c_attn = prune_conv1d_layer(self.c_attn, index_attn, dim=1)
+        self.c_proj = prune_conv1d_layer(self.c_proj, index, dim=0)
+
+        # Update hyper params
+        self.split_size = (self.split_size // self.n_head) * (self.n_head - len(heads))
+        self.n_head = self.n_head - len(heads)
+        self.pruned_heads = self.pruned_heads.union(heads)
+
+    def _attn(self, q, k, v, attention_mask=None, head_mask=None, output_attentions=False):
+        w = torch.matmul(q, k)
+        if self.scale:
+            w = w / (float(v.size(-1)) ** 0.5)
+        nd, ns = w.size(-2), w.size(-1)
+
+        if not self.is_cross_attention:
+            # if only "normal" attention layer implements causal mask
+            mask = self.bias[:, :, ns - nd : ns, :ns]
+            w = torch.where(mask.bool(), w, self.masked_bias.to(w.dtype))
+
+        if attention_mask is not None:
+            # Apply the attention mask
+            attention_mask = attention_mask.unsqueeze(1).repeat(1, w.size(1), 1, 1)
+            w = w + attention_mask
+
+        w = nn.Softmax(dim=-1)(w)
+        w = self.attn_dropout(w)
+
+        # Mask heads if we want to
+        if head_mask is not None:
+            w = w * head_mask
+
+        outputs = [torch.matmul(w, v)]
+        if output_attentions:
+            outputs.append(w)
+        return outputs, w
+
+    def merge_heads(self, x):
+        x = x.permute(0, 2, 1, 3).contiguous()
+        new_x_shape = x.size()[:-2] + (x.size(-2) * x.size(-1),)
+        return x.view(*new_x_shape)  # in Tensorflow implem: fct merge_states
+
+    def split_heads(self, x, k=False):
+        new_x_shape = x.size()[:-1] + (self.n_head, x.size(-1) // self.n_head)
+        x = x.view(*new_x_shape)  # in Tensorflow implem: fct split_states
+        if k:
+            return x.permute(0, 2, 3, 1)  # (batch, head, head_features, seq_length)
+        else:
+            return x.permute(0, 2, 1, 3)  # (batch, head, seq_length, head_features)
+
+    def forward(
+        self,
+        hidden_states,
+        layer_past=None,
+        attention_mask=None,
+        head_mask=None,
+        encoder_hidden_states=None,
+        encoder_attention_mask=None,
+        use_cache=False,
+        output_attentions=False,
+    ):
+        if encoder_hidden_states is not None:
+            assert hasattr(
+                self, "q_attn"
+            ), "If class is used as cross attention, the weights `q_attn` have to be defined. Please make sure to instantiate class with `Attention(..., is_cross_attention=True)`."
+            query = self.q_attn(hidden_states)
+            key, value = self.c_attn(encoder_hidden_states).split(self.split_size, dim=2)
+            attention_mask = encoder_attention_mask
+        else:
+            query, key, value = self.c_attn(hidden_states).split(self.split_size, dim=2)
+
+        query = self.split_heads(query)
+        key = self.split_heads(key, k=True)
+        value = self.split_heads(value)
+        if layer_past is not None and attention_mask is None:
+
+            layer_past0 = self.split_heads(layer_past[0], k=True)
+            layer_past1 = self.split_heads(layer_past[0])
+            past_key, past_value = layer_past0, layer_past1  # transpose back cf below
+            # past_key, past_value = layer_past[0].transpose(-2, -1), layer_past[1]  # transpose back cf below
+
+            key = torch.cat((past_key, key), dim=-1)
+            value = torch.cat((past_value, value), dim=-2)
+
+        if use_cache is True:
+            present = torch.stack((key.transpose(-2, -1), value))  # transpose to have same shapes for stacking
+        else:
+            present = (None,)
+
+        attn_outputs, top_attn = self._attn(query, key, value, attention_mask, head_mask, output_attentions)
+        a = attn_outputs[0]
+
+        top = top_attn.view(top_attn.size())[:, 0, :, :].contiguous()
+
+        a = self.merge_heads(a)
+        a = self.c_proj(a)
+        a = self.resid_dropout(a)
+
+        outputs = [a, present] + attn_outputs[1:]
+
+        return outputs, top  # a, present, (attentions)
+
+
+class GPT2DecoderLayer(nn.Module):
+    """
+    Args:
+      size(int): the dimension of keys/values/queries in
+                       MultiHeadedAttention, also the input size of
+                       the first-layer of the FeedForward.
+      droput(float): dropout probability(0-1.0).
+      head_count(int): the number of heads for MultiHeadedAttention.
+      hidden_size(int): the second-layer of the FeedForward.
+    """
+    def __init__(self, size, dropout,
+                 head_count=12, hidden_size=3072):
+        super(GPT2DecoderLayer, self).__init__()
+
+        self.self_attn = Conv1DAttention()
+        self.context_attn = onmt.modules.MultiHeadedAttention(
+                head_count, size, dropout=0.1)
+        self.feed_forward = MLP()
+        self.layer_norm_1 = nn.LayerNorm(size, eps=1e-05, elementwise_affine=True)
+        self.layer_norm_mid = nn.LayerNorm(size, eps=1e-05, elementwise_affine=True)
+        self.layer_norm_2 = nn.LayerNorm(size, eps=1e-05, elementwise_affine=True)
+        self.dropout = dropout
+        self.drop = nn.Dropout(dropout)
+        mask = self._get_attn_subsequent_mask(MAX_SIZE)
+        # Register self.mask as a buffer in TransformerDecoderLayer, so
+        # it gets GPT2DecoderLayer's cuda behavior automatically.
+        self.register_buffer('mask', mask)
+
+    def forward(self, inputs, memory_bank, src_pad_mask, tgt_pad_mask,
+                previous_input=None):
+        # Args Checks
+        input_batch, input_len, _ = inputs.size()        
+        if previous_input is not None:
+            pi_batch, _, _ = previous_input.size()
+            aeq(pi_batch, input_batch)
+        contxt_batch, contxt_len, _ = memory_bank.size()
+        aeq(input_batch, contxt_batch)
+
+        src_batch, t_len, s_len = src_pad_mask.size()
+        tgt_batch, t_len_, t_len__ = tgt_pad_mask.size()
+        aeq(input_batch, contxt_batch, src_batch, tgt_batch)
+        aeq(t_len, t_len_, t_len__, input_len)
+        aeq(s_len, contxt_len)
+        # END Args Checks
+
+        dec_mask = torch.gt(tgt_pad_mask +
+                            self.mask[:, :tgt_pad_mask.size(1),
+                                      :tgt_pad_mask.size(1)], 0)
+        input_norm = self.layer_norm_1(inputs)
+
+        all_input = input_norm
+        if previous_input is not None:
+            all_input = torch.cat((previous_input, input_norm), dim=1)
+            dec_mask = None
+        
+        query, attn = self.self_attn(input_norm, layer_past=(all_input, all_input), attention_mask=dec_mask)
+
+        query = query[0] + inputs
+
+        query_norm = self.layer_norm_mid(query)
+        mid, attn = self.context_attn(memory_bank, memory_bank, query_norm,
+                                      mask=src_pad_mask)
+
+        output = query + self.feed_forward(self.layer_norm_2(mid + query))
+        
+        # CHECKS
+        output_batch, output_len, _ = output.size()
+        aeq(input_len, output_len)
+        aeq(contxt_batch, output_batch)
+
+        n_batch_, t_len_, s_len_ = attn.size()
+        aeq(input_batch, n_batch_)
+        aeq(contxt_len, s_len_)
+        aeq(input_len, t_len_)
+        # END CHECKS
+
+        return output, attn, all_input
+
+    def _get_attn_subsequent_mask(self, size):
+        ''' Get an attention mask to avoid using the subsequent info.'''
+        attn_shape = (1, size, size)
+        subsequent_mask = np.triu(np.ones(attn_shape), k=1).astype('uint8')
+        subsequent_mask = torch.from_numpy(subsequent_mask)
+        return subsequent_mask
+
+
+class GPT2Decoder(nn.Module):
+    """
+    The Transformer decoder from "Attention is All You Need". 
+    
+    Except, the self-attention layer and feed-forward uses Conv1D for 
+    attention and fully-connected calculations, like in GPT2. So now 
+    it is possible to load the pre-trained weights of GPT2.
+    
+    The src-attn is same as before, because there are no pre-trained weights
+    for src-attn layer, so it can be used with Linear layer as well. 
+    Also the attention score calculated from src-attn is used for copy 
+    mechanism, so it is not changed.
+
+
+
+    .. mermaid::
+
+       graph BT
+          A[input]
+          B[multi-head self-attn]
+          BB[multi-head src-attn]
+          C[feed forward]
+          O[output]
+          A --> B
+          B --> BB
+          BB --> C
+          C --> O
+
+
+    Args:
+       num_layers (int): number of encoder layers.
+       hidden_size (int): number of hidden units
+       dropout (float): dropout parameters
+       embeddings (:obj:`onmt.modules.Embeddings`):
+          embeddings to use, should have positional encodings
+
+       attn_type (str): if using a seperate copy attention
+    """
+    def __init__(self, num_layers, hidden_size, attn_type,
+                 copy_attn, dropout, embeddings):
+        super(GPT2Decoder, self).__init__()
+
+        # Basic attributes.
+        self.decoder_type = 'gpt2_decoder'
+        self.num_layers = num_layers
+        self.embeddings = embeddings
+
+        # Build TransformerDecoder.
+        self.transformer_layers = nn.ModuleList(
+            [GPT2DecoderLayer(hidden_size, dropout)
+             for _ in range(num_layers)])
+
+        # TransformerDecoder has its own attention mechanism.
+        # Set up a separated copy attention layer, if needed.
+        self._copy = False
+        if copy_attn:
+            self.copy_attn = onmt.modules.GlobalAttention(
+                hidden_size, attn_type=attn_type)
+            self._copy = True
+        self.layer_norm = onmt.modules.LayerNorm(hidden_size)
+
+    def forward(self, tgt, memory_bank, state, memory_lengths=None):
+        """
+        See :obj:`onmt.modules.RNNDecoderBase.forward()`
+        """
+        # CHECKS
+        assert isinstance(state, GPTDecoderState)
+        tgt_len, tgt_batch, _ = tgt.size()
+        memory_len, memory_batch, _ = memory_bank.size()
+        aeq(tgt_batch, memory_batch)
+
+        src = state.src
+        src_words = src[:, :, 0].transpose(0, 1)
+        tgt_words = tgt[:, :, 0].transpose(0, 1)
+        src_batch, src_len = src_words.size()
+        tgt_batch, tgt_len = tgt_words.size()
+        aeq(tgt_batch, memory_batch, src_batch, tgt_batch)
+        aeq(memory_len, src_len)
+
+        if state.previous_input is not None:
+            tgt = torch.cat([state.previous_input, tgt], 0)
+        # END CHECKS
+
+        # Initialize return variables.
+        outputs = []
+        attns = {"std": []}
+        if self._copy:
+            attns["copy"] = []
+
+        # Run the forward pass of the TransformerDecoder.
+        emb = self.embeddings(tgt)
+        if state.previous_input is not None:
+            emb = emb[state.previous_input.size(0):, ]
+        assert emb.dim() == 3  # len x batch x embedding_dim
+
+        output = emb.transpose(0, 1).contiguous()
+        src_memory_bank = memory_bank.transpose(0, 1).contiguous()
+
+        padding_idx = self.embeddings.word_padding_idx
+        src_pad_mask = src_words.data.eq(padding_idx).unsqueeze(1) \
+            .expand(src_batch, tgt_len, src_len)
+        tgt_pad_mask = tgt_words.data.eq(padding_idx).unsqueeze(1) \
+            .expand(tgt_batch, tgt_len, tgt_len)
+
+        saved_inputs = []
+        for i in range(self.num_layers):
+            prev_layer_input = None
+            if state.previous_input is not None:
+                prev_layer_input = state.previous_layer_inputs[i]
+            output, attn, all_input \
+                = self.transformer_layers[i](output, src_memory_bank,
+                                             src_pad_mask, tgt_pad_mask,
+                                             previous_input=prev_layer_input)
+            saved_inputs.append(all_input)
+
+        saved_inputs = torch.stack(saved_inputs)
+        output = self.layer_norm(output)
+
+        # Process the result and update the attentions.
+        outputs = output.transpose(0, 1).contiguous()
+        attn = attn.transpose(0, 1).contiguous()
+
+        attns["std"] = attn
+        if self._copy:
+            attns["copy"] = attn
+
+        # Update the state.
+        state = state.update_state(tgt, saved_inputs)
+        return outputs, state, attns
+
+    def init_decoder_state(self, src, memory_bank, enc_hidden):
+        return GPTDecoderState(src)
+
+class GPTDecoderState(DecoderState):
+    def __init__(self, src):
+        """
+        Args:
+            src (FloatTensor): a sequence of source words tensors
+                    with optional feature tensors, of size (len x batch).
+        """
+        self.src = src
+        self.previous_input = None
+        self.previous_layer_inputs = None
+
+    @property
+    def _all(self):
+        """
+        Contains attributes that need to be updated in self.beam_update().
+        """
+        return (self.previous_input, self.previous_layer_inputs, self.src)
+
+    def update_state(self, input, previous_layer_inputs):
+        """ Called for every decoder forward pass. """
+        state = GPTDecoderState(self.src)
+        state.previous_input = input
+        state.previous_layer_inputs = previous_layer_inputs
+        return state
+
+    def repeat_beam_size_times(self, beam_size):
+        """ Repeat beam_size times along batch dimension. """
+        self.src = Variable(self.src.data.repeat(1, beam_size, 1),
+                            volatile=True)
+

--- a/onmt/models/load_gpt2.py
+++ b/onmt/models/load_gpt2.py
@@ -1,0 +1,99 @@
+import torch
+
+def load_pretrained_weights(model, gpt2_path):
+    """
+    This function can be used for loading pre-trained GPT2 weights, except the embedding layers (wte & wpe).
+
+    Not sure, where to put this file or to call. So adding it here, can be called anywhere according to the need.
+
+    Args:
+        model (NMTModel): the initial seq2seq model with GPT2Decoder as decoder
+        gpt2_path (str): path to pre-trained gpt2 weights downloaded from huggingface's transformers. This can 
+        be downloaded from https://s3.amazonaws.com/models.huggingface.co/bert/gpt2-pytorch_model.bin
+
+
+    Return:
+        model (NMTModel): model loaded with pre-trained weights for decoder
+    """
+
+    model_dict = model.state_dict()
+    state_dict = torch.load(gpt2_path) #pretrained weights
+
+    old_keys = []
+    new_keys = []
+    for key in state_dict.keys():
+        if "ln_1.weight" in key:
+            new_key = key.replace("ln_1.weight", "layer_norm_1.weight")
+            new_keys.append(new_key)
+            old_keys.append(key)
+        if "ln_1.bias" in key:
+            new_key = key.replace("ln_1.bias", "layer_norm_1.bias")
+            new_keys.append(new_key)
+            old_keys.append(key)
+        if "ln_2.weight" in key:
+            new_key = key.replace("ln_2.weight", "layer_norm_2.weight")
+            new_keys.append(new_key)
+            old_keys.append(key)
+        if "ln_2.bias" in key:
+            new_key = key.replace("ln_2.bias", "layer_norm_2.bias")
+            new_keys.append(new_key)
+            old_keys.append(key)
+
+        if "mlp.c_fc.weight" in key:
+            new_key = key.replace("mlp.c_fc.weight", "feed_forward.c_fc.weight")
+            new_keys.append(new_key)
+            old_keys.append(key)
+        if "mlp.c_fc.bias" in key:
+            new_key = key.replace("mlp.c_fc.bias", "feed_forward.c_fc.bias")
+            new_keys.append(new_key)
+            old_keys.append(key)
+
+        if "mlp.c_proj.weight" in key:
+            new_key = key.replace("mlp.c_proj.weight", "feed_forward.c_proj.weight")
+            new_keys.append(new_key)
+            old_keys.append(key)
+        if "mlp.c_proj.bias" in key:
+            new_key = key.replace("mlp.c_proj.bias", "feed_forward.c_proj.bias")
+            new_keys.append(new_key)
+            old_keys.append(key)
+
+        if "attn.c_attn.weight" in key:
+            new_key = key.replace("attn.c_attn.weight", "self_attn.c_attn.weight")
+            new_keys.append(new_key)
+            old_keys.append(key)
+        if "attn.c_attn.bias" in key:
+            new_key = key.replace("attn.c_attn.bias", "self_attn.c_attn.bias")
+            new_keys.append(new_key)
+            old_keys.append(key)
+
+        if "attn.c_proj.weight" in key:
+            new_key = key.replace("attn.c_proj.weight", "self_attn.c_proj.weight")
+            new_keys.append(new_key)
+            old_keys.append(key)
+        if "attn.c_proj.bias" in key:
+            new_key = key.replace("attn.c_proj.bias", "self_attn.c_proj.bias")
+            new_keys.append(new_key)
+            old_keys.append(key)
+
+        tmp = ".".join(key.split(".")[2:])
+        if "attn.bias" == tmp:
+            new_key = key.replace("attn.bias", "self_attn.bias")
+            new_keys.append(new_key)
+            old_keys.append(key)
+
+    for old_key, new_key in zip(old_keys, new_keys):
+        state_dict[new_key]=state_dict.pop(old_key)
+
+    pretrained_dict = {}
+    for ks, vs in state_dict.items():
+        for km, vm in model_dict.items():
+            if "decoder.transformer_layers" in km:
+                ks1 = '.'.join(ks.split('.')[1:])
+                km1 = '.'.join(km.split('.')[2:])
+                if ks1 == km1:
+                    pretrained_dict[km] = vs
+
+    model_dict.update(pretrained_dict)
+    model.load_state_dict(model_dict)
+
+    return model


### PR DESCRIPTION
GPT2 is different than TransformerDecoder in two ways:

1. GPT2 uses Conv1D for self-attn and feed-forward
2. GPT2 doesn't have any src-attn layer

But it can be used as a decoder by adding cross-attention (or src-attn) layer, as done in [huggingface's GPT2 implementation](https://github.com/huggingface/transformers/blob/master/src/transformers/modeling_gpt2.py#L302). 

Here, two main contributions are added:

1. I've changed the self-attention layer to Conv1D attention provided by [huggingface](https://github.com/huggingface/transformers/blob/master/src/transformers/modeling_gpt2.py#L123) so that GPT2's pre-trained weights can be loaded. For cross-attention (or src-attention), the same MultiHeadedAttn is used similar to TransformerDecoder class. I didn't change it to Conv1D mainly because I didn't want to mess with attention scores being calculated there, because attention scores calculated in the cross-attention layer are used for copy mechanism.
2. I've added a function to load pre-trained GPT2 weights to an NMTModel. The pre-trained weights are downloaded from huggingface only.

Please take a look and see if the code is correct, especially for the part where Conv1DAttention is used. I checked both, TransfomerDecoder (one with LinearLayer for attention calculation), and GPT2Decoder (one with Conv1D attention calculation) and the results are almost similar.

Thanks.