### PR TITLE
fix building of documentation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 sphinx==2.4.*
-sphinxcontrib.bibtex
-sphinxcontrib.mermaid
+sphinxcontrib.bibtex==1.0.0
+sphinxcontrib.mermaid==0.5.0
 sphinx-rtd-theme==0.4.*
 recommonmark==0.6.*
 sphinx-argparse==0.2.*

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,16 +32,12 @@
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 
-from recommonmark.parser import CommonMarkParser
 import sphinx_rtd_theme
 from recommonmark.transform import AutoStructify
 
-source_parsers = {
-    '.md': CommonMarkParser,
-}
-
 source_suffix = ['.rst', '.md']
-extensions = ['sphinx.ext.autodoc',
+extensions = ['recommonmark',
+              'sphinx.ext.autodoc',
               'sphinx.ext.mathjax',
               'sphinx.ext.viewcode',
               'sphinx.ext.coverage',


### PR DESCRIPTION
`make html` was not working due to a silent update of sphinx

- freeze dependencies
- add recommonmark correctly https://recommonmark.readthedocs.io/en/latest/