### PR TITLE
Upgrade pyonmttok package and relax the version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         "tensorboard==2.3.0",
         "flask==1.1.2",
         "waitress==1.4.4",
-        "pyonmttok==1.22.1;platform_system=='Linux'",
+        "pyonmttok>=1.23,<2;platform_system=='Linux' or platform_system=='Darwin'",
         "pyyaml==5.3.1",
     ],
     entry_points={


### PR DESCRIPTION
The module API will not change as long as it is in V1, so it is quite safe to relax the version requirement.

Also the latest version has wheels for macOS, so the platform check is updated accordingly.