### PR TITLE
BART: set `-poisson_lambda` default to 3.0

### DIFF
--- a/onmt/transforms/bart.py
+++ b/onmt/transforms/bart.py
@@ -339,7 +339,7 @@ class BARTNoiseTransform(Transform):
                   choices=["subword", "word", "span-poisson"],
                   help="Length of masking window to apply.")
         group.add("--poisson_lambda", "-poisson_lambda",
-                  type=float, default=0.0,
+                  type=float, default=3.0,
                   help="Lambda for Poisson distribution to sample span length "
                        "if `-mask_length` set to span-poisson.")
         group.add("--replace_length", "-replace_length",


### PR DESCRIPTION
So just using `-mask_length span-poisson` imply lambda=3.0, as in the paper.