### PR TITLE
Relax tqdm version requirement to 4.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     install_requires=[
         "numpy==1.19.3",
         "six==1.15.0",
-        "tqdm==4.51.0",
+        "tqdm>=4.51,<5",
         "torch==1.6.0",
         "torchtext==0.5.0",
         "future==0.18.2",


### PR DESCRIPTION
`tqdm` follows semantic versioning: https://github.com/tqdm/tqdm/blob/master/CONTRIBUTING.md#semantic-versioning