### PR TITLE
Relax configargparse version requirement to 1.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "torch==1.6.0",
         "torchtext==0.5.0",
         "future==0.18.2",
-        "configargparse==1.2.3",
+        "configargparse>=1.2.3,<2",
         "tensorboard==2.3.0",
         "flask==1.1.2",
         "waitress==1.4.4",


### PR DESCRIPTION
`configargparse` follows semantic versioning: https://github.com/bw2/ConfigArgParse#versioning