### PR TITLE
Remove explicit dependency to numpy

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade setuptools==50.3.0
-        python setup.py install
+        pip install -e .
         pip install -r requirements.opt.txt
         pip install flake8
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
@@ -273,7 +273,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade setuptools
-        python setup.py install
+        pip install -e .
         pip install -r docs/requirements.txt
     - name: Build docs
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade setuptools
-        python setup.py install
+        pip install -e .
         pip install -r docs/requirements.txt
     - name: Build docs
       run: |

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         "Source": "https://github.com/OpenNMT/OpenNMT-py/"
     },
     install_requires=[
-        "numpy==1.19.3",
         "six==1.15.0",
         "tqdm==4.51.0",
         "torch==1.6.0",


### PR DESCRIPTION
Numpy is already a dependency of PyTorch, which probably has a more specific Numpy version requirement than OpenNMT-py.