### PR TITLE
Relax tensorboard version requirement to 2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "torchtext==0.5.0",
         "future==0.18.2",
         "configargparse==1.2.3",
-        "tensorboard==2.3.0",
+        "tensorboard>=2.3,<3",
         "flask==1.1.2",
         "waitress==1.4.4",
         "pyonmttok>=1.23,<2;platform_system=='Linux' or platform_system=='Darwin'",


### PR DESCRIPTION
This is to support installing OpenNMT-py alongside TensorFlow projects which may have higher TensorBoard version requirement.