### PR TITLE
Remove six dependency (bis)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     },
     python_requires=">=3.5",
     install_requires=[
-        "six==1.15.0",
         "tqdm>=4.51,<5",
         "torch==1.6.0",
         "torchtext==0.5.0",


### PR DESCRIPTION
Looks like the `six` dependency reappeared during a merge. It would have been easier if I sent all changes in one PR. Sorry!