### PR TITLE
Update checkpoint vocabulary (fix)

### DIFF
--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -89,6 +89,9 @@ def load_test_model(opt, model_path=None):
     ArgumentParser.validate_model_opts(model_opt)
     fields = checkpoint['vocab']
 
+    # Avoid functionality on inference
+    model_opt.update_vocab = False
+
     model = build_base_model(model_opt, fields, use_gpu(opt), checkpoint,
                              opt.gpu)
     if opt.fp32:

--- a/onmt/utils/parse.py
+++ b/onmt/utils/parse.py
@@ -290,8 +290,8 @@ class ArgumentParser(cfargparse.ArgumentParser, DataOptsCheckerMixin):
         if opt.update_vocab:
             assert opt.train_from, \
                 "-update_vocab needs -train_from option"
-            assert opt.reset_optim == 'states', \
-                '-update_vocab needs -reset_optim "states"'
+            assert opt.reset_optim in ['states', 'all'], \
+                '-update_vocab needs -reset_optim "states" or "all"'
 
     @classmethod
     def validate_translate_opts(cls, opt):


### PR DESCRIPTION
This is a PR to fix some issues with checkpoint's vocabulary updating.

1. Fixed validation to accept `reset_optim` to be either "states" or "all"
2. Overrides checkpoint `update_vocab=False` on inference