### PR TITLE
Better handle transforms that require vocab

### DIFF
--- a/onmt/inputters/corpus.py
+++ b/onmt/inputters/corpus.py
@@ -249,8 +249,10 @@ def build_corpora_iters(corpora, transforms, corpora_info, is_train=False,
     """Return `ParallelCorpusIterator` for all corpora defined in opts."""
     corpora_iters = dict()
     for c_id, corpus in corpora.items():
-        c_transform_names = corpora_info[c_id].get('transforms', [])
-        corpus_transform = [transforms[name] for name in c_transform_names]
+        transform_names = corpora_info[c_id].get('transforms', [])
+        corpus_transform = [
+            transforms[name] for name in transform_names if name in transforms
+        ]
         transform_pipe = TransformPipe.build_from(corpus_transform)
         logger.info(f"{c_id}'s transforms: {str(transform_pipe)}")
         corpus_iter = ParallelCorpusIterator(

--- a/onmt/transforms/sampling.py
+++ b/onmt/transforms/sampling.py
@@ -55,12 +55,10 @@ class SwitchOutTransform(HammingDistanceSamplingTransform):
     def __init__(self, opts):
         super().__init__(opts)
 
-    def warm_up(self, vocabs):
-        super().warm_up(None)
-        self.vocabs = vocabs
-        if vocabs is None:
-            logger.warning(
-                "Switchout disable as no vocab, shouldn't happen in training!")
+    @classmethod
+    def require_vocab(cls):
+        """Override this method to inform it need vocab to start."""
+        return True
 
     @classmethod
     def add_options(cls, parser):
@@ -76,7 +74,6 @@ class SwitchOutTransform(HammingDistanceSamplingTransform):
         self.temperature = self.opts.switchout_temperature
 
     def _switchout(self, tokens, vocab, stats=None):
-        assert vocab is not None, "vocab can not be None for SwitchOut."
         # 1. sample number of tokens to corrupt
         n_chosen = self._sample_distance(tokens, self.temperature)
         # 2. sample positions to corrput
@@ -95,7 +92,7 @@ class SwitchOutTransform(HammingDistanceSamplingTransform):
 
     def apply(self, example, is_train=False, stats=None, **kwargs):
         """Apply switchout to both src and tgt side tokens."""
-        if is_train and self.vocabs is not None:
+        if is_train:
             src = self._switchout(
                 example['src'], self.vocabs['src'].itos, stats)
             tgt = self._switchout(

--- a/onmt/transforms/transform.py
+++ b/onmt/transforms/transform.py
@@ -31,7 +31,7 @@ class Transform(object):
         """
         if self.opts.seed > 0:
             self._set_seed(self.opts.seed)
-        if self.require_vocab:
+        if self.require_vocab():
             if vocabs is None:
                 raise ValueError(f"{type(self).__name__} requires vocabs!")
             self.vocabs = vocabs

--- a/onmt/transforms/transform.py
+++ b/onmt/transforms/transform.py
@@ -17,6 +17,11 @@ class Transform(object):
         """Reproducibility: Set seed for non-deterministic transform."""
         pass
 
+    @classmethod
+    def require_vocab(cls):
+        """Override this method to inform it need vocab to start."""
+        return False
+
     def warm_up(self, vocabs=None):
         """Procedure needed after initialize and before apply.
 
@@ -26,6 +31,10 @@ class Transform(object):
         """
         if self.opts.seed > 0:
             self._set_seed(self.opts.seed)
+        if self.require_vocab:
+            if vocabs is None:
+                raise ValueError(f"{type(self).__name__} requires vocabs!")
+            self.vocabs = vocabs
 
     @classmethod
     def add_options(cls, parser):
@@ -217,6 +226,11 @@ def make_transforms(opts, transforms_cls, fields):
     vocabs = get_vocabs(fields) if fields is not None else None
     transforms = {}
     for name, transform_cls in transforms_cls.items():
+        if transform_cls.require_vocab() and vocabs is None:
+            logger.warning(
+                f"{transform_cls.__name__} require vocab to apply, skip it."
+            )
+            continue
         transform_obj = transform_cls(opts)
         transform_obj.warm_up(vocabs)
         transforms[name] = transform_obj


### PR DESCRIPTION
The transforms that require vocab could not be applied if we don't provide the required vocabulary. We should not provide them when build_vocab, but only in the training phase when the vocabulary is already available.
Currently, we check this in the transform.apply which may be misleading and not optimal.
In this PR, we do the check when building the transform object, those transform requires vocabulary will not be instantiated if we don't provide them vocab as in `build_vocab.py` and should raise an explicit error when we tried to.