### PR TITLE
Set position_encoding to True in transformer example config.

### DIFF
--- a/examples/onmt.train.fp16.transformer.yaml
+++ b/examples/onmt.train.fp16.transformer.yaml
@@ -100,3 +100,4 @@ dropout: [0.1]
 attention_dropout: [0.1]
 share_decoder_embeddings: true
 share_embeddings: true
+position_encoding: true


### PR DESCRIPTION
I trained a model config by `examples/onmt.train.fp16.transformer.yaml`. I convert trained model by command `onmt_release_model -m general_en_zh_step_90000.pt -o ct2_convert --format ctranslate2 -q int8`. The error raised.
```
Traceback (most recent call last):
  File "/home/hanbing/miniconda3/bin/onmt_release_model", line 33, in <module>
    sys.exit(load_entry_point('OpenNMT-py', 'console_scripts', 'onmt_release_model')())
  File "/home/hanbing/projects/OpenNMT-py/onmt/bin/release_model.py", line 35, in main
    quantization=opt.quantization)
  File "/home/hanbing/miniconda3/lib/python3.7/site-packages/ctranslate2/converters/converter.py", line 45, in convert
    model_spec = self._load()
  File "/home/hanbing/miniconda3/lib/python3.7/site-packages/ctranslate2/converters/opennmt_py.py", line 63, in _load
    model_spec = _get_model_spec(checkpoint["opt"])
  File "/home/hanbing/miniconda3/lib/python3.7/site-packages/ctranslate2/converters/opennmt_py.py", line 42, in _get_model_spec
    utils.raise_unsupported(reasons)
  File "/home/hanbing/miniconda3/lib/python3.7/site-packages/ctranslate2/converters/utils.py", line 16, in raise_unsupported
    raise ValueError(message)
ValueError: The model you are trying to convert is not supported by CTranslate2. We identified the following reasons:

- Options --position_encoding and --max_relative_positions cannot be both enabled or both disabled
```
position_encoding should be set to true in the configuration file.