### PR TITLE
add ct2 server parameters

### DIFF
--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -262,6 +262,10 @@ class ServerModel(object):
             timeout (see :func:`do_timeout()`.)
         model_root (str): Path to the model directory
             it must contain the model and tokenizer file
+        ct2_model (str): Path to the CTranslate2 model directory
+        inter_threads (int): Maximum number of CPU translations executed in parallel
+        intra_threads (int): Number of OpenMP threads that is used per translation
+        compute_type (str): The type used for computation
     """
 
     def __init__(self, opt, model_id, preprocess_opt=None, tokenizer_opt=None,


### PR DESCRIPTION
fix: #2001 

This pull request will allow to set the server specs for CTranslate2


# Experiment

## Setting
server_conf
```
{
    "models_root": "./available_models",
    "models": [
        {
            "id": 100,
            "ct2_model": "ende_ctranslate2/",
            "model": "ende_ctranslate2/",
            "timeout": 600,
            "device": "cpu",
            "on_timeout": "to_cpu",
            "load": true,
            "tokenizer": {
                "type": "sentencepiece",
                "model": "sentencepiece.model"
            },
            "inter_threads": 1,
            "intra_threads": 1,
            "compute_type": "default",
            "opt": {
                "beam_size": 5
            }
        }
    ]
}
```
## Data
- The model uses the [CTranslate2 sample](https://github.com/OpenNMT/CTranslate2#quickstart)
- Translation is the average translation time of the top 100 sentences from [toy-ende](https://github.com/OpenNMT/OpenNMT-py#step-1-prepare-the-data).

## Performance
Process evaluation by changing `inter_threads` and `intra_threads`




inter_threads | intra_threads | time_avg[sec]
-- | -- | --
1 | 1 | 0.55
1 | 8 | 0.29
8 | 1 | 0.57
8 | 8 | 1.82
