### PR TITLE
Remove environment markers for pyonmttok package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         "tensorboard>=2.3",
         "flask",
         "waitress",
-        "pyonmttok>=1.23,<2;platform_system=='Linux' or platform_system=='Darwin'",
+        "pyonmttok>=1.23,<2",
         "pyyaml",
     ],
     entry_points={


### PR DESCRIPTION
The package is now available on Linux, macOS, and Windows.