### PR TITLE
Add int8_float16 as possible quantization value for CTranslate2

### DIFF
--- a/onmt/bin/release_model.py
+++ b/onmt/bin/release_model.py
@@ -15,7 +15,7 @@ def main():
                         default="pytorch",
                         help="The format of the released model")
     parser.add_argument("--quantization", "-q",
-                        choices=["int8", "int16", "float16"],
+                        choices=["int8", "int16", "float16", "int8_float16"],
                         default=None,
                         help="Quantization type for CT2 model.")
     opt = parser.parse_args()


### PR DESCRIPTION
This value is supported since CTranslate2 2.3. More information [here](https://github.com/OpenNMT/CTranslate2/blob/master/docs/quantization.md#quantized-types).