### PR TITLE
Use the same number of threads as PyTorch in CTranslate2

### DIFF
--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -111,7 +111,7 @@ class CTranslate2Translator(object):
 
         default_for_translator = {
             "inter_threads": 1,
-            "intra_threads": 1,
+            "intra_threads": torch.get_num_threads(),
             "compute_type": "default",
         }
         for name, value in default_for_translator.items():
@@ -189,9 +189,9 @@ class TranslationServer(object):
                       'model_root': conf.get('model_root', self.models_root),
                       'ct2_model': conf.get('ct2_model', None),
                       'ct2_translator_args': conf.get('ct2_translator_args',
-                                                      None),
+                                                      {}),
                       'ct2_translate_batch_args': conf.get(
-                          'ct2_translate_batch_args', None),
+                          'ct2_translate_batch_args', {}),
                       }
             kwargs = {k: v for (k, v) in kwargs.items() if v is not None}
             model_id = conf.get("id", None)


### PR DESCRIPTION
With `intra_threads=1`, the CTranslate2 models appear slower than PyTorch on CPU which can be surprising when using the server for the first time. A better default is to use the same number of threads as PyTorch.

Note that when running on GPU the CTranslate2 translator will automatically force this value to 1.