### PR TITLE
fixed src-feats parameter error for REST server and CTranslate2 models

### DIFF
--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -139,7 +139,10 @@ class CTranslate2Translator(object):
             setdefault_if_exists_must_match(
                 ct2_translate_batch_args, name, value)
 
-    def translate(self, texts_to_translate, batch_size=8, tgt=None):
+    def translate(self, texts_to_translate, batch_size=8,
+                  tgt=None, src_feats=None):
+        assert (src_feats is None) or (src_feats == {}), \
+            "CTranslate2 does not support source features"
         batch = [item.split(" ") for item in texts_to_translate]
         if tgt is not None:
             tgt = [item.split(" ") for item in tgt]


### PR DESCRIPTION
Fixed the src-feats parameter error for REST server when using CTranslate2 models per @francoishernandez instructions and guidance.  I did run the check PR request script to verify there were no breaking changes.  Code was tested with CTranslate2 models and functions as expected.