### PR TITLE
Introduce validation post-batch and post-epoch handlers

### DIFF
--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -20,8 +20,7 @@ from onmt.models import NMTModel
 import onmt.utils
 from onmt.utils.logging import logger
 
-PostBatchHandler = T.Callable[[NMTModel, Batch, torch.Tensor,
-                               T.Dict[str, torch.Tensor]], T.Any]
+PostBatchHandler = T.Callable[[NMTModel, Batch], T.Any]
 PostEpochHandler = T.Callable[[T.List[T.Any]], None]
 
 
@@ -346,8 +345,7 @@ class Trainer(object):
 
                     if self.valid_post_batch_handler is not None:
                         result = self.valid_post_batch_handler(valid_model,
-                                                               batch, outputs,
-                                                               attns)
+                                                               batch)
                         valid_post_batch_results.append(result)
 
                 # Update statistics.

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -18,10 +18,11 @@ from torchtext.data import Batch
 
 from onmt.models import NMTModel
 import onmt.utils
+from onmt.utils import ReportMgr
 from onmt.utils.logging import logger
 
 PostBatchHandler = T.Callable[[NMTModel, Batch], T.Any]
-PostEpochHandler = T.Callable[[T.List[T.Any]], None]
+PostEpochHandler = T.Callable[[NMTModel, T.List[T.Any], int, ReportMgr], None]
 
 
 def build_trainer(opt, device_id, model, fields, optim, model_saver=None):
@@ -356,7 +357,10 @@ class Trainer(object):
                 param.data = param_data
 
         if self.valid_post_epoch_handler is not None:
-            self.valid_post_epoch_handler(valid_post_batch_results)
+            self.valid_post_epoch_handler(valid_model,
+                                          valid_post_batch_results,
+                                          self.optim.training_step,
+                                          self.report_manager)
 
         # Set model back to training mode.
         valid_model.train()


### PR DESCRIPTION
There are many complaints regarding the lack of BLEU metric logging during training (e.g. #2146,  #2129 or #1158).  To enable calculation of any validation metric during training I suggest to introduce two validation event handlers:
- post-batch (where we can generate translations for a given batch, e.g. using `onmt.translate.Translator`)
- post-epoch (where we can gather all translated  sentences, de-tokenize them and calculate corpus-wide BLEU, chrF or any other metric on the whole validset).

The handlers can be defined by a user and assigned to `opt` before a call to `onmt_train` is made:
```
opt.valid_post_batch_handler = my_custom_valid_post_batch_handler_function
opt.valid_post_epoch_handler = my_custom_valid_post_epoch_handler_function
onmt_train(opt)
```