### PR TITLE
Support encoder/decoder freezing.

### DIFF
--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -304,6 +304,15 @@ def build_base_model(model_opt, fields, gpu, checkpoint=None, gpu_id=None):
         generator.load_state_dict(checkpoint['generator'], strict=False)
 
     model.generator = generator
+
+    if model_opt.freeze_encoder:
+        model.encoder.requires_grad_(False)
+        model.encoder.embeddings.requires_grad_()
+
+    if model_opt.freeze_decoder:
+        model.decoder.requires_grad_(False)
+        model.decoder.embeddings.requires_grad_()
+
     model.to(device)
     if model_opt.model_dtype == 'fp16' and model_opt.optim == 'fusedadam':
         model.half()

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -496,6 +496,14 @@ def _add_train_general_opts(parser):
               action='store_true',
               help="Freeze word embeddings on the decoder side.")
 
+    # Freeze Encoder and/or Decoder
+    group.add('--freeze_encoder', '-freeze_encoder',
+              action='store_true',
+              help="Freeze parameters in encoder.")
+    group.add('--freeze_decoder', '-freeze_decoder',
+              action='store_true',
+              help="Freeze parameters in decoder.")
+
     # Optimization options
     group = parser.add_argument_group('Optimization- Type')
     group.add('--batch_size', '-batch_size', type=int, default=64,

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -285,6 +285,14 @@ def model_opts(parser):
                    "are experimental. Options are "
                    "[rnn|transformer|cnn|transformer].")
 
+    # Freeze Encoder and/or Decoder
+    group.add('--freeze_encoder', '-freeze_encoder',
+              action='store_true',
+              help="Freeze parameters in encoder.")
+    group.add('--freeze_decoder', '-freeze_decoder',
+              action='store_true',
+              help="Freeze parameters in decoder.")
+
     group.add('--layers', '-layers', type=int, default=-1,
               help='Number of layers in enc/dec.')
     group.add('--enc_layers', '-enc_layers', type=int, default=2,
@@ -495,14 +503,6 @@ def _add_train_general_opts(parser):
     group.add('--freeze_word_vecs_dec', '-freeze_word_vecs_dec',
               action='store_true',
               help="Freeze word embeddings on the decoder side.")
-
-    # Freeze Encoder and/or Decoder
-    group.add('--freeze_encoder', '-freeze_encoder',
-              action='store_true',
-              help="Freeze parameters in encoder.")
-    group.add('--freeze_decoder', '-freeze_decoder',
-              action='store_true',
-              help="Freeze parameters in decoder.")
 
     # Optimization options
     group = parser.add_argument_group('Optimization- Type')

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -33,6 +33,9 @@ def _get_model_opts(opt, checkpoint=None):
             opt.tensorboard_log_dir_dated = model_opt.tensorboard_log_dir_dated
         # Override checkpoint's update_embeddings as it defaults to false
         model_opt.update_vocab = opt.update_vocab
+        # Override checkpoint's freezing settings as it defaults to false
+        model_opt.freeze_encoder = opt.freeze_encoder
+        model_opt.freeze_decoder = opt.freeze_decoder
     else:
         model_opt = opt
     return model_opt

--- a/onmt/utils/loss.py
+++ b/onmt/utils/loss.py
@@ -453,5 +453,7 @@ def shards(state, shard_size, eval_only=False):
             if isinstance(v, torch.Tensor) and state[k].requires_grad:
                 variables.extend(zip(torch.split(state[k], shard_size),
                                      [v_chunk.grad for v_chunk in v_split]))
-        inputs, grads = zip(*variables)
-        torch.autograd.backward(inputs, grads)
+
+        if variables:
+            inputs, grads = zip(*variables)
+            torch.autograd.backward(inputs, grads)


### PR DESCRIPTION
I propose supporting parameter freezing of the encoder and decoder. I've implemented the feature for use in my own experiments and would like to contribute the patch in response to interest demonstrated in #1857 and https://forum.opennmt.net/t/transformer-freezing-encoder-while-training-decoder/2723

The change works by
* Conditionally setting `requires_grad` to `False` on encoder/decoder parameters as specified in the configuration options
* Overwriting the freezing options from a loaded checkpoint (this is to support the most common use of parameter freezing, which is to freeze and transfer weights between training runs to be altered or fixed, e.g. to fine-tune, in another context)

Please leave any thoughts you have as comments. I am happy to refactor to fit the conventions of the repo, etc.