### PR TITLE
stop using the root logger and use an "onmt" logger

### DIFF
--- a/onmt/utils/logging.py
+++ b/onmt/utils/logging.py
@@ -11,7 +11,7 @@ def init_logger(
     log_level=logging.INFO,
 ):
     log_format = logging.Formatter("[%(asctime)s %(levelname)s] %(message)s")
-    logger = logging.getLogger()
+    logger = logging.getLogger("onmt")
     logger.setLevel(log_level)
 
     console_handler = logging.StreamHandler()


### PR DESCRIPTION
I've had this issues where I need to override the `init_logger` function just to avoid having `onmt` use the root logger. I'm open to making any changes here to avoid onmt polluting the root logger.