### PR TITLE
Fixscores

### DIFF
--- a/data/data_lm/gen-beam-sol.txt
+++ b/data/data_lm/gen-beam-sol.txt
@@ -1,7 +1,7 @@
 you !
 in German German Presidency in German Presidency in German Presidency in German Presidency in the Netherlands .
-the future .
-"
-ignored .
+the top of the top of the top of the top of the top of the top of the top of the top of the top of the future .
+" s central banks don " t delay the farm !
+the usefulness of the interinstitutional resources .
 do ?
-800 m2 in images .
+800 m2 in size , or hours and can be hours .

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -687,11 +687,11 @@ def _add_decoding_opts(parser):
     # Alpha and Beta values for Google Length + Coverage penalty
     # Described here: https://arxiv.org/pdf/1609.08144.pdf, Section 7
     # Length penalty options
-    group.add('--length_penalty', '-length_penalty', default='none',
+    group.add('--length_penalty', '-length_penalty', default='avg',
               choices=['none', 'wu', 'avg'],
               help="Length Penalty to use.")
-    group.add('--alpha', '-alpha', type=float, default=0.,
-              help="Google NMT length penalty parameter "
+    group.add('--alpha', '-alpha', type=float, default=1.0,
+              help="Length penalty hyper-parameter "
                    "(higher = longer generation)")
     # Coverage penalty options
     group.add('--coverage_penalty', '-coverage_penalty', default='none',

--- a/onmt/tests/test_beam_search.py
+++ b/onmt/tests/test_beam_search.py
@@ -445,7 +445,8 @@ class TestBeamSearchAgainstReferenceCase(unittest.TestCase):
         expected_beam_scores, unreduced_preds = new_scores\
             .view(self.BATCH_SZ, self.BEAM_SZ * self.N_WORDS)\
             .topk(self.BEAM_SZ, -1)
-        expected_bptr_1 = unreduced_preds // self.N_WORDS
+        expected_bptr_1 = torch.div(unreduced_preds, self.N_WORDS,
+                                    rounding_mode='trunc')
         # [5, 3, 2, 6, 0], so beam 2 predicts EOS!
         expected_preds_1 = unreduced_preds - expected_bptr_1 * self.N_WORDS
         self.assertTrue(beam.topk_log_probs.allclose(expected_beam_scores))
@@ -479,7 +480,8 @@ class TestBeamSearchAgainstReferenceCase(unittest.TestCase):
         expected_beam_scores, unreduced_preds = new_scores\
             .view(self.BATCH_SZ, self.BEAM_SZ * self.N_WORDS)\
             .topk(self.BEAM_SZ, -1)
-        expected_bptr_2 = unreduced_preds // self.N_WORDS
+        expected_bptr_2 = torch.div(unreduced_preds, self.N_WORDS,
+                                    rounding_mode='trunc')
         # [2, 5, 3, 6, 0] repeat self.BATCH_SZ, so beam 0 predicts EOS!
         expected_preds_2 = unreduced_preds - expected_bptr_2 * self.N_WORDS
         # [-2.4879, -3.8910, -4.1010, -4.2010, -4.4010] repeat self.BATCH_SZ
@@ -517,7 +519,8 @@ class TestBeamSearchAgainstReferenceCase(unittest.TestCase):
         expected_beam_scores, unreduced_preds = new_scores\
             .view(self.BATCH_SZ, self.BEAM_SZ * self.N_WORDS)\
             .topk(self.BEAM_SZ, -1)
-        expected_bptr_3 = unreduced_preds // self.N_WORDS
+        expected_bptr_3 = torch.div(unreduced_preds, self.N_WORDS,
+                                    rounding_mode='trunc')
         # [5, 2, 6, 1, 0] repeat self.BATCH_SZ, so beam 1 predicts EOS!
         expected_preds_3 = unreduced_preds - expected_bptr_3 * self.N_WORDS
         self.assertTrue(beam.topk_log_probs.allclose(

--- a/onmt/tests/test_beam_search.py
+++ b/onmt/tests/test_beam_search.py
@@ -538,7 +538,7 @@ class TestBeamSearchAgainstReferenceCase(unittest.TestCase):
         self.assertTrue(expected_bptr_3[:, 1].eq(4).all())
         beam.update_finished()
         self.assertTrue(beam.top_beam_finished.all())
-        #self.assertTrue(beam.done)
+        # self.assertTrue(beam.done)
         return expected_beam_scores
 
     def test_beam_advance_against_known_reference(self):
@@ -621,6 +621,6 @@ class TestBeamSearchLM(TestBeamSearchAgainstReferenceCase):
         self.init_step(beam, 1)
         self.finish_first_beam_step(beam)
 
-        n_steps = beam.alive_seq.shape[-1] - 1
-        #self.assertTrue(beam.memory_lengths.equal(
+        # n_steps = beam.alive_seq.shape[-1] - 1
+        # self.assertTrue(beam.memory_lengths.equal(
         #    n_steps+fn_map_state(src_lengths[1:], dim=0)))

--- a/onmt/translate/beam_search.py
+++ b/onmt/translate/beam_search.py
@@ -189,11 +189,11 @@ class BeamSearchBase(DecodeStrategy):
                     self.is_finished[i].all()
             else:
                 finish_flag = self.top_beam_finished[i] != 0
-            if finish_flag and len(self.hypotheses[b]) >= self.n_best:
+            if finish_flag and len(self.hypotheses[b]) >= self.beam_size:
                 best_hyp = sorted(
                     self.hypotheses[b], key=lambda x: x[0], reverse=True)
                 for n, (score, pred, attn) in enumerate(best_hyp):
-                    if n >= self.n_best:
+                    if n >= self.beam_size:
                         break
                     self.scores[b].append(score)
                     self.predictions[b].append(pred)  # ``(batch, n_best,)``

--- a/onmt/translate/penalties.py
+++ b/onmt/translate/penalties.py
@@ -93,8 +93,8 @@ class PenaltyBuilder(object):
         return ((5 + cur_len) / 6.0) ** alpha
 
     def length_average(self, cur_len, alpha=0.):
-        """Returns the current sequence length."""
-        return cur_len
+        """Returns the current sequence length ** alpha."""
+        return cur_len ** alpha
 
     def length_none(self, cur_len, alpha=0.):
         """Returns unmodified scores."""

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -557,24 +557,24 @@ class Inference(object):
 
         if self.report_score:
             msg = self._report_score(
-                "PRED", pred_score_total, pred_words_total
+                "PRED", pred_score_total, len(all_scores)
             )
             self._log(msg)
             if tgt is not None:
                 msg = self._report_score(
-                    "GOLD", gold_score_total, gold_words_total
+                    "GOLD", gold_score_total, len(all_scores)
                 )
                 self._log(msg)
 
         if self.report_time:
             total_time = end_time - start_time
-            self._log("Total translation time (s): %f" % total_time)
+            self._log("Total translation time (s): %.1f" % total_time)
             self._log(
-                "Average translation time (s): %f"
-                % (total_time / len(all_predictions))
+                "Average translation time (ms): %.1f"
+                % (total_time / len(all_predictions) * 1000)
             )
             self._log(
-                "Tokens per second: %f" % (pred_words_total / total_time)
+                "Tokens per second: %.1f" % (pred_words_total / total_time)
             )
 
         if self.dump_beam:
@@ -618,17 +618,18 @@ class Inference(object):
         )  # (batch, n_best, tgt_l)
         return batched_nbest_predict
 
-    def _report_score(self, name, score_total, words_total):
-        if words_total == 0:
-            msg = "%s No words predicted" % (name,)
+    def _report_score(self, name, score_total, lines):
+        if lines == 0:
+            msg = "%s No translations" % (name,)
         else:
-            avg_score = score_total / words_total
-            ppl = np.exp(-score_total.item() / words_total)
-            msg = "%s AVG SCORE: %.4f, %s PPL: %.4f" % (
+            score = score_total / lines
+            ppl = np.exp(-score_total.item() / lines)
+            msg = "%s SCORE: %.4f, %s PPL: %.2f LINES: %d" % (
                 name,
-                avg_score,
+                score,
                 name,
                 ppl,
+                lines
             )
         return msg
 


### PR DESCRIPTION
This PR fixes some score logs as discussed in #2173 

Also, changing the Beam search exit condition to match the behavior of Ctranslate2 (and Fairseq). Score is slightly improved and beam_size X  n-best=1 should match beam_size X n_best X taking the best of n_best.

BUT unit_test fails and I don't really understand why. @francoishernandez need help to fix this.