### PR TITLE
Adjust better score reporting

### DIFF
--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -557,24 +557,24 @@ class Inference(object):
 
         if self.report_score:
             msg = self._report_score(
-                "PRED", pred_score_total, pred_words_total
+                "PRED", pred_score_total, len(all_scores)
             )
             self._log(msg)
             if tgt is not None:
                 msg = self._report_score(
-                    "GOLD", gold_score_total, gold_words_total
+                    "GOLD", gold_score_total, len(all_scores)
                 )
                 self._log(msg)
 
         if self.report_time:
             total_time = end_time - start_time
-            self._log("Total translation time (s): %f" % total_time)
+            self._log("Total translation time (s): %.1f" % total_time)
             self._log(
-                "Average translation time (s): %f"
-                % (total_time / len(all_predictions))
+                "Average translation time (ms): %.1f"
+                % (total_time / len(all_predictions) * 1000)
             )
             self._log(
-                "Tokens per second: %f" % (pred_words_total / total_time)
+                "Tokens per second: %.1f" % (pred_words_total / total_time)
             )
 
         if self.dump_beam:
@@ -618,17 +618,24 @@ class Inference(object):
         )  # (batch, n_best, tgt_l)
         return batched_nbest_predict
 
-    def _report_score(self, name, score_total, words_total):
-        if words_total == 0:
-            msg = "%s No words predicted" % (name,)
+    def _report_score(self, name, score_total, nb_sentences):
+        # In the case of length_penalty = none we report the total logprobs
+        # divided by the number of sentence to get an approximation of the
+        # per sentence logprob. We also return the corresponding ppl
+        # When a length_penalty is used eg: "avg" or "wu" since logprobs
+        # are normalized per token we report the per line per token logprob
+        # and the corresponding "per word perplexity"
+        if nb_sentences == 0:
+            msg = "%s No translations" % (name,)
         else:
-            avg_score = score_total / words_total
-            ppl = np.exp(-score_total.item() / words_total)
-            msg = "%s AVG SCORE: %.4f, %s PPL: %.4f" % (
+            score = score_total / nb_sentences
+            ppl = np.exp(-score_total.item() / nb_sentences)
+            msg = "%s SCORE: %.4f, %s PPL: %.2f NB SENTENCES: %d" % (
                 name,
-                avg_score,
+                score,
                 name,
                 ppl,
+                nb_sentences
             )
         return msg
 


### PR DESCRIPTION
Behavior before this PR:
if length_penalty = none
AVG SCORE = total logprobs of all sentences / total nb of words ===> ("average per word log prob")
PPL = exp(above) ===> ("average per word perplexity" even if not really relevant)
if length_penalty = avg (or wu)
AVG SCORE and PPL are completely wrong since scores were normalized twice.

Behavior after this PR:
if length_penalty = none
SCORE = total logprobs of all sentences / number of sentences ===> (gives an average score per sentence, but again not 100% precise, we would need to report scores at the sentence level and then average)
PPL = exp (above) ===> Approx of a per sentence perplexity
if length_penalty = avg (or wu)
SCORE = total normalized logprob (per token) / number of sentences ===> average normalized log prob
PPL = exp(above) ===> Approx 'average per word perplexity' similar to the case none before this PR.

