### PR TITLE
Include wider scope in try / exception training loop

### DIFF
--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -393,11 +393,12 @@ class Trainer(object):
 
                 except Exception as exc:
                     trace_content = traceback.format_exc()
-                    if trace_content.find("CUDA out of memory") < 0:
-                        print(exc)
+                    if "CUDA out of memory" in trace_content:
+                        logger.info("Step %d, cuda OOM - batch removed",
+                                    self.optim.training_step)
+                    else:
+                        traceback.print_exc()
                         raise exc
-                    logger.info("At step %d, we removed a batch - accum %d",
-                                self.optim.training_step, k)
 
                 # 4. Update the parameters and statistics.
                 if self.accum_count == 1:

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -391,8 +391,11 @@ class Trainer(object):
                     total_stats.update(batch_stats)
                     report_stats.update(batch_stats)
 
-                except Exception:
-                    traceback.print_exc()
+                except Exception as exc:
+                    trace_content = traceback.format_exc()
+                    if trace_content.find("CUDA out of memory") < 0:
+                        print(exc)
+                        raise exc
                     logger.info("At step %d, we removed a batch - accum %d",
                                 self.optim.training_step, k)
 

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -368,23 +368,23 @@ class Trainer(object):
                 if self.accum_count == 1:
                     self.optim.zero_grad()
 
-                with torch.cuda.amp.autocast(enabled=self.optim.amp):
-                    outputs, attns = self.model(
-                        src, tgt, src_lengths, bptt=bptt,
-                        with_align=self.with_align)
-                    bptt = True
-
-                    # 3. Compute loss.
-                    loss, batch_stats = self.train_loss(
-                        batch,
-                        outputs,
-                        attns,
-                        normalization=normalization,
-                        shard_size=self.shard_size,
-                        trunc_start=j,
-                        trunc_size=trunc_size)
-
                 try:
+                    with torch.cuda.amp.autocast(enabled=self.optim.amp):
+                        outputs, attns = self.model(
+                            src, tgt, src_lengths, bptt=bptt,
+                            with_align=self.with_align)
+                        bptt = True
+
+                        # 3. Compute loss.
+                        loss, batch_stats = self.train_loss(
+                            batch,
+                            outputs,
+                            attns,
+                            normalization=normalization,
+                            shard_size=self.shard_size,
+                            trunc_start=j,
+                            trunc_size=trunc_size)
+
                     if loss is not None:
                         self.optim.backward(loss)
 


### PR DESCRIPTION

Cuda OOM exception errors can be triggered not only by the backward operation but also by the forward or loss computation.

This PR discards batches that may trigger such errors.
