### PR TITLE
Add length penalty alpha, change docs for clarity

### DIFF
--- a/docs/source/examples/Translation.md
+++ b/docs/source/examples/Translation.md
@@ -152,12 +152,20 @@ for checkpoint in data/wmt/run/model_step*.pt; do
         -gpu 0 \
         -batch_size 16384 -batch_type tokens \
         -beam_size 5 \
+        -length_penalty avg \
         -model $checkpoint \
         -src data/wmt/test.en.sp \
         -tgt data/wmt/test.de.sp \
         -output data/wmt/test.de.hyp_${base%.*}.sp
 done
 ```
+
+Note1: the default value of length_penalty is "none". If you want to compare with some
+other toolkit, "avg" normalization is often the default value.
+
+Note2: when using "avg" length penalty, if you know the tokenized ratio between target
+language length divided by source language length (in average) you can set this flag.
+
 
 Prior to evaluation, we need to detokenize the hypothesis:
 

--- a/docs/source/examples/Translation.md
+++ b/docs/source/examples/Translation.md
@@ -164,7 +164,8 @@ Note1: the default value of length_penalty is "none". If you want to compare wit
 other toolkit, "avg" normalization is often the default value.
 
 Note2: when using "avg" length penalty, if you know the tokenized ratio between target
-language length divided by source language length (in average) you can set this flag.
+language length divided by source language length (in average) you can set it
+in the -ratio flag.
 
 
 Prior to evaluation, we need to detokenize the hypothesis:

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -705,8 +705,8 @@ def _add_decoding_opts(parser):
     group.add('--length_penalty', '-length_penalty', default='none',
               choices=['none', 'wu', 'avg'],
               help="Length Penalty to use.")
-    group.add('--alpha', '-alpha', type=float, default=0.,
-              help="Google NMT length penalty parameter "
+    group.add('--alpha', '-alpha', type=float, default=1.,
+              help="Length penalty parameter"
                    "(higher = longer generation)")
     # Coverage penalty options
     group.add('--coverage_penalty', '-coverage_penalty', default='none',

--- a/onmt/tests/test_beam_search.py
+++ b/onmt/tests/test_beam_search.py
@@ -435,7 +435,8 @@ class TestBeamSearchAgainstReferenceCase(unittest.TestCase):
         expected_beam_scores, unreduced_preds = new_scores\
             .view(self.BATCH_SZ, self.BEAM_SZ * self.N_WORDS)\
             .topk(self.BEAM_SZ, -1)
-        expected_bptr_1 = unreduced_preds // self.N_WORDS
+        expected_bptr_1 = torch.div(unreduced_preds, self.N_WORDS,
+                                    rounding_mode='trunc')
         # [5, 3, 2, 6, 0], so beam 2 predicts EOS!
         expected_preds_1 = unreduced_preds - expected_bptr_1 * self.N_WORDS
         self.assertTrue(beam.topk_log_probs.allclose(expected_beam_scores))
@@ -469,7 +470,8 @@ class TestBeamSearchAgainstReferenceCase(unittest.TestCase):
         expected_beam_scores, unreduced_preds = new_scores\
             .view(self.BATCH_SZ, self.BEAM_SZ * self.N_WORDS)\
             .topk(self.BEAM_SZ, -1)
-        expected_bptr_2 = unreduced_preds // self.N_WORDS
+        expected_bptr_2 = torch.div(unreduced_preds, self.N_WORDS,
+                                    rounding_mode='trunc')
         # [2, 5, 3, 6, 0] repeat self.BATCH_SZ, so beam 0 predicts EOS!
         expected_preds_2 = unreduced_preds - expected_bptr_2 * self.N_WORDS
         # [-2.4879, -3.8910, -4.1010, -4.2010, -4.4010] repeat self.BATCH_SZ
@@ -507,7 +509,8 @@ class TestBeamSearchAgainstReferenceCase(unittest.TestCase):
         expected_beam_scores, unreduced_preds = new_scores\
             .view(self.BATCH_SZ, self.BEAM_SZ * self.N_WORDS)\
             .topk(self.BEAM_SZ, -1)
-        expected_bptr_3 = unreduced_preds // self.N_WORDS
+        expected_bptr_3 = torch.div(unreduced_preds, self.N_WORDS,
+                                    rounding_mode='trunc')
         # [5, 2, 6, 1, 0] repeat self.BATCH_SZ, so beam 1 predicts EOS!
         expected_preds_3 = unreduced_preds - expected_bptr_3 * self.N_WORDS
         self.assertTrue(beam.topk_log_probs.allclose(
@@ -544,7 +547,7 @@ class TestBeamWithLengthPenalty(TestBeamSearchAgainstReferenceCase):
     # interactions between the GNMT scorer and the beam
 
     def test_beam_advance_against_known_reference(self):
-        scorer = GNMTGlobalScorer(0.7, 0., "avg", "none")
+        scorer = GNMTGlobalScorer(1.0, 0., "avg", "none")
         beam = BeamSearch(
             self.BEAM_SZ, self.BATCH_SZ, 0, 1, 2, 3, self.N_BEST,
             scorer,

--- a/onmt/translate/penalties.py
+++ b/onmt/translate/penalties.py
@@ -92,9 +92,9 @@ class PenaltyBuilder(object):
 
         return ((5 + cur_len) / 6.0) ** alpha
 
-    def length_average(self, cur_len, alpha=0.):
+    def length_average(self, cur_len, alpha=1.):
         """Returns the current sequence length."""
-        return cur_len
+        return cur_len ** alpha
 
     def length_none(self, cur_len, alpha=0.):
         """Returns unmodified scores."""


### PR DESCRIPTION
When normalizing with length_penalty = avg 

BEFORE:
scores / length

AFTER
score / length ** alpha
default alpha = 1

Change doc advising to use length_penalty avg (default value in fairseq) to produce "longer" translations.

