### PR TITLE
validation stats are calculated by a single GPU

### DIFF
--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -295,11 +295,6 @@ class Trainer(object):
                 valid_stats = self.validate(
                     valid_iter, moving_average=self.moving_average)
                 if self.gpu_verbose_level > 0:
-                    logger.info('GpuRank %d: gather valid stat \
-                                step %d' % (self.gpu_rank, step))
-                # gather stats unuseful on a single gpu
-                # valid_stats = self._maybe_gather_stats(valid_stats)
-                if self.gpu_verbose_level > 0:
                     logger.info('GpuRank %d: report stat step %d'
                                 % (self.gpu_rank, step))
                 self._report_step(self.optim.learning_rate(),

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -287,7 +287,7 @@ class Trainer(object):
                 report_stats)
 
             if (valid_iter is not None and step % valid_steps == 0 and
-                    self.n_gpu > 0):
+                    self.gpu_rank == 0):
                 if self.gpu_verbose_level > 0:
                     logger.info('GpuRank %d: validate step %d'
                                 % (self.gpu_rank, step))


### PR DESCRIPTION
In the previous version of the code, validation statistics were calculated by all workers. As they are also calculated on the full dataset rather than at batch level, gathering them was unnecessary.
However, all workers did exactly the same calculation, so it can be limited to a single GPU. In this way, the valid statistics gathering becomes unnecessary for this reason as well.