### PR TITLE
To remove a deprecated method _maybe_gather_stats() from Trainer

### DIFF
--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -515,21 +515,6 @@ class Trainer(object):
             else:
                 self.report_manager.start_time = start_time
 
-    def _maybe_gather_stats(self, stat):
-        """
-        Gather statistics in multi-processes cases
-
-        Args:
-            stat(:obj:onmt.utils.Statistics): a Statistics object to gather
-                or None (it returns None in this case)
-
-        Returns:
-            stat: the updated (or unchanged) stat object
-        """
-        if stat is not None and self.n_gpu > 1:
-            return onmt.utils.Statistics.all_gather_stats(stat)
-        return stat
-
     def _maybe_report_training(self, step, num_steps, learning_rate,
                                report_stats):
         """


### PR DESCRIPTION
    - The deprecated method has not been pulling its weight since we started to use IterOnDevice (#1849)
    - The only statement calling it has been removed (#2198, #2205)