### PR TITLE
allow to override the checkpoint's droupout settings

### DIFF
--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -59,6 +59,8 @@ def _add_logging_opts(parser, is_train=True):
                   type=str, default="runs/onmt",
                   help="Log directory for Tensorboard. "
                        "This is also the name of the run.")
+        group.add("--override_opts", "-override-opts",  action="store_true",
+                  help="Allow to override some checkpoint opts")
     else:
         # Options only during inference
         group.add('--attn_debug', '-attn_debug', action="store_true",

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -36,6 +36,10 @@ def _get_model_opts(opt, checkpoint=None):
         # Override checkpoint's freezing settings as it defaults to false
         model_opt.freeze_encoder = opt.freeze_encoder
         model_opt.freeze_decoder = opt.freeze_decoder
+        if opt.override_opts:
+            # Override checkpoint's droupout settings
+            model_opt.dropout = opt.dropout
+            model_opt.attention_dropout = opt.attention_dropout
     else:
         model_opt = opt
     return model_opt

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -23,23 +23,22 @@ def configure_process(opt, device_id):
 def _get_model_opts(opt, checkpoint=None):
     """Get `model_opt` to build model, may load from `checkpoint` if any."""
     if checkpoint is not None:
-        model_opt = ArgumentParser.ckpt_model_opts(checkpoint["opt"])
-        ArgumentParser.update_model_opts(model_opt)
-        ArgumentParser.validate_model_opts(model_opt)
-        if (opt.tensorboard_log_dir == model_opt.tensorboard_log_dir and
-                hasattr(model_opt, 'tensorboard_log_dir_dated')):
-            # ensure tensorboard output is written in the directory
-            # of previous checkpoints
-            opt.tensorboard_log_dir_dated = model_opt.tensorboard_log_dir_dated
-        # Override checkpoint's update_embeddings as it defaults to false
-        model_opt.update_vocab = opt.update_vocab
-        # Override checkpoint's freezing settings as it defaults to false
-        model_opt.freeze_encoder = opt.freeze_encoder
-        model_opt.freeze_decoder = opt.freeze_decoder
         if opt.override_opts:
-            # Override checkpoint's droupout settings
-            model_opt.dropout = opt.dropout
-            model_opt.attention_dropout = opt.attention_dropout
+            model_opt = opt
+        else:
+            model_opt = ArgumentParser.ckpt_model_opts(checkpoint["opt"])
+            ArgumentParser.update_model_opts(model_opt)
+            ArgumentParser.validate_model_opts(model_opt)
+            if (opt.tensorboard_log_dir == model_opt.tensorboard_log_dir and
+                    hasattr(model_opt, 'tensorboard_log_dir_dated')):
+                # ensure tensorboard output is written in the directory
+                # of previous checkpoints
+                opt.tensorboard_log_dir_dated = model_opt.tensorboard_log_dir_dated  # noqa: E501
+            # Override checkpoint's update_embeddings as it defaults to false
+            model_opt.update_vocab = opt.update_vocab
+            # Override checkpoint's freezing settings as it defaults to false
+            model_opt.freeze_encoder = opt.freeze_encoder
+            model_opt.freeze_decoder = opt.freeze_decoder
     else:
         model_opt = opt
     return model_opt


### PR DESCRIPTION

This PR provides the ability to override the checkpoint's dropout settings (`dropout`, `attention_dropout`)  when finetuning a Transformer model.
A new flag `override_opts` is added. This overriding can thus be disabled with `--override_opts False` 
It is not possible at the moment because the checkpoint's `model_opts `override those set in the config.
See the following discussion about this topic:
https://forum.opennmt.net/t/tranformer-change-dropout-when-finetuning/4625