### PR TITLE
MHA + Average + tranformer enc/dec refac

### DIFF
--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -438,10 +438,12 @@ class TransformerDecoder(TransformerDecoderBase):
         self.state["src"] = self.state["src"].detach()
 
     def forward(self, tgt, memory_bank=None, step=None, **kwargs):
-        """Decode, possibly stepwise."""
-
-        # when training step is always None, when decoding, step increases
-
+        """
+        Decode, possibly stepwise.
+        when training step is always None, when decoding, step increases
+        tgt (Tensor): len x batch x feats
+        memory_bank (Tensor): encoder output (len x batch x model_dim)
+        """
         if memory_bank is None:
             memory_bank = self.embeddings(tgt)
         if step == 0:
@@ -496,8 +498,8 @@ class TransformerDecoder(TransformerDecoderBase):
         depth = memory_bank.size(-1)
 
         for layer in self.transformer_layers:
-            layer.context_attn.step = True
-            layer.self_attn.step = True
+            # first value set to True triggered by the beginning of decoding
+            # layer_cache becomes active in the MultiHeadedAttention fwd
             layer.context_attn.layer_cache = (
                 True,
                 {'keys': torch.tensor([], device=memory_bank.device),

--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -57,12 +57,14 @@ class TransformerDecoderLayerBase(nn.Module):
         """
         super(TransformerDecoderLayerBase, self).__init__()
 
+        self.self_attn_type = self_attn_type
         if self_attn_type == "scaled-dot":
             self.self_attn = MultiHeadedAttention(
                 heads,
                 d_model,
                 dropout=attention_dropout,
                 max_relative_positions=max_relative_positions,
+                attn_type="self"
             )
         elif self_attn_type == "average":
             self.self_attn = AverageAttention(
@@ -139,19 +141,17 @@ class TransformerDecoderLayerBase(nn.Module):
             dec_mask = tgt_pad_mask
         return dec_mask
 
-    def _forward_self_attn(self, inputs_norm, dec_mask, layer_cache, step):
-        if isinstance(self.self_attn, MultiHeadedAttention):
+    def _forward_self_attn(self, inputs_norm, dec_mask, step):
+        if self.self_attn_type == "scaled-dot":
             return self.self_attn(
                 inputs_norm,
                 inputs_norm,
                 inputs_norm,
-                mask=dec_mask,
-                layer_cache=layer_cache,
-                attn_type="self",
+                mask=dec_mask
             )
-        elif isinstance(self.self_attn, AverageAttention):
+        elif self.self_attn_type == "average":
             return self.self_attn(
-                inputs_norm, mask=dec_mask, layer_cache=layer_cache, step=step
+                inputs_norm, mask=dec_mask, step=step
             )
         else:
             raise ValueError(
@@ -211,7 +211,8 @@ class TransformerDecoderLayer(TransformerDecoderLayerBase):
             pos_ffn_activation_fn=pos_ffn_activation_fn,
         )
         self.context_attn = MultiHeadedAttention(
-            heads, d_model, dropout=attention_dropout
+            heads, d_model, dropout=attention_dropout,
+            attn_type="context"
         )
         self.layer_norm_2 = nn.LayerNorm(d_model, eps=1e-6)
 
@@ -227,7 +228,6 @@ class TransformerDecoderLayer(TransformerDecoderLayerBase):
         memory_bank,
         src_pad_mask,
         tgt_pad_mask,
-        layer_cache=None,
         step=None,
         future=False,
     ):
@@ -240,7 +240,6 @@ class TransformerDecoderLayer(TransformerDecoderLayerBase):
             memory_bank (FloatTensor): ``(batch_size, src_len, model_dim)``
             src_pad_mask (bool): ``(batch_size, 1, src_len)``
             tgt_pad_mask (bool): ``(batch_size, 1, T)``
-            layer_cache (dict or None): cached layer info when stepwise decode
             step (int or None): stepwise decoding counter
             future (bool): If set True, do not apply future_mask.
 
@@ -260,7 +259,7 @@ class TransformerDecoderLayer(TransformerDecoderLayerBase):
         inputs_norm = self.layer_norm_1(inputs)
 
         query, _ = self._forward_self_attn(
-            inputs_norm, dec_mask, layer_cache, step
+            inputs_norm, dec_mask, step
         )
 
         query = self.drop(query) + inputs
@@ -270,9 +269,7 @@ class TransformerDecoderLayer(TransformerDecoderLayerBase):
             memory_bank,
             memory_bank,
             query_norm,
-            mask=src_pad_mask,
-            layer_cache=layer_cache,
-            attn_type="context",
+            mask=src_pad_mask
         )
         output = self.feed_forward(self.drop(mid) + query)
 
@@ -322,21 +319,28 @@ class TransformerDecoderBase(DecoderBase):
     def init_state(self, src, memory_bank, enc_hidden):
         """Initialize decoder state."""
         self.state["src"] = src
-        self.state["cache"] = None
 
     def map_state(self, fn):
-        def _recursive_map(struct, batch_dim=0):
-            for k, v in struct.items():
-                if v is not None:
-                    if isinstance(v, dict):
-                        _recursive_map(v)
-                    else:
-                        struct[k] = fn(v, batch_dim)
 
         if self.state["src"] is not None:
             self.state["src"] = fn(self.state["src"], 1)
-        if self.state["cache"] is not None:
-            _recursive_map(self.state["cache"])
+        for layer in self.transformer_layers:
+            if hasattr(layer, 'context_attn'):
+                if layer.context_attn.layer_cache[1]['keys'].numel() != 0:
+                    x = fn(layer.context_attn.layer_cache[1]['keys'], 0)
+                    y = fn(layer.context_attn.layer_cache[1]['values'], 0)
+                    layer.context_attn.layer_cache = True, {'keys': x,
+                                                            'values': y}
+            if isinstance(layer.self_attn, AverageAttention):
+                if layer.self_attn.layer_cache[1]['prev_g'].numel() != 0:
+                    x = fn(layer.self_attn.layer_cache[1]['prev_g'], 0)
+                    layer.self_attn.layer_cache = True, {'prev_g': x}
+            else:
+                if layer.self_attn.layer_cache[1]['keys'].numel() != 0:
+                    x = fn(layer.self_attn.layer_cache[1]['keys'], 0)
+                    y = fn(layer.self_attn.layer_cache[1]['values'], 0)
+                    layer.self_attn.layer_cache = True, {'keys': x,
+                                                         'values': y}
 
     def detach_state(self):
         raise NotImplementedError
@@ -435,6 +439,9 @@ class TransformerDecoder(TransformerDecoderBase):
 
     def forward(self, tgt, memory_bank=None, step=None, **kwargs):
         """Decode, possibly stepwise."""
+
+        # when training step is always None, when decoding, step increases
+
         if memory_bank is None:
             memory_bank = self.embeddings(tgt)
         if step == 0:
@@ -457,18 +464,12 @@ class TransformerDecoder(TransformerDecoderBase):
         with_align = kwargs.pop("with_align", False)
         attn_aligns = []
 
-        for i, layer in enumerate(self.transformer_layers):
-            layer_cache = (
-                self.state["cache"]["layer_{}".format(i)]
-                if step is not None
-                else None
-            )
+        for layer in self.transformer_layers:
             output, attn, attn_align = layer(
                 output,
                 src_memory_bank,
                 src_pad_mask,
                 tgt_pad_mask,
-                layer_cache=layer_cache,
                 step=step,
                 with_align=with_align,
             )
@@ -490,20 +491,28 @@ class TransformerDecoder(TransformerDecoderBase):
         return dec_outs, attns
 
     def _init_cache(self, memory_bank):
-        self.state["cache"] = {}
+
         batch_size = memory_bank.size(1)
         depth = memory_bank.size(-1)
 
-        for i, layer in enumerate(self.transformer_layers):
-            layer_cache = {"memory_keys": None, "memory_values": None}
-            if isinstance(layer.self_attn, AverageAttention):
-                layer_cache["prev_g"] = torch.zeros(
-                    (batch_size, 1, depth), device=memory_bank.device
+        for layer in self.transformer_layers:
+            layer.context_attn.step = True
+            layer.self_attn.step = True
+            layer.context_attn.layer_cache = (
+                True,
+                {'keys': torch.tensor([], device=memory_bank.device),
+                 'values': torch.tensor([], device=memory_bank.device)}
                 )
+            if isinstance(layer.self_attn, AverageAttention):
+                layer.self_attn.layer_cache = True, {'prev_g': torch.zeros(
+                     (batch_size, 1, depth), device=memory_bank.device
+                ).to(memory_bank.dtype)}
             else:
-                layer_cache["self_keys"] = None
-                layer_cache["self_values"] = None
-            self.state["cache"]["layer_{}".format(i)] = layer_cache
+                layer.self_attn.layer_cache = (
+                    True,
+                    {'keys': torch.tensor([], device=memory_bank.device),
+                     'values': torch.tensor([], device=memory_bank.device)}
+                    )
 
 
 class TransformerLMDecoderLayer(TransformerDecoderLayerBase):
@@ -526,7 +535,7 @@ class TransformerLMDecoderLayer(TransformerDecoderLayerBase):
     """
 
     def _forward(
-        self, inputs, tgt_pad_mask, layer_cache=None, step=None, future=False
+        self, inputs, tgt_pad_mask, step=None, future=False
     ):
         """A naive forward pass for transformer decoder.
 
@@ -555,7 +564,7 @@ class TransformerLMDecoderLayer(TransformerDecoderLayerBase):
         inputs_norm = self.layer_norm_1(inputs)
 
         query, attns = self._forward_self_attn(
-            inputs_norm, dec_mask, layer_cache, step
+            inputs_norm, dec_mask, step
         )
 
         output = self.drop(query) + inputs
@@ -645,7 +654,7 @@ class TransformerLMDecoder(TransformerDecoderBase):
     def forward(self, tgt, memory_bank=None, step=None, **kwargs):
         """Decode, possibly stepwise."""
         if step == 0:
-            self._init_cache()
+            self._init_cache(tgt)
 
         tgt_words = tgt[:, :, 0].transpose(0, 1)
 
@@ -660,16 +669,10 @@ class TransformerLMDecoder(TransformerDecoderBase):
         with_align = kwargs.pop("with_align", False)
         assert not with_align, "TransformerLMDecoder does not support align"
 
-        for i, layer in enumerate(self.transformer_layers):
-            layer_cache = (
-                self.state["cache"]["layer_{}".format(i)]
-                if step is not None
-                else None
-            )
+        for layer in self.transformer_layers:
             output, attn, _ = layer(
                 output,
                 tgt_pad_mask,
-                layer_cache=layer_cache,
                 step=step,
                 with_align=with_align,
             )
@@ -685,11 +688,14 @@ class TransformerLMDecoder(TransformerDecoderBase):
         # TODO change the way attns is returned dict => list or tuple (onnx)
         return dec_outs, attns
 
-    def _init_cache(self, memory_bank=None):
-        self.state["cache"] = {}
+    def _init_cache(self, tgt=None):
 
-        for i, layer in enumerate(self.transformer_layers):
-            layer_cache = {"self_keys": None, "self_values": None}
+        for layer in self.transformer_layers:
             if isinstance(layer.self_attn, AverageAttention):
                 raise NotImplementedError
-            self.state["cache"]["layer_{}".format(i)] = layer_cache
+            else:
+                layer.self_attn.layer_cache = (
+                    True,
+                    {'keys': torch.tensor([], device=tgt.device),
+                     'values': torch.tensor([], device=tgt.device)}
+                    )

--- a/onmt/encoders/transformer.py
+++ b/onmt/encoders/transformer.py
@@ -33,7 +33,8 @@ class TransformerEncoderLayer(nn.Module):
 
         self.self_attn = MultiHeadedAttention(
             heads, d_model, dropout=attention_dropout,
-            max_relative_positions=max_relative_positions)
+            max_relative_positions=max_relative_positions,
+            attn_type="self")
         self.feed_forward = PositionwiseFeedForward(d_model, d_ff, dropout,
                                                     pos_ffn_activation_fn)
         self.layer_norm = nn.LayerNorm(d_model, eps=1e-6)
@@ -52,7 +53,7 @@ class TransformerEncoderLayer(nn.Module):
         """
         input_norm = self.layer_norm(inputs)
         context, _ = self.self_attn(input_norm, input_norm, input_norm,
-                                    mask=mask, attn_type="self")
+                                    mask=mask)
         out = self.dropout(context) + inputs
         return self.feed_forward(out)
 

--- a/onmt/modules/average_attn.py
+++ b/onmt/modules/average_attn.py
@@ -3,12 +3,65 @@
 
 import torch
 import torch.nn as nn
-
+from torch import Tensor
+from typing import Optional
 from onmt.modules.position_ffn import PositionwiseFeedForward
 from onmt.modules.position_ffn import ActivationFunction
 
 
+def cumulative_average_mask(batch_size: int, inputs_len: int,
+                            device: Optional[torch.device] = None) -> Tensor:
+    """
+    Builds the mask to compute the cumulative average as described in
+    :cite:`DBLP:journals/corr/abs-1805-00631` -- Figure 3
+    Args:
+        batch_size (int): batch size
+        inputs_len (int): length of the inputs
+
+    Returns:
+        (Tensor):
+
+        * A Tensor of shape ``(batch_size, input_len, input_len)``
+    """
+
+    triangle = torch.tril(torch.ones(inputs_len, inputs_len,
+                          dtype=torch.float, device=device))
+    weights = torch.ones(1, inputs_len, dtype=torch.float, device=device) \
+        / torch.arange(1, inputs_len + 1, dtype=torch.float, device=device)
+    mask = triangle * weights.transpose(0, 1)
+
+    return mask.unsqueeze(0).expand(batch_size, inputs_len, inputs_len)
+
+
+def cumulative_average(inputs: Tensor, layer_cache: tuple,
+                       mask=None, step=None) -> Tensor:
+    """
+    Computes the cumulative average as described in
+    :cite:`DBLP:journals/corr/abs-1805-00631` -- Equations (1) (5) (6)
+
+    Args:
+        inputs (FloatTensor): sequence to average
+            ``(batch_size, input_len, dimension)``
+        layer_cache: tuple(bool, dict)
+        if layer_cahe[0] is True use step otherwise mask
+        mask: mask matrix used to compute the cumulative average
+        step: current step of the dynamic decoding
+
+    Returns:
+        a tensor of the same shape and type as ``inputs``.
+    """
+
+    if layer_cache[0]:
+        average_attention = (inputs + step *
+                             layer_cache[1]['prev_g']) / (step + 1)
+        layer_cache[1]['prev_g'] = average_attention
+        return average_attention
+    else:
+        return torch.matmul(mask.to(inputs.dtype), inputs)
+
+
 class AverageAttention(nn.Module):
+    # class AverageAttention(torch.jit.ScriptModule):
     """
     Average Attention module from
     "Accelerating Neural Transformer via an Average Attention Network"
@@ -33,61 +86,10 @@ class AverageAttention(nn.Module):
                                                          pos_ffn_activation_fn
                                                          )
         self.gating_layer = nn.Linear(model_dim * 2, model_dim * 2)
+        self.layer_cache = False, {'prev_g': torch.tensor([])}
 
-    def cumulative_average_mask(self, batch_size, inputs_len, device):
-        """
-        Builds the mask to compute the cumulative average as described in
-        :cite:`DBLP:journals/corr/abs-1805-00631` -- Figure 3
-
-        Args:
-            batch_size (int): batch size
-            inputs_len (int): length of the inputs
-
-        Returns:
-            (FloatTensor):
-
-            * A Tensor of shape ``(batch_size, input_len, input_len)``
-        """
-
-        triangle = torch.tril(torch.ones(inputs_len, inputs_len,
-                              dtype=torch.float, device=device))
-        weights = torch.ones(1, inputs_len, dtype=torch.float, device=device) \
-            / torch.arange(1, inputs_len + 1, dtype=torch.float, device=device)
-        mask = triangle * weights.transpose(0, 1)
-
-        return mask.unsqueeze(0).expand(batch_size, inputs_len, inputs_len)
-
-    def cumulative_average(self, inputs, mask_or_step,
-                           layer_cache=None, step=None):
-        """
-        Computes the cumulative average as described in
-        :cite:`DBLP:journals/corr/abs-1805-00631` -- Equations (1) (5) (6)
-
-        Args:
-            inputs (FloatTensor): sequence to average
-                ``(batch_size, input_len, dimension)``
-            mask_or_step: if cache is set, this is assumed
-                to be the current step of the
-                dynamic decoding. Otherwise, it is the mask matrix
-                used to compute the cumulative average.
-            layer_cache: a dictionary containing the cumulative average
-                of the previous step.
-
-        Returns:
-            a tensor of the same shape and type as ``inputs``.
-        """
-
-        if layer_cache is not None:
-            step = mask_or_step
-            average_attention = (inputs + step *
-                                 layer_cache["prev_g"]) / (step + 1)
-            layer_cache["prev_g"] = average_attention
-            return average_attention
-        else:
-            mask = mask_or_step
-            return torch.matmul(mask.to(inputs.dtype), inputs)
-
-    def forward(self, inputs, mask=None, layer_cache=None, step=None):
+    # @torch.jit.script
+    def forward(self, inputs, mask=None, step=None):
         """
         Args:
             inputs (FloatTensor): ``(batch_size, input_len, model_dim)``
@@ -102,10 +104,10 @@ class AverageAttention(nn.Module):
 
         batch_size = inputs.size(0)
         inputs_len = inputs.size(1)
-        average_outputs = self.cumulative_average(
-          inputs, self.cumulative_average_mask(batch_size,
-                                               inputs_len, inputs.device)
-          if layer_cache is None else step, layer_cache=layer_cache)
+        mask = cumulative_average_mask(batch_size, inputs_len, inputs.device)\
+            if not self.layer_cache[0] else None
+        average_outputs = cumulative_average(
+          inputs, self.layer_cache, mask, step)
         if self.aan_useffn:
             average_outputs = self.average_layer(average_outputs)
         gating_outputs = self.gating_layer(torch.cat((inputs,

--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -108,6 +108,7 @@ class MultiHeadedAttention(nn.Module):
            must be divisible by head_count
        dropout (float): dropout parameter
        max_relative_positions (int): max relative positions
+       attn_type: "self" or "context"
     """
 
     def __init__(self, head_count: int, model_dim: int, dropout: float = 0.1,

--- a/onmt/utils/misc.py
+++ b/onmt/utils/misc.py
@@ -144,41 +144,6 @@ def set_random_seed(seed, is_cuda):
         torch.cuda.manual_seed(seed)
 
 
-def generate_relative_positions_matrix(length, max_relative_positions,
-                                       cache=False):
-    """Generate the clipped relative positions matrix
-       for a given length and maximum relative positions"""
-    if cache:
-        distance_mat = torch.arange(-length+1, 1, 1).unsqueeze(0)
-    else:
-        range_vec = torch.arange(length)
-        range_mat = range_vec.unsqueeze(-1).expand(-1, length).transpose(0, 1)
-        distance_mat = range_mat - range_mat.transpose(0, 1)
-    distance_mat_clipped = torch.clamp(distance_mat,
-                                       min=-max_relative_positions,
-                                       max=max_relative_positions)
-    # Shift values to be >= 0
-    final_mat = distance_mat_clipped + max_relative_positions
-    return final_mat
-
-
-def relative_matmul(x, z, transpose):
-    """Helper function for relative positions attention."""
-    batch_size = x.shape[0]
-    heads = x.shape[1]
-    length = x.shape[2]
-    x_t = x.permute(2, 0, 1, 3)
-    x_t_r = x_t.reshape(length, heads * batch_size, -1)
-    if transpose:
-        z_t = z.transpose(1, 2)
-        x_tz_matmul = torch.matmul(x_t_r, z_t)
-    else:
-        x_tz_matmul = torch.matmul(x_t_r, z)
-    x_tz_matmul_r = x_tz_matmul.reshape(length, batch_size, heads, -1)
-    x_tz_matmul_r_t = x_tz_matmul_r.permute(1, 2, 0, 3)
-    return x_tz_matmul_r_t
-
-
 def fn_args(fun):
     """Returns the list of function arguments name."""
     return inspect.getfullargspec(fun).args


### PR DESCRIPTION
Set attn_type and layer_cache as attributes of MultiHeadedAttention and AverageAttention.
Change decoder state of the layer cache from Dict to Tensors for Torch Jit compatibility.
Optimize gen_relative_positions (tensors created directly on gpu) => inference 8% faster.
Fix average_attention on fp16 (was buggy, missing cast).

NB: when activating the JIT decorators in MultiHeadedAttention, there is no gain. Inquiring why.