### PR TITLE
reinstate apex.amp (O1 O2)

### DIFF
--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -314,7 +314,9 @@ def build_base_model(model_opt, vocabs, gpu, checkpoint=None, gpu_id=None):
         model.decoder.embeddings.requires_grad_()
 
     model.to(device)
-    if model_opt.model_dtype == 'fp16' and model_opt.optim == 'fusedadam':
+    if model_opt.model_dtype == 'fp16' and \
+            model_opt.apex_opt_level not in ['O0', 'O1', 'O2', 'O3'] and \
+            model_opt.optim == 'fusedadam':
         model.half()
     return model
 

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -435,7 +435,7 @@ def model_opts(parser):
     group.add('--loss_scale', '-loss_scale', type=float, default=0,
               help="For FP16 training, the static loss scale to use. If not "
                    "set, the loss scale is dynamically computed.")
-    group.add('--apex_opt_level', '-apex_opt_level', type=str, default="O1",
+    group.add('--apex_opt_level', '-apex_opt_level', type=str, default="",
               choices=["O0", "O1", "O2", "O3"],
               help="For FP16 training, the opt_level to use."
                    "See https://nvidia.github.io/apex/amp.html#opt-levels.")

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -331,7 +331,7 @@ class Trainer(object):
             for avg, param in zip(self.moving_average,
                                   valid_model.parameters()):
                 model_params_data.append(param.data)
-                param.data = avg.data.half() if self.optim._fp16 == "legacy" \
+                param.data = avg.data.half() if param.dtype == torch.float16 \
                     else avg.data
 
         # Set model in validating mode.
@@ -393,7 +393,7 @@ class Trainer(object):
     def _gradient_accumulation(self, true_batches, normalization, total_stats,
                                report_stats):
         if self.accum_count > 1:
-            self.optim.zero_grad()
+            self.optim.zero_grad(set_to_none=True)
 
         for k, batch in enumerate(true_batches):
             target_size = batch['tgt'].size(0)
@@ -417,7 +417,7 @@ class Trainer(object):
 
                 # 2. F-prop all but generator.
                 if self.accum_count == 1:
-                    self.optim.zero_grad()
+                    self.optim.zero_grad(set_to_none=True)
 
                 try:
                     with torch.cuda.amp.autocast(enabled=self.optim.amp):

--- a/onmt/utils/optimizers.py
+++ b/onmt/utils/optimizers.py
@@ -9,6 +9,10 @@ from math import sqrt
 import types
 import importlib
 from onmt.utils.misc import fn_args
+try:
+    import apex
+except ImportError:
+    pass
 
 
 def build_torch_optimizer(model, opt):
@@ -78,20 +82,33 @@ def build_torch_optimizer(model, opt):
                  betas=betas,
                  eps=1e-8)])
     elif opt.optim == 'fusedadam':
-        # we use here a FusedAdam() copy of an old Apex repo
         optimizer = FusedAdam(
             params,
             lr=opt.learning_rate,
             betas=betas)
-        if opt.model_dtype == 'fp16':
+        try:
             import apex
-            # In this case use the old FusedAdam with FP16_optimizer wrapper
-            static_loss_scale = opt.loss_scale
-            dynamic_loss_scale = opt.loss_scale == 0
-            optimizer = apex.contrib.optimizers.FP16_Optimizer(
+        except ImportError:
+            raise ImportError("Could not import apex")
+        if opt.apex_opt_level in ['O0', 'O1', 'O2', 'O3']:
+            # we use apex.amp
+            loss_scale = "dynamic" if opt.loss_scale == 0 else opt.loss_scale
+            model, optimizer = apex.amp.initialize(
+                [model, model.generator],
                 optimizer,
-                static_loss_scale=static_loss_scale,
-                dynamic_loss_scale=dynamic_loss_scale)
+                opt_level=opt.apex_opt_level,
+                loss_scale=loss_scale,
+                keep_batchnorm_fp32=None)
+        else:
+            if opt.model_dtype == 'fp16':
+                # In this case use the old FusedAdam with
+                # FP16_optimizer wrapper
+                static_loss_scale = opt.loss_scale
+                dynamic_loss_scale = opt.loss_scale == 0
+                optimizer = apex.contrib.optimizers.FP16_Optimizer(
+                    optimizer,
+                    static_loss_scale=static_loss_scale,
+                    dynamic_loss_scale=dynamic_loss_scale)
     else:
         raise ValueError('Invalid optimizer type: ' + opt.optim)
 
@@ -169,10 +186,10 @@ class MultipleOptimizer(object):
             param_groups.extend(optimizer.param_groups)
         return param_groups
 
-    def zero_grad(self):
+    def zero_grad(self, set_to_none=True):
         """ ? """
         for op in self.optimizers:
-            op.zero_grad()
+            op.zero_grad(set_to_none)
 
     def step(self):
         """ ? """
@@ -277,7 +294,10 @@ class Optimizer(object):
             max_grad_norm=optim_opt.max_grad_norm)
         if opt.model_dtype == "fp16":
             if opt.optim == "fusedadam":
-                optimizer._fp16 = "legacy"
+                if opt.apex_opt_level in ['O0', 'O1', 'O2', 'O3']:
+                    optimizer._fp16 = "apex.amp"
+                else:
+                    optimizer._fp16 = "legacy"
             else:
                 optimizer._fp16 = "amp"
                 from torch.cuda.amp import GradScaler
@@ -318,20 +338,26 @@ class Optimizer(object):
         if 'optimizer' in state_dict:
             self._optimizer.load_state_dict(state_dict['optimizer'])
 
-    def zero_grad(self):
+    def zero_grad(self, set_to_none=True):
         """Zero the gradients of optimized parameters."""
         self._optimizer.zero_grad()
+        # should be: self._optimizer.zero_grad(set_to_none)
+        # but apex.amp is not up-to-date:
+        # https://github.com/NVIDIA/apex/blob/master/apex/amp/_process_optimizer.py#L367
 
     def backward(self, loss):
         """Wrapper for backward pass. Some optimizer requires ownership of the
         backward pass."""
-        if self.amp:
-            self._scaler.scale(loss).backward()
-        elif self._fp16 == "legacy":
+        if self._fp16 == "legacy":
             kwargs = {}
             if "update_master_grads" in fn_args(self._optimizer.backward):
                 kwargs["update_master_grads"] = True
             self._optimizer.backward(loss, **kwargs)
+        elif self.amp:
+            self._scaler.scale(loss).backward()
+        elif self._fp16 == "apex.amp":
+            with apex.amp.scale_loss(loss, self._optimizer) as scaled_loss:
+                scaled_loss.backward()
         else:
             loss.backward()
 
@@ -676,8 +702,8 @@ class FusedAdam(torch.optim.Optimizer):
 
                 state['step'] += 1
 
-                out_p = torch.tensor([], dtype=torch.float) if output_param \
-                    is None else output_param
+                out_p = torch.tensor([], dtype=torch.float) if \
+                    output_param is None else output_param
                 fused_adam_cuda.adam(p.data,
                                      out_p,
                                      exp_avg,


### PR DESCRIPTION
For benchmark and better documentation on performance I am adding back Apex.amp.

As a reminder, we have:
For adam:
if fp32, then it will use the native fp32 adam training.
if fp16, then it will use the "amp" library included in pytorch.

For fusedadam:
if fp16 or fp32 and "opt.apex_opt_level" is NOT set, then it will use the old legacy FusedAdam algorythm from the original apex implementation. https://github.com/NVIDIA/apex/blob/master/apex/contrib/optimizers/fp16_optimizer.py

if "opt.apex_opt_level" is set to:
"O0": training will be done in fp32 whatever the opt.model_dtype flag.
"O1" or "O2" will train according to those parameters: https://github.com/NVIDIA/apex/blob/master/docs/source/amp.rst
"O3": does not work with fusedadam, so do not use.