### PR TITLE
ignoring tgt tokens in batching for translation

### DIFF
--- a/onmt/inputters/text_utils.py
+++ b/onmt/inputters/text_utils.py
@@ -27,10 +27,13 @@ def max_tok_len(new, count, sofar):
         max_tgt_in_batch = 0
     # Src: [<bos> w1 ... wN <eos>]
     max_src_in_batch = max(max_src_in_batch, len(new['src']['src_ids']) + 2)
-    # Tgt: [w1 ... wM <eos>]
-    max_tgt_in_batch = max(max_tgt_in_batch, len(new['tgt']['tgt_ids']) + 1)
     src_elements = count * max_src_in_batch
-    tgt_elements = count * max_tgt_in_batch
+    # Tgt: [w1 ... wM <eos>]
+    if new['tgt'] is not None and new['tgt_ids'] is not None:
+        max_tgt_in_batch = max(max_tgt_in_batch, len(new['tgt']['tgt_ids']) + 1)
+        tgt_elements = count * max_tgt_in_batch
+    else:
+        tgt_elements = 0
     return max(src_elements, tgt_elements)
 
 

--- a/onmt/inputters/text_utils.py
+++ b/onmt/inputters/text_utils.py
@@ -30,7 +30,8 @@ def max_tok_len(new, count, sofar):
     src_elements = count * max_src_in_batch
     # Tgt: [w1 ... wM <eos>]
     if new['tgt'] is not None:
-        max_tgt_in_batch = max(max_tgt_in_batch, len(new['tgt']['tgt_ids']) + 1)
+        max_tgt_in_batch = max(max_tgt_in_batch,
+                               len(new['tgt']['tgt_ids']) + 1)
         tgt_elements = count * max_tgt_in_batch
     else:
         tgt_elements = 0

--- a/onmt/inputters/text_utils.py
+++ b/onmt/inputters/text_utils.py
@@ -29,7 +29,7 @@ def max_tok_len(new, count, sofar):
     max_src_in_batch = max(max_src_in_batch, len(new['src']['src_ids']) + 2)
     src_elements = count * max_src_in_batch
     # Tgt: [w1 ... wM <eos>]
-    if new['tgt'] is not None and new['tgt_ids'] is not None:
+    if new['tgt'] is not None:
         max_tgt_in_batch = max(max_tgt_in_batch, len(new['tgt']['tgt_ids']) + 1)
         tgt_elements = count * max_tgt_in_batch
     else:


### PR DESCRIPTION
The translate module expects a target, which is not a standard behavior for translation, `len(new['tgt'])` is none.
https://github.com/anthdr/OpenNMT-py/blob/891b1ef08ea05a9173879d51a79cb7c52aeccd9d/onmt/inputters/text_utils.py#L16-L34
Ignoring the counting of tgt tokens in batching allows the correct behavior of this module.