### PR TITLE
Handle bad lines in vocab file gracefully

### DIFF
--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -130,8 +130,11 @@ def _read_vocab_file(vocab_path, min_count):
             if has_count:
                 vocab = []
                 for line in lines:
-                    if int(line.split(None, 1)[1]) >= min_count:
-                        vocab.append(line.split(None, 1)[0])
+                    line_and_freq = line.split(None, 1)
+                    if len(line_and_freq) == 2:
+                        token, freq = line_and_freq
+                        if int(freq) >= min_count:
+                            vocab.append(token)
             else:
                 vocab = [line.strip().split()[0] for line in lines]
             return vocab


### PR DESCRIPTION
If there is a line in the vocab file that doesn't have a token and a frequency correctly separated by whitespace skip the line instead of failing.

Example vocab file with broken last line:
```
В        118
ισχύουν  118
ΓΙΚΑ     118
ÁČ       117
✓        117
117
```

- https://github.com/OpenNMT/OpenNMT-py/issues/2242
- https://github.com/OpenNMT/OpenNMT-py/commit/baa3d73f645f10e8f3a94b334fc217afdfc4e550