### PR TITLE
onmt_server works with ctranslate2

### DIFF
--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -542,10 +542,12 @@ class ServerModel(object):
         if len(texts_to_translate) > 0:
             try:
                 if isinstance(self.translator, CTranslate2Translator):
-                    scores, predictions = self.translator.translate(texts_to_translate)
+                    scores, predictions = self.translator.translate(
+                        texts_to_translate)
                 else:
-                    infer_iter = textbatch_to_tensor(self.translator.vocabs,
-                                                 texts_to_translate)
+                    infer_iter = textbatch_to_tensor(
+                        self.translator.vocabs,
+                        texts_to_translate)
                     scores, predictions = self.translator._translate(
                         infer_iter)
             except (RuntimeError, Exception) as e:

--- a/onmt/translate/translation_server.py
+++ b/onmt/translate/translation_server.py
@@ -541,11 +541,13 @@ class ServerModel(object):
 
         if len(texts_to_translate) > 0:
             try:
-                infer_iter = textbatch_to_tensor(self.translator.vocabs,
+                if isinstance(self.translator, CTranslate2Translator):
+                    scores, predictions = self.translator.translate(texts_to_translate)
+                else:
+                    infer_iter = textbatch_to_tensor(self.translator.vocabs,
                                                  texts_to_translate)
-
-                scores, predictions = self.translator._translate(
-                    infer_iter)
+                    scores, predictions = self.translator._translate(
+                        infer_iter)
             except (RuntimeError, Exception) as e:
                 err = "Error: %s" % str(e)
                 self.logger.error(err)


### PR DESCRIPTION
seems like the code for translator_server has changed in v3.0 but the code for Ctranslate2Translator class hasn't. since it doesn't have vocab attribute, using ctranslate2 models throws error.