### PR TITLE
Add CTranslate2 in requirements

### DIFF
--- a/onmt/bin/release_model.py
+++ b/onmt/bin/release_model.py
@@ -26,10 +26,6 @@ def main():
         torch.save(model, opt.output)
     elif opt.format == "ctranslate2":
         import ctranslate2
-        if not hasattr(ctranslate2, "__version__"):
-            raise RuntimeError(
-                "onmt_release_model script requires ctranslate2 >= 2.0.0"
-            )
         converter = ctranslate2.converters.OpenNMTPyConverter(opt.model)
         converter.convert(opt.output, force=True,
                           quantization=opt.quantization)

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     install_requires=[
         "torch>=1.12.1",
         "configargparse",
+        "ctranslate2>=3.0,<4",
         "tensorboard>=2.3",
         "flask",
         "waitress",


### PR DESCRIPTION
The package was not listed as a dependency because it was not available on all platforms at first. It is now available on all the platforms where `torch` is also available.