### PR TITLE
LMprior (LM Distillation) with CT2 or Onmt-py to infer LM model

### DIFF
--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -54,8 +54,7 @@ def build_vocab(opt, specials):
     vocabs = {}
     src_vocab = _read_vocab_file(opt.src_vocab, opt.src_words_min_frequency)
 
-    src_specials = list(specials['src'])
-
+    src_specials = list(sorted(specials['src']))
     src_vocab = pyonmttok.build_vocab_from_tokens(
         src_vocab,
         maximum_size=opt.src_vocab_size,
@@ -72,7 +71,7 @@ def build_vocab(opt, specials):
     else:
         tgt_vocab = _read_vocab_file(opt.tgt_vocab,
                                      opt.tgt_words_min_frequency)
-        tgt_specials = list(specials['tgt'])
+        tgt_specials = list(sorted(specials['tgt']))
         tgt_vocab = pyonmttok.build_vocab_from_tokens(
             tgt_vocab,
             maximum_size=opt.tgt_vocab_size,

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -55,6 +55,7 @@ def build_vocab(opt, specials):
     src_vocab = _read_vocab_file(opt.src_vocab, opt.src_words_min_frequency)
 
     src_specials = list(specials['src'])
+
     src_vocab = pyonmttok.build_vocab_from_tokens(
         src_vocab,
         maximum_size=opt.src_vocab_size,

--- a/onmt/inputters/inputter.py
+++ b/onmt/inputters/inputter.py
@@ -54,7 +54,7 @@ def build_vocab(opt, specials):
     vocabs = {}
     src_vocab = _read_vocab_file(opt.src_vocab, opt.src_words_min_frequency)
 
-    src_specials = list(sorted(specials['src']))
+    src_specials = specials['src']
     src_vocab = pyonmttok.build_vocab_from_tokens(
         src_vocab,
         maximum_size=opt.src_vocab_size,
@@ -71,7 +71,7 @@ def build_vocab(opt, specials):
     else:
         tgt_vocab = _read_vocab_file(opt.tgt_vocab,
                                      opt.tgt_words_min_frequency)
-        tgt_specials = list(sorted(specials['tgt']))
+        tgt_specials = specials['tgt']
         tgt_vocab = pyonmttok.build_vocab_from_tokens(
             tgt_vocab,
             maximum_size=opt.tgt_vocab_size,

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -429,6 +429,12 @@ def model_opts(parser):
               help='Train a coverage attention layer.')
     group.add('--lambda_coverage', '-lambda_coverage', type=float, default=0.0,
               help='Lambda value for coverage loss of See et al (2017)')
+    group.add('--lm_prior_model', '-lm_prior_model', type=str, default=None,
+              help='LM model to used to train the TM')
+    group.add('--lm_prior_lambda', '-lambda_prior_lambda',
+              type=float, default=0.0, help='LM Prior Lambda')
+    group.add('--lm_prior_tau', '-lambda_prior_tau', type=float, default=1.0,
+              help='LM Prior Tau')
     group.add('--loss_scale', '-loss_scale', type=float, default=0,
               help="For FP16 training, the static loss scale to use. If not "
                    "set, the loss scale is dynamically computed.")

--- a/onmt/tests/test_transform.py
+++ b/onmt/tests/test_transform.py
@@ -52,7 +52,7 @@ class TestTransform(unittest.TestCase):
         """)
         opt = Namespace(data=corpora)
         specials = get_specials(opt, transforms_cls)
-        specials_expected = {"src": ["｟_pf_src｠"], "tgt": ["｟_pf_tgt｠"]}
+        specials_expected = {"src": {"｟_pf_src｠"}, "tgt": {"｟_pf_tgt｠"}}
         self.assertEqual(specials, specials_expected)
 
     def test_transform_pipe(self):

--- a/onmt/tests/test_transform.py
+++ b/onmt/tests/test_transform.py
@@ -52,7 +52,7 @@ class TestTransform(unittest.TestCase):
         """)
         opt = Namespace(data=corpora)
         specials = get_specials(opt, transforms_cls)
-        specials_expected = {"src": {"｟_pf_src｠"}, "tgt": {"｟_pf_tgt｠"}}
+        specials_expected = {"src": ["｟_pf_src｠"], "tgt": ["｟_pf_tgt｠"]}
         self.assertEqual(specials, specials_expected)
 
     def test_transform_pipe(self):

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -24,6 +24,7 @@ def prepare_transforms_vocabs(opt):
     """Prepare or dump transforms before training."""
     transforms_cls = get_transforms_cls(opt._all_transform)
     specials = get_specials(opt, transforms_cls)
+
     vocabs = build_vocab(opt, specials)
 
     # maybe prepare pretrained embeddings, if any

--- a/onmt/train_single.py
+++ b/onmt/train_single.py
@@ -24,7 +24,6 @@ def prepare_transforms_vocabs(opt):
     """Prepare or dump transforms before training."""
     transforms_cls = get_transforms_cls(opt._all_transform)
     specials = get_specials(opt, transforms_cls)
-
     vocabs = build_vocab(opt, specials)
 
     # maybe prepare pretrained embeddings, if any

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -441,6 +441,7 @@ class Trainer(object):
                     if loss is not None:
                         # in theory we should divide by accum_count and bptt
                         # to rescale for each sub batch
+                        loss /= self.accum_count
                         self.optim.backward(loss)
 
                     total_stats.update(batch_stats)

--- a/onmt/transforms/tokenize.py
+++ b/onmt/transforms/tokenize.py
@@ -332,19 +332,17 @@ class ONMTTokenizerTransform(TokenizerTransform):
 
     @classmethod
     def get_specials(cls, opts):
-        src_specials, tgt_specials = [], []
+        src_specials, tgt_specials = set(), set()
         if opts.src_onmttok_kwargs.get("case_markup", False):
             _case_specials = ['｟mrk_case_modifier_C｠',
                               '｟mrk_begin_case_region_U｠',
                               '｟mrk_end_case_region_U｠']
-            for src_spec in _case_specials:
-                src_specials.append(src_spec)
+            src_specials.update(_case_specials)
         if opts.tgt_onmttok_kwargs.get("case_markup", False):
             _case_specials = ['｟mrk_case_modifier_C｠',
                               '｟mrk_begin_case_region_U｠',
                               '｟mrk_end_case_region_U｠']
-            for tgt_spec in _case_specials:
-                tgt_specials.append(tgt_spec)
+            tgt_specials.update(_case_specials)
         return (src_specials, tgt_specials)
 
     def _get_subword_kwargs(self, side='src'):

--- a/onmt/transforms/tokenize.py
+++ b/onmt/transforms/tokenize.py
@@ -332,17 +332,19 @@ class ONMTTokenizerTransform(TokenizerTransform):
 
     @classmethod
     def get_specials(cls, opts):
-        src_specials, tgt_specials = set(), set()
+        src_specials, tgt_specials = [], []
         if opts.src_onmttok_kwargs.get("case_markup", False):
             _case_specials = ['｟mrk_case_modifier_C｠',
                               '｟mrk_begin_case_region_U｠',
                               '｟mrk_end_case_region_U｠']
-            src_specials.update(_case_specials)
+            for src_spec in _case_specials:
+                src_specials.append(src_spec)
         if opts.tgt_onmttok_kwargs.get("case_markup", False):
             _case_specials = ['｟mrk_case_modifier_C｠',
                               '｟mrk_begin_case_region_U｠',
                               '｟mrk_end_case_region_U｠']
-            tgt_specials.update(_case_specials)
+            for tgt_spec in _case_specials:
+                tgt_specials.append(tgt_spec)
         return (src_specials, tgt_specials)
 
     def _get_subword_kwargs(self, side='src'):

--- a/onmt/transforms/transform.py
+++ b/onmt/transforms/transform.py
@@ -47,7 +47,7 @@ class Transform(object):
 
     @classmethod
     def get_specials(cls, opts):
-        return ([], [])
+        return (set(), set())
 
     def apply(self, example, is_train=False, stats=None, **kwargs):
         """Apply transform to `example`.
@@ -174,13 +174,11 @@ class TransformPipe(Transform):
     @classmethod
     def get_specials(cls, opts, transforms):
         """Return all specials introduced by `transforms`."""
-        src_specials, tgt_specials = [], []
+        src_specials, tgt_specials = set(), set()
         for transform in transforms:
             _src_special, _tgt_special = transform.get_specials(transform.opts)
-            for _src_spec in _src_special:
-                src_specials.append(_src_spec)
-            for _tgt_spec in _tgt_special:
-                tgt_specials.append(_tgt_spec)
+            src_specials.update(_src_special)
+            tgt_specials.update(_tgt_special)
         return (src_specials, tgt_specials)
 
     def apply(self, example, is_train=False, **kwargs):
@@ -239,13 +237,11 @@ def make_transforms(opts, transforms_cls, vocabs):
 
 def get_specials(opts, transforms_cls_dict):
     """Get specials of transforms that should be registed in Vocab."""
-    all_specials = {'src': [], 'tgt': []}
+    all_specials = {'src': set(), 'tgt': set()}
     for name, transform_cls in transforms_cls_dict.items():
         src_specials, tgt_specials = transform_cls.get_specials(opts)
-        for src_spec in src_specials:
-            all_specials['src'].append(src_spec)
-        for tgt_spec in tgt_specials:
-            all_specials['tgt'].append(tgt_spec)
+        all_specials['src'].update(src_specials)
+        all_specials['tgt'].update(tgt_specials)
     logger.info(f"Get special vocabs from Transforms: {all_specials}.")
     return all_specials
 

--- a/onmt/transforms/transform.py
+++ b/onmt/transforms/transform.py
@@ -47,7 +47,7 @@ class Transform(object):
 
     @classmethod
     def get_specials(cls, opts):
-        return (set(), set())
+        return ([], [])
 
     def apply(self, example, is_train=False, stats=None, **kwargs):
         """Apply transform to `example`.
@@ -174,11 +174,13 @@ class TransformPipe(Transform):
     @classmethod
     def get_specials(cls, opts, transforms):
         """Return all specials introduced by `transforms`."""
-        src_specials, tgt_specials = set(), set()
+        src_specials, tgt_specials = [], []
         for transform in transforms:
             _src_special, _tgt_special = transform.get_specials(transform.opts)
-            src_specials.update(_src_special)
-            tgt_specials.update(_tgt_special)
+            for _src_spec in _src_special:
+                src_specials.append(_src_spec)
+            for _tgt_spec in _tgt_special:
+                tgt_specials.append(_tgt_spec)
         return (src_specials, tgt_specials)
 
     def apply(self, example, is_train=False, **kwargs):
@@ -237,11 +239,13 @@ def make_transforms(opts, transforms_cls, vocabs):
 
 def get_specials(opts, transforms_cls_dict):
     """Get specials of transforms that should be registed in Vocab."""
-    all_specials = {'src': set(), 'tgt': set()}
+    all_specials = {'src': [], 'tgt': []}
     for name, transform_cls in transforms_cls_dict.items():
         src_specials, tgt_specials = transform_cls.get_specials(opts)
-        all_specials['src'].update(src_specials)
-        all_specials['tgt'].update(tgt_specials)
+        for src_spec in src_specials:
+            all_specials['src'].append(src_spec)
+        for tgt_spec in tgt_specials:
+            all_specials['tgt'].append(tgt_spec)
     logger.info(f"Get special vocabs from Transforms: {all_specials}.")
     return all_specials
 

--- a/onmt/transforms/transform.py
+++ b/onmt/transforms/transform.py
@@ -47,7 +47,7 @@ class Transform(object):
 
     @classmethod
     def get_specials(cls, opts):
-        return (set(), set())
+        return ([], [])
 
     def apply(self, example, is_train=False, stats=None, **kwargs):
         """Apply transform to `example`.
@@ -174,11 +174,13 @@ class TransformPipe(Transform):
     @classmethod
     def get_specials(cls, opts, transforms):
         """Return all specials introduced by `transforms`."""
-        src_specials, tgt_specials = set(), set()
+        src_specials, tgt_specials = [], []
         for transform in transforms:
             _src_special, _tgt_special = transform.get_specials(transform.opts)
-            src_specials.update(_src_special)
-            tgt_specials.update(tgt_specials)
+            for _src_spec in _src_special:
+                src_specials.append(_src_spec)
+            for _tgt_spec in _tgt_special:
+                tgt_specials.append(_tgt_spec)
         return (src_specials, tgt_specials)
 
     def apply(self, example, is_train=False, **kwargs):
@@ -237,11 +239,13 @@ def make_transforms(opts, transforms_cls, vocabs):
 
 def get_specials(opts, transforms_cls_dict):
     """Get specials of transforms that should be registed in Vocab."""
-    all_specials = {'src': set(), 'tgt': set()}
+    all_specials = {'src': [], 'tgt': []}
     for name, transform_cls in transforms_cls_dict.items():
         src_specials, tgt_specials = transform_cls.get_specials(opts)
-        all_specials['src'].update(src_specials)
-        all_specials['tgt'].update(tgt_specials)
+        for src_spec in src_specials:
+            all_specials['src'].append(src_spec)
+        for tgt_spec in tgt_specials:
+            all_specials['tgt'].append(tgt_spec)
     logger.info(f"Get special vocabs from Transforms: {all_specials}.")
     return all_specials
 

--- a/onmt/utils/loss.py
+++ b/onmt/utils/loss.py
@@ -5,12 +5,15 @@ This includes: LossComputeBase and the standard NMTLossCompute, and
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import ctranslate2
 import onmt
 from onmt.modules.sparse_losses import SparsemaxLoss
 from onmt.modules.sparse_activations import LogSparsemax
 from onmt.constants import ModelTask, DefaultTokens
 from onmt.modules.copy_generator import collapse_copy_scores
+try:
+    import ctranslate2
+except ImportError:
+    pass   # this is tested when importing for loading a LM
 
 
 class LossCompute(nn.Module):

--- a/tools/LM_scoring.py
+++ b/tools/LM_scoring.py
@@ -100,9 +100,8 @@ def main():
         batch_size = len(batch['srclen'])
         src = batch['src']
         src_len = batch['srclen']
-        tgt = batch['tgt']
 
-        outputs, attns = model(src, tgt, src_len,
+        outputs, attns = model(src, None, src_len,
                                with_align=False)
         # Compute and retrieve the loss for EACH sentence
         lossflat, _ = valid_loss(batch, outputs, attns)


### PR DESCRIPTION
This PR does:

Cf: https://arxiv.org/pdf/2004.14928.pdf
Initially designed for Low Resource NMT but it gave also good results with a EN-DE experiment. Output perplexity in the target language is lower than without the LM distillation.

Also fix the set() randomness in the get_specials() transforms.
(we need the exact same vocab for the LM and NMT models)
fix #2251 