### PR TITLE
Fix detok in scoring utils

### DIFF
--- a/onmt/bin/build_vocab.py
+++ b/onmt/bin/build_vocab.py
@@ -61,8 +61,10 @@ def build_sub_vocab(corpora, transforms, opts, n_sample, stride, offset):
         stride=stride, offset=offset)
     for c_name, c_iter in datasets_iterables.items():
         for i, item in enumerate(c_iter):
-            maybe_example = process(CorpusTask.TRAIN, [item])[0]
-            if maybe_example is None:
+            maybe_example = process(CorpusTask.TRAIN, [item])
+            if maybe_example is not None:
+                maybe_example = maybe_example[0]
+            else:
                 if opts.dump_samples:
                     build_sub_vocab.queues[c_name][offset].put("blank")
                 continue

--- a/onmt/inputters/text_utils.py
+++ b/onmt/inputters/text_utils.py
@@ -286,11 +286,13 @@ def _addcopykeys(vocabs, example):
     example['src_ex_vocab'] = src_ex_vocab
 
     if example['tgt'] is not None:
+        tgt = None
         if vocabs['data_task'] == ModelTask.SEQ2SEQ:
             tgt = [DefaultTokens.UNK] + example['tgt']['tgt'].split() \
                   + [DefaultTokens.UNK]
         elif vocabs['data_task'] == ModelTask.LANGUAGE_MODEL:
             tgt = example['tgt']['tgt'].split() \
                   + [DefaultTokens.UNK]
-        example['alignment'] = src_ex_vocab(tgt)
+        if tgt:
+            example['alignment'] = src_ex_vocab(tgt)
     return example

--- a/onmt/inputters/text_utils.py
+++ b/onmt/inputters/text_utils.py
@@ -64,8 +64,6 @@ def process(task, bucket, **kwargs):
             (example, transform, cid) = processed_bucket[i]
             example = clean_example(example)
             processed_bucket[i] = example
-        with open('processed_bucket_clean', "w") as w:
-            w.write(str(processed_bucket))
         # at this point an example looks like:
         # {'src': {'src': ..., 'feat1': ...., 'feat2': ....},
         #  'tgt': {'tgt': ...},

--- a/onmt/inputters/text_utils.py
+++ b/onmt/inputters/text_utils.py
@@ -266,7 +266,6 @@ def _addcopykeys(vocabs, example):
     Returns:
         ``example``, changed as described.
     """
-
     src = example['src']['src'].split()
     src_ex_vocab = pyonmttok.build_vocab_from_tokens(
         Counter(src),
@@ -284,13 +283,11 @@ def _addcopykeys(vocabs, example):
     example['src_ex_vocab'] = src_ex_vocab
 
     if example['tgt'] is not None:
-        tgt = None
         if vocabs['data_task'] == ModelTask.SEQ2SEQ:
             tgt = [DefaultTokens.UNK] + example['tgt']['tgt'].split() \
                   + [DefaultTokens.UNK]
         elif vocabs['data_task'] == ModelTask.LANGUAGE_MODEL:
             tgt = example['tgt']['tgt'].split() \
                   + [DefaultTokens.UNK]
-        if tgt:
-            example['alignment'] = src_ex_vocab(tgt)
+        example['alignment'] = src_ex_vocab(tgt)
     return example

--- a/onmt/inputters/text_utils.py
+++ b/onmt/inputters/text_utils.py
@@ -58,21 +58,25 @@ def process(task, bucket, **kwargs):
     _, transform, cid = bucket[0]
     # We apply the same TransformPipe to all the bucket
     processed_bucket = transform.batch_apply(
-        bucket, is_train=(task == CorpusTask.TRAIN), corpus_name=cid)
-    for i in range(len(processed_bucket)):
-        (example, transform, cid) = processed_bucket[i]
-        if example is not None:
+       bucket, is_train=(task == CorpusTask.TRAIN), corpus_name=cid)
+    if processed_bucket:
+        for i in range(len(processed_bucket)):
+            (example, transform, cid) = processed_bucket[i]
             example = clean_example(example)
-        processed_bucket[i] = example
-    # at this point an example looks like:
-    # {'src': {'src': ..., 'feat1': ...., 'feat2': ....},
-    #  'tgt': {'tgt': ...},
-    #  'src_original': ['tok1', ...'tokn'],
-    #  'tgt_original': ['tok1', ...'tokm'],
-    #  'indices' : seq in bucket
-    #  'align': ...,
-    # }
-    return processed_bucket
+            processed_bucket[i] = example
+        with open('processed_bucket_clean', "w") as w:
+            w.write(str(processed_bucket))
+        # at this point an example looks like:
+        # {'src': {'src': ..., 'feat1': ...., 'feat2': ....},
+        #  'tgt': {'tgt': ...},
+        #  'src_original': ['tok1', ...'tokn'],
+        #  'tgt_original': ['tok1', ...'tokm'],
+        #  'indices' : seq in bucket
+        #  'align': ...,
+        # }
+        return processed_bucket
+    else:
+        return None
 
 
 def numericalize(vocabs, example):

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -38,7 +38,10 @@ def build_trainer(opt, device_id, model, vocabs, optim, model_saver=None):
     train_loss = LossCompute.from_opts(opt, model, vocabs['tgt'])
     valid_loss = LossCompute.from_opts(opt, model, vocabs['tgt'], train=False)
 
-    scoring_preparator = ScoringPreparator(vocabs, opt)
+    scoring_preparator = ScoringPreparator(vocabs=vocabs, opt=opt)
+    validset_transforms = opt.data.get("valid", {}).get("transforms", None)
+    if validset_transforms:
+        scoring_preparator.warm_up(validset_transforms)
     scorers_cls = get_scorers_cls(opt.train_metrics)
     train_scorers = build_scorers(opt, scorers_cls)
     scorers_cls = get_scorers_cls(opt.valid_metrics)
@@ -249,6 +252,8 @@ class Trainer(object):
         else:
             logger.info('Start training loop and validate every %d steps...',
                         valid_steps)
+        logger.info(
+            "Scoring with: {}".format(self.scoring_preparator.transform))
 
         total_stats = onmt.utils.Statistics()
         report_stats = onmt.utils.Statistics()
@@ -324,8 +329,7 @@ class Trainer(object):
         # Set model in validating mode.
         valid_model.eval()
 
-        sources = []
-        refs = []
+        tokenized_batchs = []
         with torch.no_grad():
             stats = onmt.utils.Statistics()
             start = time.time()
@@ -334,10 +338,9 @@ class Trainer(object):
                 src_len = batch['srclen']
                 tgt = batch['tgt']
                 if self.valid_scorers:
-                    sources_, refs_ = self.scoring_preparator.\
-                        build_sources_and_refs(batch)
-                    sources.append(sources_)
-                    refs += refs_
+                    tokenized_batch = self.scoring_preparator.\
+                        tokenize_batch(batch)
+                    tokenized_batchs.append(tokenized_batch)
                 with torch.cuda.amp.autocast(enabled=self.optim.amp):
                     # F-prop through the model.
                     model_out, attns = valid_model(src, tgt, src_len,
@@ -356,8 +359,7 @@ class Trainer(object):
                 start = time.time()
                 preds, texts_ref = self.scoring_preparator.translate(
                     model=self.model,
-                    sources=sources,
-                    refs=refs,
+                    tokenized_batchs=tokenized_batchs,
                     gpu_rank=self.gpu_rank,
                     step=self.optim.training_step,
                     mode="valid")
@@ -451,12 +453,11 @@ class Trainer(object):
                     ):
                         # Compute and save stats
                         computed_metrics = {}
-                        sources_, refs_ = self.scoring_preparator.\
-                            build_sources_and_refs(batch)
+                        tokenized_batch = self.scoring_preparator.\
+                            tokenize_batch(batch)
                         preds, texts_ref = self.scoring_preparator.translate(
                             model=self.model,
-                            sources=[sources_],
-                            refs=refs_,
+                            tokenized_batchs=[tokenized_batch],
                             gpu_rank=self.gpu_rank,
                             step=self.optim.training_step,
                             mode="train")

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -329,7 +329,7 @@ class Trainer(object):
         # Set model in validating mode.
         valid_model.eval()
 
-        tokenized_batchs = []
+        tokenized_batches = []
         with torch.no_grad():
             stats = onmt.utils.Statistics()
             start = time.time()
@@ -340,7 +340,7 @@ class Trainer(object):
                 if self.valid_scorers:
                     tokenized_batch = self.scoring_preparator.\
                         tokenize_batch(batch)
-                    tokenized_batchs.append(tokenized_batch)
+                    tokenized_batches.append(tokenized_batch)
                 with torch.cuda.amp.autocast(enabled=self.optim.amp):
                     # F-prop through the model.
                     model_out, attns = valid_model(src, tgt, src_len,
@@ -350,7 +350,7 @@ class Trainer(object):
                     _, batch_stats = self.valid_loss(batch, model_out, attns)
 
                     stats.update(batch_stats)
-            logger.info("""valid stats calculation and batchs detokenization
+            logger.info("""valid stats calculation and batches detokenization
                            took: {} s.""".format(time.time() - start))
 
             # Compute validation metrics (at batch.dataset level)
@@ -359,7 +359,7 @@ class Trainer(object):
                 start = time.time()
                 preds, texts_ref = self.scoring_preparator.translate(
                     model=self.model,
-                    tokenized_batchs=tokenized_batchs,
+                    tokenized_batches=tokenized_batches,
                     gpu_rank=self.gpu_rank,
                     step=self.optim.training_step,
                     mode="valid")
@@ -457,7 +457,7 @@ class Trainer(object):
                             tokenize_batch(batch)
                         preds, texts_ref = self.scoring_preparator.translate(
                             model=self.model,
-                            tokenized_batchs=[tokenized_batch],
+                            tokenized_batches=[tokenized_batch],
                             gpu_rank=self.gpu_rank,
                             step=self.optim.training_step,
                             mode="train")

--- a/onmt/transforms/tokenize.py
+++ b/onmt/transforms/tokenize.py
@@ -202,12 +202,12 @@ class SentencePieceTransform(TokenizerTransform):
         example['src'], example['tgt'] = src_out, tgt_out
         return example
 
-    def apply_reverse(self, translated, side='tgt'):
+    def apply_reverse(self, translated):
         """Apply SentencePiece Detokenizer."""
         if isinstance(translated, list):
-            return self._detokenize(translated, side)
+            return self._detokenize(translated, "tgt")
         else:
-            return self._detokenize(translated.split(), side)
+            return self._detokenize(translated.split(), "tgt")
 
     def _repr_args(self):
         """Return str represent key arguments for class."""
@@ -287,12 +287,12 @@ class BPETransform(TokenizerTransform):
         example['src'], example['tgt'] = src_out, tgt_out
         return example
 
-    def apply_reverse(self, translated, side='tgt'):
+    def apply_reverse(self, translated):
         """Apply bpe subword detokenizer"""
         if isinstance(translated, list):
-            return self._detokenize(translated, side)
+            return self._detokenize(translated, "tgt")
         else:
-            return self._detokenize(translated.split(), side)
+            return self._detokenize(translated.split(), "tgt")
 
 
 @register_transform(name='onmt_tokenize')
@@ -461,12 +461,12 @@ class ONMTTokenizerTransform(TokenizerTransform):
         example['src'], example['tgt'] = src_out, tgt_out
         return example
 
-    def apply_reverse(self, translated, side='tgt'):
+    def apply_reverse(self, translated):
         """Apply OpenNMT Tokenizer to src & tgt."""
         if isinstance(translated, list):
-            return self._detokenize(translated, side)
+            return self._detokenize(translated, "tgt")
         else:
-            return self._detokenize(translated.split(), side)
+            return self._detokenize(translated.split(), "tgt")
 
     def _repr_args(self):
         """Return str represent key arguments for class."""

--- a/onmt/transforms/tokenize.py
+++ b/onmt/transforms/tokenize.py
@@ -185,6 +185,11 @@ class SentencePieceTransform(TokenizerTransform):
                 alpha=alpha, nbest_size=nbest_size)
         return segmented
 
+    def _detokenize(self, tokens, side="src"):
+        """Apply SentencePiece Detokenizer"""
+        sp_model = self.load_models[side]
+        return sp_model.DecodePieces(tokens)
+
     def apply(self, example, is_train=False, stats=None, **kwargs):
         """Apply sentencepiece subword encode to src & tgt."""
         src_out = self._tokenize(example['src'], 'src', is_train)
@@ -195,6 +200,13 @@ class SentencePieceTransform(TokenizerTransform):
             stats.update(SubwordStats(n_subwords, n_words))
         example['src'], example['tgt'] = src_out, tgt_out
         return example
+
+    def apply_reverse(self, translated, side='tgt'):
+        """Apply OpenNMT Tokenizer to src & tgt."""
+        if isinstance(translated, list):
+            return self._detokenize(translated, side)
+        else:
+            return self._detokenize(translated.split(), side)
 
     def _repr_args(self):
         """Return str represent key arguments for class."""
@@ -436,9 +448,9 @@ class ONMTTokenizerTransform(TokenizerTransform):
         example['src'], example['tgt'] = src_out, tgt_out
         return example
 
-    def apply_reverse(self, translated):
+    def apply_reverse(self, translated, side='tgt'):
         """Apply OpenNMT Tokenizer to src & tgt."""
-        return self._detokenize(translated.split(), 'tgt')
+        return self._detokenize(translated.split(), side)
 
     def _repr_args(self):
         """Return str represent key arguments for class."""

--- a/onmt/transforms/transform.py
+++ b/onmt/transforms/transform.py
@@ -72,7 +72,7 @@ class Transform(object):
                 transformed_batch.append((example, self, cid))
         return transformed_batch
 
-    def apply_reverse(self, translated):
+    def apply_reverse(self, translated, side="tgt"):
         return translated
 
     def __getstate__(self):
@@ -224,9 +224,9 @@ class TransformPipe(Transform):
                 break
         return batch
 
-    def apply_reverse(self, translated):
+    def apply_reverse(self, translated, side="tgt"):
         for transform in self.transforms:
-            translated = transform.apply_reverse(translated)
+            translated = transform.apply_reverse(translated, side)
         return translated
 
     def __getstate__(self):

--- a/onmt/transforms/transform.py
+++ b/onmt/transforms/transform.py
@@ -72,7 +72,7 @@ class Transform(object):
                 transformed_batch.append((example, self, cid))
         return transformed_batch
 
-    def apply_reverse(self, translated, side="tgt"):
+    def apply_reverse(self, translated):
         return translated
 
     def __getstate__(self):
@@ -224,9 +224,9 @@ class TransformPipe(Transform):
                 break
         return batch
 
-    def apply_reverse(self, translated, side="tgt"):
+    def apply_reverse(self, translated):
         for transform in self.transforms:
-            translated = transform.apply_reverse(translated, side)
+            translated = transform.apply_reverse(translated)
         return translated
 
     def __getstate__(self):

--- a/onmt/utils/scoring_utils.py
+++ b/onmt/utils/scoring_utils.py
@@ -7,78 +7,39 @@ from onmt.opts import translate_opts
 from onmt.constants import DefaultTokens
 from onmt.inputters.text_utils import _addcopykeys, tensorify, text_sort_key
 from onmt.inputters.inputter import IterOnDevice
-
-
-class Detokenizer():
-    """ Allow detokenizing sequences in batchs"""
-    def __init__(self, opt):
-        if 'bpe' in opt.transforms:
-            self.type = "subword-nmt"
-        elif 'sentencepiece' in opt.transforms:
-            self.type = "sentencepiece"
-        elif 'onmt_tokenize' in opt.transforms:
-            self.type = "pyonmttok"
-            self.tgt_onmttok_kwargs = opt.tgt_onmttok_kwargs
-        else:
-            self.type = None
-        if self.type in ['bpe', 'sentencepiece']:
-            if opt.tgt_subword_model is None:
-                raise ValueError(
-                    "Missing mandatory tokenizer option 'tgt_subword_model'")
-            else:
-                self.model_path = opt.tgt_subword_model
-
-    def build_detokenizer(self):
-        if self.type == "pyonmttok":
-            import pyonmttok
-            self.tgt_detokenizer = pyonmttok.Tokenizer(
-                **self.tgt_onmttok_kwargs)
-        elif self.type == "sentencepiece":
-            import sentencepiece as spm
-            self.tgt_detokenizer = spm.SentencePieceProcessor()
-            self.tgt_detokenizer.Load(self.model_path)
-        elif self.type == "subword-nmt":
-            from subword_nmt.apply_bpe import BPE
-            with open(self.model_path, encoding='utf-8') as tgt_codes:
-                self.tgt_detokenizer = BPE(codes=tgt_codes, vocab=None)
-        else:
-            self.tgt_detokenizer = None
-        return self.tgt_detokenizer
-
-    def _detokenize(self, tokens):
-        if self.type == "pyonmttok":
-            detok = self.tgt_detokenizer.detokenize(tokens)
-        elif self.type == "sentencepiece":
-            detok = self.tgt_detokenizer.DecodePieces(tokens)
-        elif self.type == "subword-nmt":
-            detok = self.tgt_detokenizer.segment_tokens(tokens, dropout=0.0)
-        else:
-            detok = " ".join(tokens)
-        return detok
+from onmt.transforms import get_transforms_cls, make_transforms, TransformPipe
 
 
 class ScoringPreparator():
     """Allow the calculation of metrics via the Trainer's
-     training_eval_handler method"""
+     training_eval_handler method.
+    """
     def __init__(self, vocabs, opt):
         self.vocabs = vocabs
         self.opt = opt
-        self.tgt_detokenizer = Detokenizer(opt)
-        self.tgt_detokenizer.build_detokenizer()
         if self.opt.dump_preds is not None:
             if not os.path.exists(self.opt.dump_preds):
                 os.makedirs(self.opt.dump_preds)
+        transforms_cls = get_transforms_cls(opt.transforms)
+        transforms = make_transforms(self.opt, transforms_cls, self.vocabs)
+        self.transform = TransformPipe.build_from(transforms.values())
 
-    def tokenize_batch(self, batch_side, side):
+    def warm_up(self, transforms):
+        transforms_cls = get_transforms_cls(transforms)
+        transforms = make_transforms(self.opt, transforms_cls, self.vocabs)
+        self.transform = TransformPipe.build_from(transforms.values())
+
+    def tokenize_batch_side(self, batch, side):
         """Convert a batch into a list of tokenized sentences
         Args:
-            batch_side: 'src' or 'tgt' field of a batch.
+            batch: batch yielded from `DynamicDatasetIter` object
             side (string): 'src' or 'tgt'.
         Returns
             tokenized_sentences (list): List of lists of tokens.
                 Each list is a tokenized sentence.
         """
         vocab = self.vocabs[side]
+        batch_side = batch[side]
         nb_sentences = batch_side.shape[0]
         nb_tokens_per_sentence = batch_side.shape[1]
         indices_to_remove = [vocab.lookup_token(token)
@@ -93,27 +54,27 @@ class ScoringPreparator():
             tokenized_sentences.append(tokens)
         return tokenized_sentences
 
-    def build_sources_and_refs(self, batch):
-        """Reconstruct sources and references from a batch
+    def tokenize_batch(self, batch):
+        """Reconstruct raw sources and references from a batch
         Args:
             batch: batch yielded from `DynamicDatasetIter` object
         Returns:
-           sources (list): Tokenized source sentences
-           refs (list): Tokenized target sentences
+            tokenized_batch(list): A list of examples
+        with the fields "src" and "tgt"
         """
-        sources = self.tokenize_batch(batch['src'], 'src')
-        refs = self.tokenize_batch(batch['tgt'], 'tgt')
-        return sources, refs
+        tokenized_batch = [{'src': src_ex, 'tgt': tgt_ex}
+                           for src_ex, tgt_ex
+                           in zip(self.tokenize_batch_side(batch, 'src'),
+                                  self.tokenize_batch_side(batch, 'tgt'))]
+        return tokenized_batch
 
-    def translate(self, model, sources, refs, gpu_rank, step, mode):
+    def translate(self, model, tokenized_batchs, gpu_rank, step, mode):
         """Compute and save the sentences predicted by the
         current model's state related to a batch.
 
         Args:
             model (:obj:`onmt.models.NMTModel`): The current model's state.
-            sources: (list) List of lists of tokenized source sentences.
-                Each list is related to a batch.
-            refs (list): Tokenized target sentences.
+            tokenized_batchs(list of lists): A list of tokenized batchs.
             gpu_rank (int): Ordinal rank of the gpu where the
                 translation is to be done.
             step: The current training step.
@@ -122,6 +83,9 @@ class ScoringPreparator():
             preds (list): Detokenized predictions
             texts_ref (list): Detokenized target sentences
         """
+        with open("tokenized_batchs", "w") as f:
+            f.write(str(type(tokenized_batchs)) + "/n")
+            f.write(str(tokenized_batchs) + "/n")
         model_opt = self.opt
         parser = ArgumentParser()
         translate_opts(parser)
@@ -143,47 +107,56 @@ class ScoringPreparator():
             report_align=opt.report_align,
             report_score=False,
             logger=None)
+        # translate
         preds = []
-        for sources_ in sources:
+        raw_sources = []
+        raw_refs = []
+        for batch in tokenized_batchs:
             # for validation we build an infer_iter per batch
             # in order to avoid oom issues because there is no
             # batching strategy in `textbatch_to_tensor`
             numeric = []
-            for i, ex in enumerate(sources_):
-                if isinstance(ex, bytes):
-                    ex = ex.decode("utf-8")
-                idxs = translator.vocabs['src'](ex)
-                num_ex = {'src': {'src': " ".join(ex),
-                          'src_ids': idxs},
-                          'srclen': len(ex),
-                          'tgt': None,
-                          'indices': i,
-                          'align': None}
-                num_ex = _addcopykeys(translator.vocabs["src"], num_ex)
-                num_ex["src"]["src"] = ex
-                numeric.append(num_ex)
+            for i, ex in enumerate(batch):
+                # ex =  self.transform.apply(ex)
+                if ex is not None:
+                    raw_sources.append(ex['src'])
+                    raw_refs.append(ex['tgt'])
+                    if isinstance(ex['src'], bytes):
+                        ex['src'] = ex['src'].decode("utf-8")
+                    idxs = translator.vocabs['src'](ex['src'])
+                    num_ex = {'src': {'src': " ".join(ex['src']),
+                              'src_ids': idxs},
+                              'srclen': len(ex['src']),
+                              'tgt': None,
+                              'indices': i,
+                              'align': None}
+                    num_ex = _addcopykeys(translator.vocabs["src"], num_ex)
+                    num_ex["src"]["src"] = ex['src']
+                    numeric.append(num_ex)
             numeric.sort(key=text_sort_key, reverse=True)
             infer_iter = [tensorify(self.vocabs, numeric)]
             infer_iter = IterOnDevice(infer_iter, opt.gpu)
             _, preds_ = translator._translate(
-                        infer_iter)
+                        infer_iter, transform=self.transform)
             preds += preds_
-        # flatten sources (for validation)
-        sources = [item for sources_ in sources for item in sources_]
-        texts_ref = []
-        for i in range(len(preds)):
-            preds[i] = self.tgt_detokenizer._detokenize(preds[i][0].split())
-            texts_ref.append(self.tgt_detokenizer._detokenize(refs[i]))
+        # apply_reverse on raw references
+        texts_ref = [self.transform.apply_reverse(raw_ref, "tgt")
+                     for raw_ref in raw_refs]
+        # apply_reverse on predictions
+        preds = [self.transform.apply_reverse(preds_, "tgt")
+                 for preds_ in preds]
+
+        # save results
         if len(preds) > 0 and self.opt.scoring_debug:
             path = os.path.join(self.opt.dump_preds,
                                 "preds.{}_step_{}.{}".format(
                                     mode, step, "txt"))
             with open(path, "a") as file:
                 for i in range(len(preds)):
-                    file.write("SOURCE: {}\n".format(sources[i]))
+                    file.write("SOURCE: {}\n".format(raw_sources[i]))
                     file.write("REF: {}\n".format(texts_ref[i]))
                     file.write("PRED: {}\n\n".format(preds[i]))
-        # we deactivate the decoder's cache
+        # We deactivate the decoder's cache
         # as we use teacher forcing at training time.
         if hasattr(model.decoder, 'transformer_layers'):
             for layer in model.decoder.transformer_layers:

--- a/onmt/utils/scoring_utils.py
+++ b/onmt/utils/scoring_utils.py
@@ -137,12 +137,15 @@ class ScoringPreparator():
             _, preds_ = translator._translate(
                         infer_iter, transform=self.transform)
             preds += preds_
-        # detokenize refs and predicitons
+            with open("x", "a") as f:
+                f.write(str(len(preds_)))
+
+        # detokenize refs
         if self.transforms:
             texts_ref = [self.transform.apply_reverse(raw_ref)
                          for raw_ref in raw_refs]
-            preds = [self.transform.apply_reverse(preds_)
-                     for preds_ in preds]
+            # flatten preds
+            preds = [item for preds_ in preds for item in preds_]
         else:
             texts_ref = [" ".join(raw_ref) for raw_ref in raw_refs]
             preds = [" ".join(preds_) for preds_ in preds]

--- a/onmt/utils/scoring_utils.py
+++ b/onmt/utils/scoring_utils.py
@@ -70,13 +70,13 @@ class ScoringPreparator():
                                   self.tokenize_batch_side(batch, 'tgt'))]
         return tokenized_batch
 
-    def translate(self, model, tokenized_batchs, gpu_rank, step, mode):
+    def translate(self, model, tokenized_batches, gpu_rank, step, mode):
         """Compute and save the sentences predicted by the
         current model's state related to a batch.
 
         Args:
             model (:obj:`onmt.models.NMTModel`): The current model's state.
-            tokenized_batchs(list of lists): A list of tokenized batchs.
+            tokenized_batches(list of lists): A list of tokenized batches.
             gpu_rank (int): Ordinal rank of the gpu where the
                 translation is to be done.
             step: The current training step.
@@ -110,7 +110,7 @@ class ScoringPreparator():
         preds = []
         raw_sources = []
         raw_refs = []
-        for batch in tokenized_batchs:
+        for batch in tokenized_batches:
             # for validation we build an infer_iter per batch
             # in order to avoid oom issues because there is no
             # batching strategy in `textbatch_to_tensor`
@@ -139,9 +139,9 @@ class ScoringPreparator():
             preds += preds_
         # detokenize refs and predicitons
         if self.transforms:
-            texts_ref = [self.transform.apply_reverse(raw_ref, "tgt")
+            texts_ref = [self.transform.apply_reverse(raw_ref)
                          for raw_ref in raw_refs]
-            preds = [self.transform.apply_reverse(preds_, "tgt")
+            preds = [self.transform.apply_reverse(preds_)
                      for preds_ in preds]
         else:
             texts_ref = [" ".join(raw_ref) for raw_ref in raw_refs]


### PR DESCRIPTION
This PR removes the `Detokenizer` class from `onmt.utils.scoring_utils`. The detokenization is now based on the `applys_reverse` method of the `TransformPipe`.