### PR TITLE
Add uppercase transform

### DIFF
--- a/docs/source/FAQ.md
+++ b/docs/source/FAQ.md
@@ -303,6 +303,18 @@ data:
         src_prefix: __some_src_prefix__
         tgt_prefix: __some_tgt_prefix__
 ```
+#### Convert examples to uppercase
+
+Transform name: `uppercase`
+
+Class: `onmt.transforms.uppercase.UpperCaseTransform`
+
+Converts source and target (if present) examples to uppercase so the model can learn better to translate
+sentences in all caps. This transform normalizes the examples so the uppercased strings are stripped from
+any diacritics and accents. Usually this is desirable for most languages, although there are few exceptions.
+
+The following option can be added to the configuration :
+- `upper_corpus_ratio`: ratio of the corpus that will be transformed to uppercase (default: 0.01);
 
 ### Tokenization
 

--- a/onmt/transforms/uppercase.py
+++ b/onmt/transforms/uppercase.py
@@ -6,7 +6,14 @@ import random
 
 @register_transform(name='uppercase')
 class UpperCaseTransform(Transform):
-    """Convert source and target examples to uppercase."""
+    """
+    Convert source and target examples to uppercase.
+    
+    This transform uses `unicodedata` to normalize the converted uppercase strings 
+    as this is needed for some languages (e.g. Greek). One issue is that the normalization 
+    removes all diacritics and accents from the uppercased strings, even though in 
+    few occasions some diacritics should be kept even in the uppercased form.
+    """
 
     def __init__(self, opts):
         super().__init__(opts)
@@ -29,14 +36,14 @@ class UpperCaseTransform(Transform):
             return example
 
         src_str = ' '.join(example['src'])
-        tgt_str = ' '.join(example['tgt'])
-
         src_str = ''.join(c for c in unicodedata.normalize('NFD',
                           src_str.upper()) if unicodedata.category(c) != 'Mn')
-        tgt_str = ''.join(c for c in unicodedata.normalize('NFD',
-                          tgt_str.upper()) if unicodedata.category(c) != 'Mn')
-
         example['src'] = src_str.split()
-        example['tgt'] = tgt_str.split()
+
+        if example['tgt'] is not None:
+            tgt_str = ' '.join(example['tgt'])
+            tgt_str = ''.join(c for c in unicodedata.normalize('NFD',
+                              tgt_str.upper()) if unicodedata.category(c) != 'Mn')
+            example['tgt'] = tgt_str.split()
 
         return example

--- a/onmt/transforms/uppercase.py
+++ b/onmt/transforms/uppercase.py
@@ -1,5 +1,5 @@
 from onmt.transforms import register_transform
-from .transform import Transform, ObservableStats
+from .transform import Transform
 import unicodedata
 import random
 
@@ -13,7 +13,7 @@ class UpperCaseTransform(Transform):
 
     @classmethod
     def add_options(cls, parser):
-        """Avalailable options relate to this Transform."""
+        """Add an option for the corpus ratio to apply this transform."""
 
         group = parser.add_argument_group("Transform/Uppercase")
         group.add("--upper_corpus_ratio", "-upper_corpus_ratio", type=float,
@@ -23,7 +23,7 @@ class UpperCaseTransform(Transform):
         self.upper_corpus_ratio = self.opts.upper_corpus_ratio
 
     def apply(self, example, is_train=False, stats=None, **kwargs):
-        """Convert source and target to uppercase."""
+        """Convert source and target examples to uppercase."""
 
         if random.random() > self.upper_corpus_ratio:
             return example

--- a/onmt/transforms/uppercase.py
+++ b/onmt/transforms/uppercase.py
@@ -1,0 +1,42 @@
+from onmt.transforms import register_transform
+from .transform import Transform, ObservableStats
+import unicodedata
+import random
+
+
+@register_transform(name='uppercase')
+class UpperCaseTransform(Transform):
+    """Convert source and target examples to uppercase."""
+
+    def __init__(self, opts):
+        super().__init__(opts)
+
+    @classmethod
+    def add_options(cls, parser):
+        """Avalailable options relate to this Transform."""
+
+        group = parser.add_argument_group("Transform/Uppercase")
+        group.add("--upper_corpus_ratio", "-upper_corpus_ratio", type=float,
+                  default=0.01, help="Corpus ratio to apply uppercasing.")
+
+    def _parse_opts(self):
+        self.upper_corpus_ratio = self.opts.upper_corpus_ratio
+
+    def apply(self, example, is_train=False, stats=None, **kwargs):
+        """Convert source and target to uppercase."""
+
+        if random.random() > self.upper_corpus_ratio:
+            return example
+
+        src_str = ' '.join(example['src'])
+        tgt_str = ' '.join(example['tgt'])
+
+        src_str = ''.join(c for c in unicodedata.normalize('NFD',
+                          src_str.upper()) if unicodedata.category(c) != 'Mn')
+        tgt_str = ''.join(c for c in unicodedata.normalize('NFD',
+                          tgt_str.upper()) if unicodedata.category(c) != 'Mn')
+
+        example['src'] = src_str.split()
+        example['tgt'] = tgt_str.split()
+
+        return example

--- a/onmt/transforms/uppercase.py
+++ b/onmt/transforms/uppercase.py
@@ -8,11 +8,12 @@ import random
 class UpperCaseTransform(Transform):
     """
     Convert source and target examples to uppercase.
-    
-    This transform uses `unicodedata` to normalize the converted uppercase strings 
-    as this is needed for some languages (e.g. Greek). One issue is that the normalization 
-    removes all diacritics and accents from the uppercased strings, even though in 
-    few occasions some diacritics should be kept even in the uppercased form.
+
+    This transform uses `unicodedata` to normalize the converted
+    uppercase strings as this is needed for some languages (e.g. Greek).
+    One issue is that the normalization removes all diacritics and
+    accents from the uppercased strings, even though in few occasions some
+    diacritics should be kept even in the uppercased form.
     """
 
     def __init__(self, opts):
@@ -43,7 +44,8 @@ class UpperCaseTransform(Transform):
         if example['tgt'] is not None:
             tgt_str = ' '.join(example['tgt'])
             tgt_str = ''.join(c for c in unicodedata.normalize('NFD',
-                              tgt_str.upper()) if unicodedata.category(c) != 'Mn')
+                              tgt_str.upper()) if unicodedata.category(c) !=
+                              'Mn')
             example['tgt'] = tgt_str.split()
 
         return example


### PR DESCRIPTION
This transform converts source and target examples to uppercase. This is needed so the model can better learn to translate sentences in all caps. 

I use `unicodedata` to normalize the converted uppercase strings as this is needed for some languages (e.g. Greek). One issue is that the normalization removes all diacritics and accents from the uppercased strings, even though in few occasions some diacritics should be kept even in the uppercased form. 