### PR TITLE
Prepare for NLLB-200 inference (and maybe finetuning)

### DIFF
--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -47,6 +47,7 @@ def build_embeddings(opt, vocabs, for_encoder=True):
     emb = Embeddings(
         word_vec_size=emb_dim,
         position_encoding=opt.position_encoding,
+        position_encoding_type=opt.position_encoding_type,
         feat_merge=opt.feat_merge,
         feat_vec_exponent=opt.feat_vec_exponent,
         feat_vec_size=opt.feat_vec_size,
@@ -91,9 +92,11 @@ def load_test_model(opt, model_path=None):
                             map_location=lambda storage, loc: storage)
 
     model_opt = ArgumentParser.ckpt_model_opts(checkpoint['opt'])
-    # this patch is no longer needed, included in converter
-    # if hasattr(model_opt, 'rnn_size'):
-    #     model_opt.hidden_size = model_opt.rnn_size
+    # Patch for NLLB200 model loading
+    if ('encoder.embeddings.make_embedding.pe.pe' not in
+            checkpoint['model'].keys()):
+        model_opt.position_encoding_type = 'SinusoidalConcat'
+
     ArgumentParser.update_model_opts(model_opt)
     ArgumentParser.validate_model_opts(model_opt)
     vocabs = dict_to_vocabs(checkpoint['vocab'])

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -754,7 +754,7 @@ def _add_decoding_opts(parser):
                    "corresponding target token. If it is not provided "
                    "(or the identified source token does not exist in "
                    "the table), then it will copy the source token.")
-    group.add('--start_decoder_tok', '-start_decoder_tok', type=str,
+    group.add('--decoder_start_token', '-decoder_start_token', type=str,
               default=DefaultTokens.BOS,
               help="Default decoder start token "
                    "for most ONMT models it is <s> = BOS "

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -6,6 +6,7 @@ from onmt.transforms import AVAILABLE_TRANSFORMS
 from onmt.constants import ModelTask
 from onmt.modules.position_ffn import ACTIVATION_FUNCTIONS
 from onmt.modules.position_ffn import ActivationFunction
+from onmt.constants import DefaultTokens
 
 
 def config_opts(parser):
@@ -244,6 +245,12 @@ def model_opts(parser):
     group.add('--position_encoding', '-position_encoding', action='store_true',
               help="Use a sin to mark relative words positions. "
                    "Necessary for non-RNN style models.")
+    group.add('--position_encoding_type', '-position_encoding_type',
+              type=str, default='SinusoidalInterleaved',
+              choices=['SinusoidalInterleaved', 'SinusoidalConcat'],
+              help="Type of positional encoding. At the moment: "
+                   "Sinusoidal fixed, Interleaved or Concat")
+
     group.add("-update_vocab", "--update_vocab", action="store_true",
               help="Update source and target existing vocabularies")
 
@@ -747,6 +754,11 @@ def _add_decoding_opts(parser):
                    "corresponding target token. If it is not provided "
                    "(or the identified source token does not exist in "
                    "the table), then it will copy the source token.")
+    group.add('--start_decoder_tok', '-start_decoder_tok', type=str,
+              default=DefaultTokens.BOS,
+              help="Default decoder start token "
+                   "for most ONMT models it is <s> = BOS "
+                   "it happens that for some Fairseq model it requires </s> ")
 
 
 def translate_opts(parser, dynamic=False):

--- a/onmt/tests/test_beam_search.py
+++ b/onmt/tests/test_beam_search.py
@@ -37,7 +37,7 @@ class TestBeamSearch(unittest.TestCase):
         device_init = torch.zeros(1, 1)
         for batch_sz in [1, 3]:
             beam = BeamSearch(
-                beam_sz, batch_sz, 0, 1, 2, 3, 2,
+                beam_sz, batch_sz, 0, 1, 2, 3, 1, 2,
                 GlobalScorerStub(), 0, 30,
                 False, ngram_repeat, set(),
                 False, 0., False)
@@ -86,7 +86,7 @@ class TestBeamSearch(unittest.TestCase):
         device_init = torch.zeros(1, 1)
         for batch_sz in [1, 3]:
             beam = BeamSearch(
-                beam_sz, batch_sz, 0, 1, 2, 3, 2,
+                beam_sz, batch_sz, 0, 1, 2, 3, 1, 2,
                 GlobalScorerStub(), 0, 30,
                 False, ngram_repeat, set(),
                 False, 0., False)
@@ -150,7 +150,7 @@ class TestBeamSearch(unittest.TestCase):
         device_init = torch.zeros(1, 1)
         for batch_sz in [1, 3]:
             beam = BeamSearch(
-                beam_sz, batch_sz, 0, 1, 2, 3, 2,
+                beam_sz, batch_sz, 0, 1, 2, 3, 1, 2,
                 GlobalScorerStub(), 0, 30,
                 False, ngram_repeat, {repeat_idx_ignored},
                 False, 0., False)
@@ -207,7 +207,7 @@ class TestBeamSearch(unittest.TestCase):
             min_length = 5
             eos_idx = 2
             lengths = torch.randint(0, 30, (batch_sz,))
-            beam = BeamSearch(beam_sz, batch_sz, 0, 1, 2, 3, 2,
+            beam = BeamSearch(beam_sz, batch_sz, 0, 1, 2, 3, 1, 2,
                               GlobalScorerStub(),
                               min_length, 30, False, 0, set(),
                               False, 0., False)
@@ -264,7 +264,7 @@ class TestBeamSearch(unittest.TestCase):
         min_length = 5
         eos_idx = 2
         beam = BeamSearch(
-            beam_sz, batch_sz, 0, 1, 2, 3, 2,
+            beam_sz, batch_sz, 0, 1, 2, 3, 1, 2,
             GlobalScorerStub(),
             min_length, 30, False, 0, set(),
             False, 0., False)
@@ -319,7 +319,7 @@ class TestBeamSearch(unittest.TestCase):
         eos_idx = 2
         inp_lens = torch.randint(1, 30, (batch_sz,))
         beam = BeamSearch(
-            beam_sz, batch_sz, 0, 1, 2, 3, 2,
+            beam_sz, batch_sz, 0, 1, 2, 3, 1, 2,
             GlobalScorerStub(),
             min_length, 30, True, 0, set(),
             False, 0., False)
@@ -530,7 +530,7 @@ class TestBeamSearchAgainstReferenceCase(unittest.TestCase):
 
     def test_beam_advance_against_known_reference(self):
         beam = BeamSearch(
-            self.BEAM_SZ, self.BATCH_SZ, 0, 1, 2, 3, self.N_BEST,
+            self.BEAM_SZ, self.BATCH_SZ, 0, 1, 2, 3, 1, self.N_BEST,
             GlobalScorerStub(),
             0, 30, False, 0, set(),
             False, 0., False)
@@ -549,7 +549,7 @@ class TestBeamWithLengthPenalty(TestBeamSearchAgainstReferenceCase):
     def test_beam_advance_against_known_reference(self):
         scorer = GNMTGlobalScorer(1.0, 0., "avg", "none")
         beam = BeamSearch(
-            self.BEAM_SZ, self.BATCH_SZ, 0, 1, 2, 3, self.N_BEST,
+            self.BEAM_SZ, self.BATCH_SZ, 0, 1, 2, 3, 1, self.N_BEST,
             scorer,
             0, 30, False, 0, set(),
             False, 0., False)
@@ -580,7 +580,7 @@ class TestBeamSearchLM(TestBeamSearchAgainstReferenceCase):
 
     def test_beam_lm_increase_src_len(self):
         beam = BeamSearchLM(
-            self.BEAM_SZ, self.BATCH_SZ, 0, 1, 2, 3, self.N_BEST,
+            self.BEAM_SZ, self.BATCH_SZ, 0, 1, 2, 3, 1, self.N_BEST,
             GlobalScorerStub(),
             0, 30, False, 0, set(),
             False, 0., False)
@@ -598,7 +598,7 @@ class TestBeamSearchLM(TestBeamSearchAgainstReferenceCase):
 
     def test_beam_lm_update_src_len_when_finished(self):
         beam = BeamSearchLM(
-            self.BEAM_SZ, self.BATCH_SZ, 0, 1, 2, 3, self.N_BEST,
+            self.BEAM_SZ, self.BATCH_SZ, 0, 1, 2, 3, 1, self.N_BEST,
             GlobalScorerStub(),
             0, 30, False, 0, set(),
             False, 0., False)

--- a/onmt/tests/test_greedy_search.py
+++ b/onmt/tests/test_greedy_search.py
@@ -41,7 +41,7 @@ class TestGreedySearch(unittest.TestCase):
             eos_idx = 2
             lengths = torch.randint(0, 30, (batch_sz,))
             samp = GreedySearch(
-                0, 1, 2, 3, batch_sz, GlobalScorerStub(), min_length,
+                0, 1, 2, 3, 1, batch_sz, GlobalScorerStub(), min_length,
                 False, set(), False, 30, 1., 1, 0, 1, False)
             samp.initialize(torch.zeros((1, 1)), lengths)
             all_attns = []
@@ -82,7 +82,7 @@ class TestGreedySearch(unittest.TestCase):
                 eos_idx = 2
                 lengths = torch.randint(0, 30, (batch_sz,))
                 samp = GreedySearch(
-                    0, 1, 2, 3, batch_sz, GlobalScorerStub(), 0,
+                    0, 1, 2, 3, 1, batch_sz, GlobalScorerStub(), 0,
                     False, set(), False, 30, temp, 1, 0, 1, False)
                 samp.initialize(torch.zeros((1, 1)), lengths)
                 # initial step
@@ -153,7 +153,7 @@ class TestGreedySearch(unittest.TestCase):
                 eos_idx = 2
                 lengths = torch.randint(0, 30, (batch_sz,))
                 samp = GreedySearch(
-                    0, 1, 2, 3, batch_sz, GlobalScorerStub(), 0,
+                    0, 1, 2, 3, 1, batch_sz, GlobalScorerStub(), 0,
                     False, set(), False, 30, temp, 2, 0, 1, False)
                 samp.initialize(torch.zeros((1, 1)), lengths)
                 # initial step
@@ -243,7 +243,7 @@ class TestGreedySearch(unittest.TestCase):
                 eos_idx = 2
                 lengths = torch.randint(0, 30, (batch_sz,))
                 samp = GreedySearch(
-                    0, 1, 2, 3, batch_sz, GlobalScorerStub(), 0,
+                    0, 1, 2, 3, 1, batch_sz, GlobalScorerStub(), 0,
                     False, set(), False, 30, temp, 50, 0,
                     beam_size, False)
                 samp.initialize(torch.zeros((1, 1)), lengths)
@@ -345,7 +345,7 @@ class TestGreedySearch(unittest.TestCase):
                 eos_idx = 2
                 lengths = torch.randint(0, 30, (batch_sz,))
                 samp = GreedySearch(
-                    0, 1, 2, 3, batch_sz, GlobalScorerStub(), 0,
+                    0, 1, 2, 3, 1, batch_sz, GlobalScorerStub(), 0,
                     False, set(), False, -1, temp, 50, 0.5, 1, False)
                 samp.initialize(torch.zeros((1, 1)), lengths)
                 # initial step

--- a/onmt/transforms/misc.py
+++ b/onmt/transforms/misc.py
@@ -119,6 +119,8 @@ class PrefixTransform(Transform):
         for side, side_prefix in prefix.items():
             if example.get(side) is not None:
                 example[side] = side_prefix.split() + example[side]
+            elif len(side_prefix) > 0:
+                example[side] = side_prefix.split()
         return example
 
     def apply(self, example, is_train=False, stats=None, **kwargs):
@@ -134,6 +136,100 @@ class PrefixTransform(Transform):
             raise ValueError(f'prefix for {corpus_name} does not exist.')
         return self._prepend(example, corpus_prefix)
 
+    def apply_reverse(self, translated):
+        def _removeprefix(s, prefix):
+            if s.startswith(prefix):
+                return s[len(prefix):]
+            else:
+                return s
+        corpus_prefix = self.prefix_dict.get('infer', None)
+        return _removeprefix(translated, corpus_prefix['tgt'])
+
     def _repr_args(self):
         """Return str represent key arguments for class."""
         return '{}={}'.format('prefix_dict', self.prefix_dict)
+
+
+@register_transform(name='suffix')
+class SuffixTransform(Transform):
+    """Add Suffix to src (& tgt) sentence."""
+
+    def __init__(self, opts):
+        super().__init__(opts)
+
+    @classmethod
+    def add_options(cls, parser):
+        """Avalailable options relate to this Transform."""
+        group = parser.add_argument_group("Transform/Prefix")
+        group.add("--src_suffix", "-src_suffix", type=str, default="",
+                  help="String to append to all source example.")
+        group.add("--tgt_suffix", "-tgt_suffix", type=str, default="",
+                  help="String to append to all target example.")
+
+    @staticmethod
+    def _get_prefix(corpus):
+        """Get suffix string of a `corpus`."""
+        if 'suffix' in corpus['transforms']:
+            suffix = {
+                'src': corpus['src_suffix'],
+                'tgt': corpus['tgt_suffix']
+            }
+        else:
+            suffix = None
+        return suffix
+
+    @classmethod
+    def get_suffix_dict(cls, opts):
+        """Get all needed suffix correspond to corpus in `opts`."""
+        suffix_dict = {}
+        if hasattr(opts, 'data'):
+            for c_name, corpus in opts.data.items():
+                suffix = cls._get_suffix(corpus)
+                if suffix is not None:
+                    logger.info(f"Get suffix for {c_name}: {suffix}")
+                    suffix_dict[c_name] = suffix
+        else:
+            suffix_dict['infer'] = {'src': opts.src_suffix,
+                                    'tgt': opts.tgt_suffix}
+        return suffix_dict
+
+    @classmethod
+    def get_specials(cls, opts):
+        """Get special vocabs added by suffix transform."""
+        suffix_dict = cls.get_suffix_dict(opts)
+        src_specials, tgt_specials = set(), set()
+        for _, suffix in suffix_dict.items():
+            src_specials.update(suffix['src'].split())
+            tgt_specials.update(suffix['tgt'].split())
+        return (src_specials, tgt_specials)
+
+    def warm_up(self, vocabs=None):
+        """Warm up to get suffix dictionary."""
+        super().warm_up(None)
+        self.suffix_dict = self.get_suffix_dict(self.opts)
+
+    def _append(self, example, suffix):
+        """Prepend `suffix` to `tokens`."""
+        for side, side_suffix in suffix.items():
+            if example.get(side) is not None:
+                example[side] = example[side] + side_suffix.split()
+            elif len(side_suffix) > 0:
+                example[side] = side_suffix.split()
+        return example
+
+    def apply(self, example, is_train=False, stats=None, **kwargs):
+        """Apply suffix append to example.
+
+        Should provide `corpus_name` to get correspond suffix.
+        """
+        corpus_name = kwargs.get('corpus_name', None)
+        if corpus_name is None:
+            raise ValueError('corpus_name is required.')
+        corpus_suffix = self.suffix_dict.get(corpus_name, None)
+        if corpus_suffix is None:
+            raise ValueError(f'suffix for {corpus_name} does not exist.')
+        return self._append(example, corpus_suffix)
+
+    def _repr_args(self):
+        """Return str represent key arguments for class."""
+        return '{}={}'.format('suffix_dict', self.suffix_dict)

--- a/onmt/transforms/misc.py
+++ b/onmt/transforms/misc.py
@@ -139,7 +139,7 @@ class PrefixTransform(Transform):
     def apply_reverse(self, translated):
         def _removeprefix(s, prefix):
             if s.startswith(prefix):
-                return s[len(prefix):]
+                return s[len(prefix) + 1:]
             else:
                 return s
         corpus_prefix = self.prefix_dict.get('infer', None)

--- a/onmt/translate/beam_search.py
+++ b/onmt/translate/beam_search.py
@@ -20,6 +20,7 @@ class BeamSearchBase(DecodeStrategy):
         bos (int): See base.
         eos (int): See base.
         unk (int): See base.
+        start (int): See base.
         n_best (int): Don't stop until at least this many beams have
             reached EOS.
         global_scorer (onmt.translate.GNMTGlobalScorer): Scorer instance.
@@ -54,12 +55,12 @@ class BeamSearchBase(DecodeStrategy):
         hypotheses (list[list[Tuple[Tensor]]]): Contains a tuple
             of score (float), sequence (long), and attention (float or None).
     """
-    def __init__(self, beam_size, batch_size, pad, bos, eos, unk, n_best,
-                 global_scorer, min_length, max_length, return_attention,
-                 block_ngram_repeat, exclusion_tokens, stepwise_penalty,
-                 ratio, ban_unk_token):
+    def __init__(self, beam_size, batch_size, pad, bos, eos, unk, start,
+                 n_best, global_scorer, min_length, max_length,
+                 return_attention, block_ngram_repeat, exclusion_tokens,
+                 stepwise_penalty, ratio, ban_unk_token):
         super(BeamSearchBase, self).__init__(
-            pad, bos, eos, unk, batch_size, beam_size, global_scorer,
+            pad, bos, eos, unk, start, batch_size, beam_size, global_scorer,
             min_length, block_ngram_repeat, exclusion_tokens,
             return_attention, max_length, ban_unk_token)
         # beam parameters

--- a/onmt/translate/greedy_search.py
+++ b/onmt/translate/greedy_search.py
@@ -101,6 +101,7 @@ class GreedySearch(DecodeStrategy):
         bos (int): See base.
         eos (int): See base.
         unk (int): See base.
+        start (int): See base.
         batch_size (int): See base.
         global_scorer (onmt.translate.GNMTGlobalScorer): Scorer instance.
         min_length (int): See base.
@@ -119,12 +120,12 @@ class GreedySearch(DecodeStrategy):
         beam_size (int): Number of beams to use.
     """
 
-    def __init__(self, pad, bos, eos, unk, batch_size, global_scorer,
+    def __init__(self, pad, bos, eos, unk, start, batch_size, global_scorer,
                  min_length, block_ngram_repeat, exclusion_tokens,
                  return_attention, max_length, sampling_temp, keep_topk,
                  keep_topp, beam_size, ban_unk_token):
         super(GreedySearch, self).__init__(
-            pad, bos, eos, unk, batch_size, beam_size, global_scorer,
+            pad, bos, eos, unk, start, batch_size, beam_size, global_scorer,
             min_length, block_ngram_repeat, exclusion_tokens,
             return_attention, max_length, ban_unk_token)
         self.sampling_temp = sampling_temp

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -129,7 +129,7 @@ class Inference(object):
         logger=None,
         seed=-1,
         with_score=False,
-        start_decoder_tok=DefaultTokens.BOS
+        decoder_start_token=DefaultTokens.BOS
     ):
         self.model = model
         self.vocabs = vocabs
@@ -139,7 +139,7 @@ class Inference(object):
         self._tgt_bos_idx = self.vocabs['tgt'].lookup_token(DefaultTokens.BOS)
         self._tgt_unk_idx = self.vocabs['tgt'].lookup_token(DefaultTokens.UNK)
         self._tgt_start_with =\
-            self.vocabs['tgt'].lookup_token(start_decoder_tok)
+            self.vocabs['tgt'].lookup_token(decoder_start_token)
         self._tgt_vocab_len = len(self._tgt_vocab)
 
         self._gpu = gpu
@@ -273,7 +273,7 @@ class Inference(object):
             logger=logger,
             seed=opt.seed,
             with_score=opt.with_score,
-            start_decoder_tok=opt.start_decoder_tok
+            decoder_start_token=opt.decoder_start_token
         )
 
     def _log(self, msg):
@@ -292,7 +292,7 @@ class Inference(object):
         batch_size,
         src,
     ):
-        if 'tgt' in batch.keys():
+        if 'tgt' in batch.keys() and not self.tgt_file_prefix:
             gs = self._score_target(
                 batch,
                 enc_out,
@@ -440,7 +440,7 @@ class Inference(object):
                 "PRED", pred_score_total, len(all_scores)
             )
             self._log(msg)
-            if 'tgt' in batch.keys():
+            if 'tgt' in batch.keys() and not self.tgt_file_prefix:
                 msg = self._report_score(
                     "GOLD", gold_score_total, len(all_scores)
                 )

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -128,7 +128,8 @@ class Inference(object):
         report_score=True,
         logger=None,
         seed=-1,
-        with_score=False
+        with_score=False,
+        start_decoder_tok=DefaultTokens.BOS
     ):
         self.model = model
         self.vocabs = vocabs
@@ -137,6 +138,8 @@ class Inference(object):
         self._tgt_pad_idx = self.vocabs['tgt'].lookup_token(DefaultTokens.PAD)
         self._tgt_bos_idx = self.vocabs['tgt'].lookup_token(DefaultTokens.BOS)
         self._tgt_unk_idx = self.vocabs['tgt'].lookup_token(DefaultTokens.UNK)
+        self._tgt_start_with =\
+            self.vocabs['tgt'].lookup_token(start_decoder_tok)
         self._tgt_vocab_len = len(self._tgt_vocab)
 
         self._gpu = gpu
@@ -269,7 +272,8 @@ class Inference(object):
             report_score=report_score,
             logger=logger,
             seed=opt.seed,
-            with_score=opt.with_score
+            with_score=opt.with_score,
+            start_decoder_tok=opt.start_decoder_tok
         )
 
     def _log(self, msg):
@@ -687,6 +691,7 @@ class Translator(Inference):
                     bos=self._tgt_bos_idx,
                     eos=self._tgt_eos_idx,
                     unk=self._tgt_unk_idx,
+                    start=self._tgt_start_with,
                     batch_size=len(batch['srclen']),
                     global_scorer=self.global_scorer,
                     min_length=self.min_length,
@@ -710,6 +715,7 @@ class Translator(Inference):
                     bos=self._tgt_bos_idx,
                     eos=self._tgt_eos_idx,
                     unk=self._tgt_unk_idx,
+                    start=self._tgt_start_with,
                     n_best=self.n_best,
                     global_scorer=self.global_scorer,
                     min_length=self.min_length,
@@ -906,6 +912,7 @@ class GeneratorLM(Inference):
                     bos=self._tgt_bos_idx,
                     eos=self._tgt_eos_idx,
                     unk=self._tgt_unk_idx,
+                    start=self._tgt_start_with,
                     batch_size=len(batch['srclen']),
                     global_scorer=self.global_scorer,
                     min_length=self.min_length,
@@ -929,6 +936,7 @@ class GeneratorLM(Inference):
                     bos=self._tgt_bos_idx,
                     eos=self._tgt_eos_idx,
                     unk=self._tgt_unk_idx,
+                    start=self._tgt_start_with,
                     n_best=self.n_best,
                     global_scorer=self.global_scorer,
                     min_length=self.min_length,


### PR DESCRIPTION
This PR does 4 things:
1) Introduces a variant of Positional Encoding (fixed Sinusoidal) where SIn/Cos are concat instead of interleaved (default). This is required to load the NLLB-200 models from Fairseq Architecture.
2) Allow a change in the start decoder token (so far it was hard coded to be BOS as we do at Onmt) so that we can make it </s> which is the behavior for Fairseq's NLLB-200 models
3) Introduce a transform "suffix" which is equivalent to "prefix". This enables to add automatically a suffix to source (or target). This is required for NLLB-200 (which asks for a </s> src_lang in the source) but also allow to add a domain or such in the source.
4) Add a apply_reverse behavior to the "prefix" transform. When using a target prefix (eg: target language for NLLB-200) it will remove it from the prediction automatically.

There is still a small flaw in the fact that Gold scoring (the target) and target prefix usage are still mutually exclusive.
We may change this in the future.
