### PR TITLE
Update CTranslate2 minimum version to 3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     install_requires=[
         "torch>=1.12.1",
         "configargparse",
-        "ctranslate2>=3.0,<4",
+        "ctranslate2>=3.2,<4",
         "tensorboard>=2.3",
         "flask",
         "waitress",


### PR DESCRIPTION
This version is required to convert models with the latest generator structure from https://github.com/OpenNMT/OpenNMT-py/pull/2270.