### PR TITLE
"better" log

### DIFF
--- a/onmt/inputters/dynamic_iterator.py
+++ b/onmt/inputters/dynamic_iterator.py
@@ -6,7 +6,7 @@ from onmt.inputters.text_corpus import get_corpora, build_corpora_iters
 from onmt.inputters.text_utils import text_sort_key, process,\
     numericalize, tensorify, _addcopykeys
 from onmt.transforms import make_transforms
-from onmt.utils.logging import logger
+from onmt.utils.logging import init_logger, logger
 from onmt.utils.misc import RandomShuffler
 from torch.utils.data import DataLoader
 
@@ -58,6 +58,8 @@ class WeightedMixer(MixingStrategy):
     def _logging(self):
         """Report corpora loading statistics."""
         msgs = []
+        # patch to log stdout spawned processes of dataloader
+        logger = init_logger()
         for ds_name, ds_count in self._counts.items():
             msgs.append(f"\t\t\t* {ds_name}: {ds_count}")
         logger.info("Weighted corpora loaded so far:\n"+"\n".join(msgs))

--- a/onmt/utils/logging.py
+++ b/onmt/utils/logging.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 import logging
 from logging.handlers import RotatingFileHandler
-logger = logging.getLogger()
+
+# placing this here make it easier to call logger.info
+# from anywhere, just 'from onmt.utils.logging import logger'
+logger = logging.getLogger("onmt")
 
 
 def init_logger(
@@ -11,7 +14,7 @@ def init_logger(
     log_level=logging.INFO,
 ):
     log_format = logging.Formatter("[%(asctime)s %(levelname)s] %(message)s")
-    logger = logging.getLogger()
+    logger = logging.getLogger("onmt")
     logger.setLevel(log_level)
 
     console_handler = logging.StreamHandler()


### PR DESCRIPTION
replace #2178 

also since dataloader is in spawn mode by default, added a hack to keep logs to stdout from spawned processes. (datasets loading cycles)