### PR TITLE
Add fuzzymatching transform for Neural Fuzzy Repair

### DIFF
--- a/docs/source/FAQ.md
+++ b/docs/source/FAQ.md
@@ -360,6 +360,29 @@ The following options can be added to the configuration :
 - `pre_replace_unicode_punct`: Replace unicode punct (default=False)
 - `post_remove_control_chars`: Remove control chars (default=False)
 
+#### Augment source segments with fuzzy matches for Neural Fuzzy Repair
+
+Transform name: `fuzzymatch`
+
+Class: `onmt.transforms.fuzzymatch.FuzzyMatchTransform`
+
+Augments source segments with fuzzy matches for Neural Fuzzy Repair, as described in [Neural Fuzzy Repair: Integrating Fuzzy Matches into Neural Machine Translation](https://aclanthology.org/P19-1175). Currently, the transform augments source segments with only a single fuzzy match.
+The Translation Memory (TM) format should be a flat text file, with each line containing the source and the target segment separated by a delimiter. As fuzzy matching during training is computational intensive, we offer some advice to achieve good performance and minimize overhead:
+
+- Depending on your system's specs, you may have to experiment with the options `bucket_size`, `bucket_size_init`, and `bucket_size_increment`;
+- You should increase the `num_workers` and `prefetch_factor` so your GPU does not have to wait for the batches to be augmented with fuzzy matches;
+- Try to use a sensible Translation Memory size. 200k-250k translation units should be enough for yielding a sufficient number of matches;
+- Although the transform performs some basic filtering both in the TM and in the corpus for very short or very long segments, some examples may still be long enough, so you should increase a bit the `src_seq_length`.
+
+The following options can be added to the configuration:
+- `tm_path`: The path to the Translation Memory text file;
+- `fuzzy_corpus_ratio`: Ratio of corpus to augment with fuzzy matches (default: 0.1);
+- `fuzzy_threshold`: The fuzzy matching threshold (default: 70);
+- `tm_delimiter`: The delimiter used in the flat text TM (default: "\t");
+- `fuzzy_token`: The fuzzy token to be added with the matches (default: "｟fuzzy｠");
+- `fuzzymatch_min_length`: Min length for TM entries and examples to match (default: 4);
+- `fuzzymatch_max_length`: Max length for TM entries and examples to match (default: 70).
+
 ### Tokenization
 
 Common options for the tokenization transforms are the following:

--- a/docs/source/FAQ.md
+++ b/docs/source/FAQ.md
@@ -372,7 +372,8 @@ The Translation Memory (TM) format should be a flat text file, with each line co
 - Depending on your system's specs, you may have to experiment with the options `bucket_size`, `bucket_size_init`, and `bucket_size_increment`;
 - You should increase the `num_workers` and `prefetch_factor` so your GPU does not have to wait for the batches to be augmented with fuzzy matches;
 - Try to use a sensible Translation Memory size. 200k-250k translation units should be enough for yielding a sufficient number of matches;
-- Although the transform performs some basic filtering both in the TM and in the corpus for very short or very long segments, some examples may still be long enough, so you should increase a bit the `src_seq_length`.
+- Although the transform performs some basic filtering both in the TM and in the corpus for very short or very long segments, some examples may still be long enough, so you should increase a bit the `src_seq_length`;
+- Currently, when using `n_sample`, examples are always processed one by one and not in batches.
 
 The following options can be added to the configuration:
 - `tm_path`: The path to the Translation Memory text file;

--- a/docs/source/refs.bib
+++ b/docs/source/refs.bib
@@ -499,3 +499,19 @@ year = {2015}
   biburl    = {https://dblp.org/rec/journals/corr/abs-1808-07512.bib},
   bibsource = {dblp computer science bibliography, https://dblp.org}
 }
+
+@inproceedings{bulte-tezcan-2019-neural,
+    title = "Neural Fuzzy Repair: Integrating Fuzzy Matches into Neural Machine Translation",
+    author = "Bulte, Bram  and
+      Tezcan, Arda",
+    booktitle = "Proceedings of the 57th Annual Meeting of the Association for Computational Linguistics",
+    month = jul,
+    year = "2019",
+    address = "Florence, Italy",
+    publisher = "Association for Computational Linguistics",
+    url = "https://aclanthology.org/P19-1175",
+    doi = "10.18653/v1/P19-1175",
+    pages = "1800--1809",
+    abstract = "We present a simple yet powerful data augmentation method for boosting Neural Machine Translation (NMT) performance by leveraging information retrieved from a Translation Memory (TM). We propose and test two methods for augmenting NMT training data with fuzzy TM matches. Tests on the DGT-TM data set for two language pairs show consistent and substantial improvements over a range of baseline systems. The results suggest that this method is promising for any translation environment in which a sizeable TM is available and a certain amount of repetition across translations is to be expected, especially considering its ease of implementation.",
+}
+

--- a/onmt/transforms/fuzzymatch.py
+++ b/onmt/transforms/fuzzymatch.py
@@ -140,7 +140,7 @@ class FuzzyMatchTransform(Transform):
         self.fuzzy_corpus_ratio = self.opts.fuzzy_corpus_ratio
         self.fuzzy_threshold = self.opts.fuzzy_threshold
         self.tm_delimiter = self.opts.tm_delimiter
-        self.fuzy_token = self.opts.fuzzy_token
+        self.fuzzy_token = self.opts.fuzzy_token
         self.fuzzymatch_min_length = self.opts.fuzzymatch_min_length
         self.fuzzymatch_max_length = self.opts.fuzzymatch_max_length
 

--- a/onmt/transforms/fuzzymatch.py
+++ b/onmt/transforms/fuzzymatch.py
@@ -158,7 +158,7 @@ class FuzzyMatchTransform(Transform):
                                     self.fuzzy_corpus_ratio,
                                     self.fuzzy_threshold,
                                     self.tm_delimiter,
-                                    self.fuzy_token,
+                                    self.fuzzy_token,
                                     self.fuzzymatch_min_length,
                                     self.fuzzymatch_max_length)
 

--- a/onmt/transforms/fuzzymatch.py
+++ b/onmt/transforms/fuzzymatch.py
@@ -61,7 +61,8 @@ class FuzzyMatcher(object):
         # reduce memory usage.
         # Perfomance is not affected.
         chunk_size = 10000
-        mini_batches = np.array_split(batch, len(batch) // chunk_size)
+        mini_batches = np.array_split(batch, len(batch) // chunk_size
+                                      if len(batch) > chunk_size else 1)
         for mini_batch in mini_batches:
             plist = list(mini_batch)
             if fuzzy_count >= len(batch) * self.corpus_ratio:

--- a/onmt/transforms/fuzzymatching.py
+++ b/onmt/transforms/fuzzymatching.py
@@ -1,0 +1,172 @@
+from onmt.utils.logging import logger
+from onmt.transforms import register_transform
+from .transform import Transform
+
+from rapidfuzz import fuzz, process
+import numpy as np
+import time
+
+_FUZZY_TOKEN = '｟fuzzy｠'
+
+
+class FuzzyMatcher(object):
+    """Class for creating and setting up fuzzy matchers."""
+
+    def __init__(self, tm_path, corpus_ratio, threshold=70, tm_delimiter='\t'):
+        self.threshold = threshold
+        self.corpus_ratio = corpus_ratio
+        self.tm_delimiter = tm_delimiter
+        self.dict_tm = self._create_tm(tm_path)
+
+    def _create_tm(self, tm_path):
+        src_segments, tgt_segments = list(), list()
+        with open(tm_path, mode='r', encoding='utf-8') as file:
+            pairs = file.readlines()
+            for pair in pairs:
+                source, target = map(str, pair.split(self.tm_delimiter))
+
+                # Filter out very short or very long sentences
+                # from the TM for better performance
+                if len(source) < 4 or len(source) > 70:
+                    continue
+                src_segments.append(source.strip())
+                tgt_segments.append(target.strip())
+        logger.info(f'Translation Memory size for fuzzymatching transform: '
+                    f'{len(src_segments)}')
+        return [src_segments, tgt_segments]
+
+    def _get_match(self, query):
+        """Not used. We use the `_get_batch_match` method
+        in conjuction with the transform's `batch_apply`
+        for acceptable performance."""
+
+        # We can speed things up a bit by addding the argument
+        # `processor=None` to avoid preprocessing the string
+        result = process.extractOne(
+            query, self.dict_tm, scorer=fuzz.ratio, score_cutoff=self.threshold
+        )
+        if result is not None and result[1] < 100:  # We don't want exact match
+            target_match = result[2]
+            return self._concatenated_example(query, target_match)
+        else:
+            return query
+
+    def _get_batch_match(self, query_list):
+        logger.info(f'Starting fuzzy matching on {len(query_list)} examples')
+        fuzzy_count = 0
+        start = time.time()
+        augmented = list()
+
+        # We split the bucket (`query_list`) and perform fuzzy matching
+        # in smaller batches in order to reduce memory usage.
+        # Perfomance is not affected.
+        portion = 25
+        corpus_batches = np.array_split(query_list, portion)
+        for corpus_batch in corpus_batches:
+            plist = list(corpus_batch)
+            if fuzzy_count >= len(query_list) * self.corpus_ratio:
+                augmented.extend(plist)
+                continue
+
+            results = process.cdist(plist,
+                                    self.dict_tm[0],
+                                    scorer=fuzz.ratio,
+                                    dtype=np.uint8,
+                                    score_cutoff=self.threshold,
+                                    workers=-1)
+
+            matches = np.any(results, 1)
+            argmax = np.argmax(results, axis=1)
+            for idx, s in enumerate(plist):
+                # Probably redundant
+                if _FUZZY_TOKEN in s:
+                    continue
+                # We don't want exact matches
+                if matches[idx] and results[idx][argmax[idx]] < 100:
+                    if fuzzy_count >= len(query_list) * self.corpus_ratio:
+                        break
+                    plist[idx] = s + _FUZZY_TOKEN + \
+                        self.dict_tm[1][argmax[idx]]
+                    fuzzy_count += 1
+            augmented.extend(plist)
+
+        end = time.time()
+        logger.info(f'FuzzyMatching Transform: Added {fuzzy_count} '
+                    f'fuzzies in {end-start} secs')
+
+        return augmented
+
+    # Only used for single example fuzzy matching with `_get_match`
+    def _concatenated_example(self, query, target_match):
+        if target_match is None:
+            return query
+        return query + _FUZZY_TOKEN + target_match
+
+
+@register_transform(name='fuzzymatching')
+class FuzzyTransform(Transform):
+    """Perform fuzzy matching against a translation memory and
+    augment source examples with target matches for Neural Fuzzy Adaptation.
+
+    TODO: cite <https://aclanthology.org/P19-1175>"
+    """
+
+    def __init__(self, opts):
+        super().__init__(opts)
+
+    @classmethod
+    def add_options(cls, parser):
+        """Options for fuzzy matching."""
+
+        group = parser.add_argument_group("Transform/FuzzyMatching")
+        group.add("--tm_path", "-tm_path",
+                  type=str, help="Path to a flat text TM.")
+        group.add("--fuzzy_corpus_ratio", "-fuzzy_corpus_ratio", type=float,
+                  default=0.1,
+                  help="Ratio of corpus to augment with fuzzy matches.")
+        group.add("--fuzzy_threshold", "-fuzzy_threshold", type=int,
+                  default=70, help="The fuzzy matching threshold.")
+        group.add("--tm_delimiter", "-tm_delimiter",
+                  type=str, default="\t",
+                  help="The delimiter used in the flat text TM.")
+
+    def _parse_opts(self):
+        self.tm_path = self.opts.tm_path
+        self.fuzzy_corpus_ratio = self.opts.fuzzy_corpus_ratio
+        self.fuzzy_threshold = self.opts.fuzzy_threshold
+        self.tm_delimiter = self.opts.tm_delimiter
+
+    @classmethod
+    def get_specials(cls, opts):
+        """Add the fuzzy mark token to the src vocab."""
+        return ([_FUZZY_TOKEN], list())
+
+    def warm_up(self, vocabs=None):
+        """Create the fuzzy matcher."""
+
+        super().warm_up(None)
+        self.matcher = FuzzyMatcher(self.tm_path,
+                                    self.fuzzy_corpus_ratio,
+                                    self.fuzzy_threshold,
+                                    self.tm_delimiter)
+
+    def apply(self, example, is_train=False, stats=None, **kwargs):
+        return example
+
+    def batch_apply(self, batch, is_train=False, stats=None, **kwargs):
+        src_segments = list()
+        for (ex, _, _) in batch:
+
+            # Apply a basic filtering to leave out very short or very long
+            # sentences and speed up things a bit during fuzzy matching
+            if len(' '.join(ex['src'])) > 4 and len(' '.join(ex['src'])) < 70:
+                src_segments.append(' '.join(ex['src']))
+            else:
+                src_segments.append('')
+        fuzzied_src = self.matcher._get_batch_match(src_segments)
+        assert (len(src_segments) == len(fuzzied_src))
+        for idx, (example, _, _) in enumerate(batch):
+            if fuzzied_src[idx] != '':
+                example['src'] = fuzzied_src[idx].split()
+
+        return batch

--- a/requirements.opt.txt
+++ b/requirements.opt.txt
@@ -2,3 +2,4 @@ pyrouge
 git+https://github.com/NVIDIA/apex.git@700d6825e205732c1d6be511306ca4e595297070
 sentencepiece>=0.1.94
 subword-nmt>=0.3.7
+rapidfuzz

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,8 @@ setup(
         "waitress",
         "pyonmttok>=1.35,<2",
         "pyyaml",
-        "sacrebleu"
+        "sacrebleu",
+        "rapidfuzz"
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
This transform augments training examples with fuzzy matches for Neural Fuzzy Repair (https://aclanthology.org/P19-1175/). Although it works fine in my custom workflow, I'm sending this PR as draft as we need to discuss some generalization decisions (e.g. the special fuzzy token which is currently provided as a global constant and not as an option in the config) and probably add some more documentation for other important training options that must be fine-tuned in order to get good performance and minimize overhead during training (more specifically, the `-bucket_size`, `-bucket_size_init`, `-bucket_size_increment` and `-prefetch_factor` options).