### PR TITLE
Recover source and gold target alignment computation

### DIFF
--- a/docs/source/FAQ.md
+++ b/docs/source/FAQ.md
@@ -601,7 +601,7 @@ Note: The *second to last* default behaviour was empirically determined. It is n
 
 * alignments use the standard "Pharaoh format", where a pair `i-j` indicates the i<sub>th</sub> word of source language is aligned to j<sub>th</sub> word of target language.
 * Example: {'src': 'das stimmt nicht !'; 'output': 'that is not true ! ||| 0-0 0-1 1-2 2-3 1-4 1-5 3-6'}
-* Using the`-tgt` option when calling `translate.py`, we output alignments between the source and the gold target rather than the inferred target, assuming we're doing evaluation.
+* Using `-tgt` and `-gold_align` options when calling `translate.py`, we output alignments between the source and the gold target rather than the inferred target, assuming we're doing evaluation.
 * To convert subword alignments to word alignments, or symetrize bidirectional alignments, please refer to the [lilt scripts](https://github.com/lilt/alignment-scripts).
 
 ### Supervised learning on a specific head

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -804,6 +804,9 @@ def translate_opts(parser, dynamic=False):
                    "be the decoded sequence")
     group.add('--report_align', '-report_align', action='store_true',
               help="Report alignment for each translation.")
+    group.add('--gold_align', '-gold_align', action='store_true',
+              help="Report alignment between source and gold target."
+                   "Useful to test the performance of learnt alignments.")
     group.add('--report_time', '-report_time', action='store_true',
               help="Report some translation time metrics")
 

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -706,7 +706,7 @@ class Translator(Inference):
         # (0) add BOS and padding to tgt prediction
         if 'tgt' in batch.keys() and self.gold_align:
             if self.logger:
-                self.logger.info("Computing alignments with gold target")
+                self._log("Computing alignments with gold target")
             batch_tgt_idxs = batch['tgt'].transpose(1, 2)
         else:
             batch_tgt_idxs = self._align_pad_prediction(

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -483,7 +483,10 @@ class Inference(object):
                         os.write(1, output.encode("utf-8"))
 
                 if align_debug:
-                    tgts = trans.pred_sents[0]
+                    if self.gold_align:
+                        tgts = trans.gold_sent
+                    else:
+                        tgts = trans.pred_sents[0]
                     align = trans.word_aligns[0].tolist()
                     if self.data_type == "text":
                         srcs = trans.src_raw

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -127,6 +127,7 @@ class Inference(object):
         global_scorer=None,
         out_file=None,
         report_align=False,
+        gold_align=False,
         report_score=True,
         logger=None,
         seed=-1,
@@ -192,6 +193,7 @@ class Inference(object):
             )
         self.out_file = out_file
         self.report_align = report_align
+        self.gold_align = gold_align
         self.report_score = report_score
         self.logger = logger
 
@@ -272,6 +274,7 @@ class Inference(object):
             global_scorer=global_scorer,
             out_file=out_file,
             report_align=report_align,
+            gold_align=opt.gold_align,
             report_score=report_score,
             logger=logger,
             seed=opt.seed,
@@ -698,9 +701,13 @@ class Translator(Inference):
         """
 
         # (0) add BOS and padding to tgt prediction
-        batch_tgt_idxs = self._align_pad_prediction(
-            predictions, bos=self._tgt_bos_idx, pad=self._tgt_pad_idx
-        )
+        if 'tgt' in batch.keys() and self.gold_align:
+            if self.logger:
+                self.logger.info("Computing alignments with gold target")
+            batch_tgt_idxs = batch['tgt'].transpose(1, 2)
+        else:
+            batch_tgt_idxs = self._align_pad_prediction(
+                predictions, bos=self._tgt_bos_idx, pad=self._tgt_pad_idx)
         tgt_mask = (
             batch_tgt_idxs.eq(self._tgt_pad_idx)
             | batch_tgt_idxs.eq(self._tgt_eos_idx)
@@ -714,7 +721,11 @@ class Translator(Inference):
         # (2) Repeat src objects `n_best` times.
         # We use batch_size x n_best, get ``(batch * n_best, src_len, nfeat)``
         src = tile(src, n_best, dim=0)
-        enc_states = tile(enc_states, n_best, dim=0)
+        if enc_states is not None:
+            # Quick fix. Transformers return None as enc_states.
+            # enc_states are only used later on to init decoder's state
+            # but are never used in Transformer decoder, so we can skip
+            enc_states = tile(enc_states, n_best, dim=0)
         if isinstance(enc_out, tuple):
             enc_out = tuple(tile(x, n_best, dim=0) for x in enc_out)
         else:

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -705,8 +705,7 @@ class Translator(Inference):
 
         # (0) add BOS and padding to tgt prediction
         if 'tgt' in batch.keys() and self.gold_align:
-            if self.logger:
-                self._log("Computing alignments with gold target")
+            self._log("Computing alignments with gold target")
             batch_tgt_idxs = batch['tgt'].transpose(1, 2)
         else:
             batch_tgt_idxs = self._align_pad_prediction(

--- a/onmt/utils/parse.py
+++ b/onmt/utils/parse.py
@@ -317,7 +317,13 @@ class ArgumentParser(cfargparse.ArgumentParser, DataOptsCheckerMixin):
 
     @classmethod
     def validate_translate_opts(cls, opt):
-        pass
+        if opt.gold_align:
+            assert opt.report_align, \
+                "-report_align should be enabled with -gold_align"
+            assert not opt.replace_unk, \
+                "-replace_unk option can not be used with -gold_align enabled"
+            assert opt.tgt, \
+                "-tgt should be specified with -gold_align"
 
     @classmethod
     def validate_translate_opts_dynamic(cls, opt):


### PR DESCRIPTION
This PR intends to recover alignment computation between source and gold target (See issue https://github.com/OpenNMT/OpenNMT-py/issues/2310).

This functionality is essential to evaluate learnt alignements during training.

It was discarded in https://github.com/OpenNMT/OpenNMT-py/pull/1788

