### PR TITLE
Add BPE and SentencePiece subword tokenization options

### DIFF
--- a/onmt/bin/build_vocab.py
+++ b/onmt/bin/build_vocab.py
@@ -11,6 +11,19 @@ from onmt.transforms import make_transforms, get_transforms_cls
 from onmt.constants import CorpusName, CorpusTask
 from collections import Counter
 import multiprocessing as mp
+import pyonmttok
+
+
+def learn_subword(tokenization_type, vocab_size):
+    if tokenization_type == "bpe":
+        # BPE training
+        tokenizer = pyonmttok.Tokenizer("aggressive", joiner_annotate=True, segment_numbers=True)
+        learner = pyonmttok.BPELearner(tokenizer=tokenizer, symbols=vocab_size)
+    elif tokenization_type == "spm":
+        # SentencePiece training
+        learner = pyonmttok.SentencePieceLearner(vocab_size=vocab_size, character_coverage=0.98)
+
+    return learner
 
 
 def write_files_from_queues(sample_path, queues):
@@ -49,6 +62,27 @@ def build_sub_vocab(corpora, transforms, opts, n_sample, stride, offset):
         corpora, transforms, opts.data,
         skip_empty_level=opts.skip_empty_level,
         stride=stride, offset=offset)
+    
+    if opts.tokenization_type is not None:
+        learner = learn_subword(opts.tokenization_type, opts.src_vocab_size)
+        data_dir = os.path.split(opts.save_data)[0]
+        if not os.path.exists(data_dir):
+            os.makedirs(data_dir)
+        tok_path = os.path.join(data_dir, f"{opts.tokenization_type}.model")
+        for c_name, c_iter in datasets_iterables.items():
+            for i, item in enumerate(c_iter):
+                maybe_example = process(CorpusTask.TRAIN, [item])
+                if maybe_example is not None:
+                    maybe_example = maybe_example[0]
+                else:
+                    if opts.dump_samples:
+                        build_sub_vocab.queues[c_name][offset].put("blank")
+                    continue
+                src_line, tgt_line = (maybe_example['src']['src'],
+                                    maybe_example['tgt']['tgt'])
+                learner.ingest(src_line)
+                learner.ingest(tgt_line)
+        tokenizer = learner.learn(tok_path)
     for c_name, c_iter in datasets_iterables.items():
         for i, item in enumerate(c_iter):
             maybe_example = process(CorpusTask.TRAIN, [item])
@@ -60,8 +94,16 @@ def build_sub_vocab(corpora, transforms, opts, n_sample, stride, offset):
                 continue
             src_line, tgt_line = (maybe_example['src']['src'],
                                   maybe_example['tgt']['tgt'])
-            sub_counter_src.update(src_line.split(' '))
-            sub_counter_tgt.update(tgt_line.split(' '))
+            if opts.tokenization_type is not None:
+                src_subwords = tokenizer.tokenize(src_line, as_token_objects=True)
+                src_subwords = tokenizer.serialize_tokens(src_subwords)[0]
+                tgt_subwords = tokenizer.tokenize(tgt_line, as_token_objects=True)
+                tgt_subwords = tokenizer.serialize_tokens(tgt_subwords)[0]
+                sub_counter_src.update(src_subwords)
+                sub_counter_tgt.update(tgt_subwords)
+            else:
+                sub_counter_src.update(src_line.split(' '))
+                sub_counter_tgt.update(tgt_line.split(' '))
 
             if 'feats' in maybe_example['src']:
                 src_feats_lines = maybe_example['src']['feats']

--- a/onmt/bin/build_vocab.py
+++ b/onmt/bin/build_vocab.py
@@ -83,7 +83,7 @@ def build_sub_vocab(corpora, transforms, opts, n_sample, stride, offset):
                         build_sub_vocab.queues[c_name][offset].put("blank")
                     continue
                 src_line, tgt_line = (maybe_example['src']['src'],
-                                    maybe_example['tgt']['tgt'])
+                                      maybe_example['tgt']['tgt'])
                 learner.ingest(src_line)
                 learner.ingest(tgt_line)
         tokenizer = learner.learn(tok_path)

--- a/onmt/bin/build_vocab.py
+++ b/onmt/bin/build_vocab.py
@@ -17,11 +17,15 @@ import pyonmttok
 def learn_subword(tokenization_type, vocab_size):
     if tokenization_type == "bpe":
         # BPE training
-        tokenizer = pyonmttok.Tokenizer("aggressive", joiner_annotate=True, segment_numbers=True)
-        learner = pyonmttok.BPELearner(tokenizer=tokenizer, symbols=vocab_size)
+        tokenizer = pyonmttok.Tokenizer("aggressive",
+                                        joiner_annotate=True,
+                                        segment_numbers=True)
+        learner = pyonmttok.BPELearner(tokenizer=tokenizer,
+                                       symbols=vocab_size)
     elif tokenization_type == "spm":
         # SentencePiece training
-        learner = pyonmttok.SentencePieceLearner(vocab_size=vocab_size, character_coverage=0.98)
+        learner = pyonmttok.SentencePieceLearner(vocab_size=vocab_size,
+                                                 character_coverage=0.98)
 
     return learner
 
@@ -62,7 +66,7 @@ def build_sub_vocab(corpora, transforms, opts, n_sample, stride, offset):
         corpora, transforms, opts.data,
         skip_empty_level=opts.skip_empty_level,
         stride=stride, offset=offset)
-    
+
     if opts.tokenization_type is not None:
         learner = learn_subword(opts.tokenization_type, opts.src_vocab_size)
         data_dir = os.path.split(opts.save_data)[0]
@@ -95,9 +99,11 @@ def build_sub_vocab(corpora, transforms, opts, n_sample, stride, offset):
             src_line, tgt_line = (maybe_example['src']['src'],
                                   maybe_example['tgt']['tgt'])
             if opts.tokenization_type is not None:
-                src_subwords = tokenizer.tokenize(src_line, as_token_objects=True)
+                src_subwords = tokenizer.tokenize(src_line,
+                                                  as_token_objects=True)
                 src_subwords = tokenizer.serialize_tokens(src_subwords)[0]
-                tgt_subwords = tokenizer.tokenize(tgt_line, as_token_objects=True)
+                tgt_subwords = tokenizer.tokenize(tgt_line,
+                                                  as_token_objects=True)
                 tgt_subwords = tokenizer.serialize_tokens(tgt_subwords)[0]
                 sub_counter_src.update(src_subwords)
                 sub_counter_tgt.update(tgt_subwords)

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -807,6 +807,9 @@ def translate_opts(parser, dynamic=False):
                    "be the decoded sequence")
     group.add('--report_align', '-report_align', action='store_true',
               help="Report alignment for each translation.")
+    group.add('--gold_align', '-gold_align', action='store_true',
+              help="Report alignment between source and gold target."
+              "Useful to test the performance of learnt alignments.")
     group.add('--report_time', '-report_time', action='store_true',
               help="Report some translation time metrics")
 

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -159,15 +159,15 @@ def _add_dynamic_vocab_opts(parser, build_vocab_only=False):
                    "for most ONMT models it is <s> = BOS "
                    "it happens that for some Fairseq model it requires </s> ")
     group.add('-tokenization_type', '--tokenization_type',
-                  type=str, default=None,
-                  choices=["bpe", "spm"],
-                  help="Tokenization type used in build_vocab.")
+              type=str, default=None,
+              choices=["bpe", "spm"],
+              help="Tokenization type used in build_vocab.")
     group.add("-src_vocab_size", "--src_vocab_size",
-                  type=int, default=32768,
-                  help="Maximum size of the source vocabulary.")
+              type=int, default=32768,
+              help="Maximum size of the source vocabulary.")
     group.add("-tgt_vocab_size", "--tgt_vocab_size",
-                  type=int, default=32768,
-                  help="Maximum size of the target vocabulary")
+              type=int, default=32768,
+              help="Maximum size of the target vocabulary")
 
     _add_features_opts(parser)
 

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -153,15 +153,9 @@ def _add_dynamic_vocab_opts(parser, build_vocab_only=False):
               "Format: one <word> or <word>\t<count> per line.")
     group.add("-share_vocab", "--share_vocab", action="store_true",
               help="Share source and target vocabulary.")
-    group.add('--decoder_start_token', '-decoder_start_token', type=str,
-              default=DefaultTokens.BOS,
-              help="Default decoder start token "
-                   "for most ONMT models it is <s> = BOS "
-                   "it happens that for some Fairseq model it requires </s> ")
-    group.add('-tokenization_type', '--tokenization_type',
-              type=str, default=None,
-              choices=["bpe", "spm"],
-              help="Tokenization type used in build_vocab.")
+    group.add('-learn_subword', '--learn_subword', action="store_true",
+              help="If true, build_vocab will train a new tokenizer. "
+              "src_subword_type should be set too")
     group.add("-src_vocab_size", "--src_vocab_size",
               type=int, default=32768,
               help="Maximum size of the source vocabulary.")
@@ -769,6 +763,11 @@ def _add_decoding_opts(parser):
                    "corresponding target token. If it is not provided "
                    "(or the identified source token does not exist in "
                    "the table), then it will copy the source token.")
+    group.add('--decoder_start_token', '-decoder_start_token', type=str,
+              default=DefaultTokens.BOS,
+              help="Default decoder start token "
+                   "for most ONMT models it is <s> = BOS "
+                   "it happens that for some Fairseq model it requires </s> ")
 
 
 def translate_opts(parser, dynamic=False):
@@ -808,9 +807,6 @@ def translate_opts(parser, dynamic=False):
                    "be the decoded sequence")
     group.add('--report_align', '-report_align', action='store_true',
               help="Report alignment for each translation.")
-    group.add('--gold_align', '-gold_align', action='store_true',
-              help="Report alignment between source and gold target."
-                   "Useful to test the performance of learnt alignments.")
     group.add('--report_time', '-report_time', action='store_true',
               help="Report some translation time metrics")
 

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -158,16 +158,20 @@ def _add_dynamic_vocab_opts(parser, build_vocab_only=False):
               help="Default decoder start token "
                    "for most ONMT models it is <s> = BOS "
                    "it happens that for some Fairseq model it requires </s> ")
+    group.add('-tokenization_type', '--tokenization_type',
+                  type=str, default=None,
+                  choices=["bpe", "spm"],
+                  help="Tokenization type used in build_vocab.")
+    group.add("-src_vocab_size", "--src_vocab_size",
+                  type=int, default=32768,
+                  help="Maximum size of the source vocabulary.")
+    group.add("-tgt_vocab_size", "--tgt_vocab_size",
+                  type=int, default=32768,
+                  help="Maximum size of the target vocabulary")
 
     _add_features_opts(parser)
 
     if not build_vocab_only:
-        group.add("-src_vocab_size", "--src_vocab_size",
-                  type=int, default=32768,
-                  help="Maximum size of the source vocabulary.")
-        group.add("-tgt_vocab_size", "--tgt_vocab_size",
-                  type=int, default=32768,
-                  help="Maximum size of the target vocabulary")
         group.add("-vocab_size_multiple", "--vocab_size_multiple",
                   type=int, default=8,
                   help="Make the vocabulary size a multiple of this value.")

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -153,6 +153,11 @@ def _add_dynamic_vocab_opts(parser, build_vocab_only=False):
               "Format: one <word> or <word>\t<count> per line.")
     group.add("-share_vocab", "--share_vocab", action="store_true",
               help="Share source and target vocabulary.")
+    group.add('--decoder_start_token', '-decoder_start_token', type=str,
+              default=DefaultTokens.BOS,
+              help="Default decoder start token "
+                   "for most ONMT models it is <s> = BOS "
+                   "it happens that for some Fairseq model it requires </s> ")
     group.add('-learn_subword', '--learn_subword', action="store_true",
               help="If true, build_vocab will train a new tokenizer. "
               "src_subword_type should be set too")
@@ -763,11 +768,6 @@ def _add_decoding_opts(parser):
                    "corresponding target token. If it is not provided "
                    "(or the identified source token does not exist in "
                    "the table), then it will copy the source token.")
-    group.add('--decoder_start_token', '-decoder_start_token', type=str,
-              default=DefaultTokens.BOS,
-              help="Default decoder start token "
-                   "for most ONMT models it is <s> = BOS "
-                   "it happens that for some Fairseq model it requires </s> ")
 
 
 def translate_opts(parser, dynamic=False):


### PR DESCRIPTION
During `build_vocab` the option `tokenization_type` can be set to either `bpe` or `spm`. If it is not set, i.e. `None`, the default is regular word-level vocabulary building.