### PR TITLE
Change LoRa saving + tool to merge or retrieve model for further training

### DIFF
--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -506,7 +506,7 @@ def _add_train_general_opts(parser):
               help="Port of master for torch.distributed training.")
 
     # LoRa
-    group.add('--lora_layers', '-lora_layers', default=[], nargs='*', type=str,
+    group.add('--lora_layers', '-lora_layers', default=[], nargs='+', type=str,
               help="list of layers to be replaced by LoRa layers."
                    " ex: ['linear_values', 'linear_query'] "
                    " cf paper §4.2 https://arxiv.org/abs/2106.09685")

--- a/onmt/transforms/tokenize.py
+++ b/onmt/transforms/tokenize.py
@@ -172,20 +172,25 @@ class SentencePieceTransform(TokenizerTransform):
         """Do sentencepiece subword tokenize."""
         sp_model = self.load_models[side]
         sentence = ' '.join(tokens).replace(DefaultTokens.SEP, '\n')
-        nbest_size = self.tgt_subword_nbest if side == 'tgt' else \
-            self.src_subword_nbest
-        if is_train is False or nbest_size in [0, 1]:
-            # derterministic subwording
-            segmented = sp_model.encode(sentence, out_type=str)
-        else:
-            # subword sampling when nbest_size > 1 or -1
-            # alpha should be 0.0 < alpha < 1.0
-            alpha = self.tgt_subword_alpha if side == 'tgt' else \
-                self.src_subword_alpha
-            segmented = sp_model.encode(
-                sentence, out_type=str, enable_sampling=True,
-                alpha=alpha, nbest_size=nbest_size)
-        return segmented
+        sent_list = sentence.split(DefaultTokens.EOS)
+        segmented = []
+        for sentence in sent_list:
+            nbest_size = self.tgt_subword_nbest if side == 'tgt' else \
+                self.src_subword_nbest
+            if is_train is False or nbest_size in [0, 1]:
+                # derterministic subwording
+                segmented += sp_model.encode(sentence, out_type=str)
+            else:
+                # subword sampling when nbest_size > 1 or -1
+                # alpha should be 0.0 < alpha < 1.0
+                alpha = self.tgt_subword_alpha if side == 'tgt' else \
+                    self.src_subword_alpha
+                segmented += sp_model.encode(
+                    sentence, out_type=str, enable_sampling=True,
+                    alpha=alpha, nbest_size=nbest_size)
+            segmented += [DefaultTokens.EOS]
+
+        return segmented[:-1]
 
     def _detokenize(self, tokens, side="src"):
         """Apply SentencePiece Detokenizer"""

--- a/tools/lora_weights.py
+++ b/tools/lora_weights.py
@@ -1,0 +1,82 @@
+import torch
+import torch.nn as nn
+import argparse
+from onmt.utils.parse import ArgumentParser
+from onmt.inputters.inputter import dict_to_vocabs, vocabs_to_dict
+from onmt.model_builder import build_base_model
+from onmt.modules import Linear
+
+"""
+    This script merges or concat LoRa weights into the main model
+    * merge
+        the weights of LoRa are merged and we save the merged model without
+        the optimizer hence in the same format as the original base model.
+    * concat
+        the weights of LoRa are added to the base model in the way the model
+        can be further trained as it was stopped. The Optimizer is also
+        restored from the LoRa checkpoint
+"""
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--action', type=str, required=False,
+                        default='merge', choices=['merge', 'concat'],
+                        help="""Path to the model directory""")
+    parser.add_argument('--base_model', type=str, required=True,
+                        help="""Path to the base model""")
+    parser.add_argument('--lora_weights', type=str, required=True,
+                        help="""Path to the lora checkpoint""")
+    parser.add_argument('--output', type=str, required=True,
+                        help="""Path to the output model""")
+    opt = parser.parse_args()
+
+    base_checkpoint = torch.load(opt.base_model,
+                                 map_location=torch.device('cpu'))
+    model_opt = ArgumentParser.ckpt_model_opts(base_checkpoint['opt'])
+
+    ArgumentParser.update_model_opts(model_opt)
+    ArgumentParser.validate_model_opts(model_opt)
+    vocabs = dict_to_vocabs(base_checkpoint['vocab'])
+
+    model_opt.update_vocab = False
+
+    lora_checkpoint = torch.load(opt.lora_weights,
+                                 map_location=torch.device('cpu'))
+
+    layers = lora_checkpoint['model'].keys()
+
+    model = build_base_model(model_opt, vocabs, base_checkpoint)
+
+    for name, module in model.named_children():
+        if isinstance(module, nn.Linear) and name in layers:
+            model._modules[name] = Linear(
+                module.in_features,
+                module.out_features,
+                r=1,
+                lora_alpha=1,
+                lora_dropout=0,
+                bias=False)
+
+    model.half()  # We keep FP16 for all
+    model.load_state_dict(lora_checkpoint['model'], strict=False)
+
+    if opt.action == 'merge':
+        model.eval()  # this merges automatically LoRa weights in main
+        optim = None
+
+    elif opt.action == 'concat':
+        model.train()
+        optim = lora_checkpoint['optim']
+
+    model_state_dict = model.state_dict()
+    model_state_dict = {k: v for k, v in model_state_dict.items()
+                        if 'generator' not in k}
+    generator_state_dict = model.generator.state_dict()
+    new_checkpoint = {
+        'model': model_state_dict,
+        'generator': generator_state_dict,
+        'vocab': vocabs_to_dict(vocabs),
+        'opt': model_opt,
+        'optim': optim,
+        }
+    torch.save(new_checkpoint, opt.output)


### PR DESCRIPTION
* Now LoRa training will save the diff weights only in a separate checkpoint. This checkpoint contains diff LoRa weights and the optimizer state.
* added new tool to either 1) merge diff LoRa weights in the base model and save the new trained model in the same format as the base model or 2) add back the LoRa weights and optimizer states to the base model for further training.
* misc change in sentenepiece tokenization to take into account potential </s> (DefaultTokens.EOS) in the middle of sentences.