### PR TITLE
8bit loading and LoRa fixes

### DIFF
--- a/docs/source/FAQ.md
+++ b/docs/source/FAQ.md
@@ -655,9 +655,11 @@ Also you can read the blog post here: https://huggingface.co/blog/hf-bitsandbyte
 
 You need to add the following option:
 
-* `quant_layers: ['w_1', 'w_2', 'w_3', 'linear_values', 'linear_query', 'linear_keys', 'final_linear']` 
+* `quant_layers: ['w_1', 'w_2']` 
 
-These are the layers of the PositionWise Feed-Forward from the Encoder/Decoder and the Self-Attention module layers.
+These are the layers of the PositionWise Feed-Forward from the Encoder/Decoder.
+
+At the moment, for a given layer you cannot mix LoRa and 8bit compression. (TODO List)
 
 
 ## Can I get word alignments while translating?

--- a/docs/source/FAQ.md
+++ b/docs/source/FAQ.md
@@ -635,7 +635,7 @@ The `example` argument of `apply` is a `dict` of the form:
 This is defined in `onmt.inputters.corpus.ParallelCorpus.load`. This class is not easily extendable for now but it can be considered for future developments. For instance, we could create some `CustomParallelCorpus` class that would handle other kind of inputs.
 
 
-## How to use LoRa to finetune a big model ?
+## How to use LoRa and 8bit loading to finetune a big model ?
 
 Cf paper: [LoRa](https://arxiv.org/abs/2106.09685)
 
@@ -649,6 +649,15 @@ You need to train_from a model (for instance NLLB-200 3.3B) and use the followin
 * `lora_dropout: 0.1` or any value you can test
 * `lora_alpha: 1` or any value you can test
 * `lora_embedding: true` makes Embeddings LoRa compatible, hence trainable in the case you use `update_vocab: true` or if you want to finetune Embeddings as well.
+
+Bitsandbytes enables quantization of Linear layers. For more information: https://github.com/TimDettmers/bitsandbytes
+Also you can read the blog post here: https://huggingface.co/blog/hf-bitsandbytes-integration
+
+You need to add the following option:
+
+* `quant_layers: ['w_1', 'w_2', 'w_3', 'linear_values', 'linear_query', 'linear_keys', 'final_linear']` 
+
+These are the layers of the PositionWise Feed-Forward from the Encoder/Decoder and the Self-Attention module layers.
 
 
 ## Can I get word alignments while translating?

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -18,6 +18,26 @@ from onmt.constants import DefaultTokens, ModelTask
 from onmt.modules import Linear, Embedding, mark_only_lora_as_trainable
 
 
+def replace_8bit_linear(model, threshold=6.0, module_to_convert=""):
+    try:
+        import bitsandbytes as bnb
+    except ImportError:
+        raise ImportError("Install bitsandbytes to use 8bit compression")
+    for name, module in model.named_children():
+        if len(list(module.children())) > 0:
+            replace_8bit_linear(module, threshold, module_to_convert)
+
+        if isinstance(module, nn.Linear) and name == module_to_convert:
+            model._modules[name] = bnb.nn.Linear8bitLt(
+                module.in_features,
+                module.out_features,
+                module.bias is not None,
+                has_fp16_weights=False,
+                threshold=threshold,
+            )
+    return model
+
+
 def replace_lora_linear(model, r=2, lora_alpha=1,
                         lora_dropout=0, layer=""):
     """
@@ -292,6 +312,7 @@ def build_base_model(model_opt, vocabs, checkpoint=None):
         if model_opt.freeze_encoder or model_opt.freeze_decoder:
             raise ValueError("Cannot use LoRa with Enc/Dec-oder freezing")
         for layer in model_opt.lora_layers:
+            logger.info("Adding LoRa layers for %s" % layer)
             model = replace_lora_linear(model, r=model_opt.lora_rank,
                                         lora_alpha=model_opt.lora_alpha,
                                         lora_dropout=model_opt.lora_dropout,
@@ -300,12 +321,18 @@ def build_base_model(model_opt, vocabs, checkpoint=None):
     if hasattr(model_opt, 'lora_embedding') and model_opt.lora_embedding:
         if model_opt.freeze_encoder or model_opt.freeze_decoder:
             raise ValueError("Cannot use LoRa with Enc/Dec-oder freezing")
+        logger.info("Adding LoRa Embeddings")
         model = replace_lora_embedding(model, r=model_opt.lora_rank,
                                        lora_alpha=model_opt.lora_alpha)
         mark_lora = True
 
     if mark_lora:
-        mark_only_lora_as_trainable(model, bias='lora_only')
+        mark_only_lora_as_trainable(model, bias='none')
+
+    if hasattr(model_opt, 'quant_layers') and len(model_opt.quant_layers) > 0:
+        for layer in model_opt.quant_layers:
+            logger.info("8bit compression of layer %s" % layer)
+            model = replace_8bit_linear(model, module_to_convert=layer)
 
     # Build Generator.
     if not model_opt.copy_attn:

--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -262,6 +262,20 @@ class MultiHeadedAttention(nn.Module):
             value = shape(value, self.dim_per_head)
             query = shape(query, self.dim_per_head)
 
+            if self.max_relative_positions == -1:  # Rotary Embeddings
+                start_pos = 0
+                seqlen = query.size(2)
+                rope = self.rope[start_pos:
+                                 start_pos +
+                                 seqlen].to(query.device)
+
+                query = query.transpose(1, 2)
+                key = key.transpose(1, 2)
+                query, key = apply_rotary_emb(query,
+                                              key,
+                                              rope=rope)
+                query = query.transpose(1, 2)
+                key = key.transpose(1, 2)
         # 2) Calculate and scale scores.
         query = query / math.sqrt(self.dim_per_head)
         # batch x num_heads x query_len x key_len

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -519,6 +519,9 @@ def _add_train_general_opts(parser):
     group.add('--lora_dropout', '-lora_dropout', type=float, default=0.0,
               help="rule of thumb: same value as in main model")
 
+    group.add('--quant_layers', '-quant_layers', default=[], nargs='+',
+              type=str, help="list of layers to be compressed in 8bit.")
+
     _add_reproducibility_opts(parser)
 
     # Init options

--- a/requirements.opt.txt
+++ b/requirements.opt.txt
@@ -3,3 +3,4 @@ git+https://github.com/NVIDIA/apex.git@700d6825e205732c1d6be511306ca4e595297070
 sentencepiece>=0.1.94,<0.1.98
 subword-nmt>=0.3.7
 rapidfuzz
+bitsandbytes

--- a/tools/lora_weights.py
+++ b/tools/lora_weights.py
@@ -1,11 +1,7 @@
 import torch
-import torch.nn as nn
 import argparse
-from onmt.utils.parse import ArgumentParser
 from onmt.inputters.inputter import dict_to_vocabs, vocabs_to_dict
 from onmt.model_builder import build_base_model
-from onmt.modules import Linear
-
 """
     This script merges or concat LoRa weights into the main model
     * merge
@@ -32,51 +28,44 @@ if __name__ == "__main__":
 
     base_checkpoint = torch.load(opt.base_model,
                                  map_location=torch.device('cpu'))
-    model_opt = ArgumentParser.ckpt_model_opts(base_checkpoint['opt'])
 
-    ArgumentParser.update_model_opts(model_opt)
-    ArgumentParser.validate_model_opts(model_opt)
     vocabs = dict_to_vocabs(base_checkpoint['vocab'])
-
-    model_opt.update_vocab = False
 
     lora_checkpoint = torch.load(opt.lora_weights,
                                  map_location=torch.device('cpu'))
 
-    layers = lora_checkpoint['model'].keys()
+    lora_opt = lora_checkpoint['opt']
 
-    model = build_base_model(model_opt, vocabs, base_checkpoint)
+    model = build_base_model(lora_opt, vocabs, base_checkpoint)
 
-    for name, module in model.named_children():
-        if isinstance(module, nn.Linear) and name in layers:
-            model._modules[name] = Linear(
-                module.in_features,
-                module.out_features,
-                r=1,
-                lora_alpha=1,
-                lora_dropout=0,
-                bias=False)
-
-    model.half()  # We keep FP16 for all
     model.load_state_dict(lora_checkpoint['model'], strict=False)
 
     if opt.action == 'merge':
         model.eval()  # this merges automatically LoRa weights in main
+        model.half()  # We keep FP16 for all
         optim = None
-
+        model_state_dict = model.state_dict()
+        model_state_dict = {k: v for k, v in model_state_dict.items()
+                            if 'generator' not in k and 'lora' not in k}
+        new_opt = base_checkpoint['opt']
     elif opt.action == 'concat':
-        model.train()
+        model.half()  # We keep FP16 for all
         optim = lora_checkpoint['optim']
+        model_state_dict = model.state_dict()
+        model_state_dict = {k: v for k, v in model_state_dict.items()
+                            if 'generator' not in k}
+        new_opt = lora_opt
+    else:
+        raise ValueError(
+            "action not supported, please choose merge or concat")
 
-    model_state_dict = model.state_dict()
-    model_state_dict = {k: v for k, v in model_state_dict.items()
-                        if 'generator' not in k}
     generator_state_dict = model.generator.state_dict()
+
     new_checkpoint = {
         'model': model_state_dict,
         'generator': generator_state_dict,
         'vocab': vocabs_to_dict(vocabs),
-        'opt': model_opt,
+        'opt': new_opt,
         'optim': optim,
         }
     torch.save(new_checkpoint, opt.output)

--- a/tools/lora_weights.py
+++ b/tools/lora_weights.py
@@ -1,5 +1,6 @@
 import torch
 import argparse
+from onmt.utils.logging import init_logger
 from onmt.inputters.inputter import dict_to_vocabs, vocabs_to_dict
 from onmt.model_builder import build_base_model
 """
@@ -26,6 +27,8 @@ if __name__ == "__main__":
                         help="""Path to the output model""")
     opt = parser.parse_args()
 
+    init_logger()
+
     base_checkpoint = torch.load(opt.base_model,
                                  map_location=torch.device('cpu'))
 
@@ -35,6 +38,8 @@ if __name__ == "__main__":
                                  map_location=torch.device('cpu'))
 
     lora_opt = lora_checkpoint['opt']
+
+    lora_opt.quant_layers = []
 
     model = build_base_model(lora_opt, vocabs, base_checkpoint)
 


### PR DESCRIPTION
New:
Enables 8bit compression for nn.Linear layers
=> Training can load the base model in 8bit mode and train the LoRa layers in FP16

Fixes:
Rotary embedding during training
LoRa merging (bug in MS LoRa repo)

At the moment you cannot compress a layer for which you want to finetune with LoRa.

