### PR TITLE
Fix vicuna tutorial path in doc index

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,7 +26,7 @@ Contents
       examples/wiki_103/LanguageModelGeneration.md
       examples/summary/Summarization.md
       examples/ggnn/GGNN.md
-      replicate_alpaca-vicuna/ReplicateAlpaca.md
+      examples/replicate_vicuna/ReplicateVicuna.md
 
 
 .. toctree::


### PR DESCRIPTION
The path of the tutorial in the index was not aligned with the final file path that was merged.
This commit fixes it.
Though, to fix the deployed docs, we need to either:
- trigger a new release (easy but very dirty);
- push a locally built version with the fix on the gh-pages branch (quite easy and a bit less dirty);
- take this opportunity to separate the docs build in the workflow, to allow rebuilding docs without necessarily triggering a release (a bit more time consuming).