### PR TITLE
Fix corpus ratio for inlinetags transform

### DIFF
--- a/onmt/transforms/inlinetags.py
+++ b/onmt/transforms/inlinetags.py
@@ -19,33 +19,40 @@ class InlineTagger(object):
     of start and end tags. A dictionary with 20.000-30.000 entries
     should give sufficient number of matches."""
 
-    def __init__(self, tags_dictionary_path, max_tags,
-                 paired_start_tag,
-                 paired_end_tag,
-                 isolated_tag,
-                 src_delimiter,
-                 tag_corpus_ratio=0.1):
+    def __init__(
+        self,
+        tags_dictionary_path,
+        max_tags,
+        paired_start_tag,
+        paired_end_tag,
+        isolated_tag,
+        src_delimiter,
+        tag_corpus_ratio=0.1,
+    ):
         self.max_tags = max_tags
         self.tag_corpus_ratio = tag_corpus_ratio
         self.src_delimiter = src_delimiter
         self.internal_dictionary = self._create_internal_dictionary(
             tags_dictionary_path
         )
-        self.paired_stag_prefix, self.paired_stag_suffix = \
-            map(str, paired_start_tag.split("#"))
-        self.paired_etag_prefix, self.paired_etag_suffix = \
-            map(str, paired_end_tag.split("#"))
-        self.isolated_tag_prefix, self.isolated_tag_suffix = \
-            map(str, isolated_tag.split("#"))
+        self.paired_stag_prefix, self.paired_stag_suffix = map(
+            str, paired_start_tag.split("#")
+        )
+        self.paired_etag_prefix, self.paired_etag_suffix = map(
+            str, paired_end_tag.split("#")
+        )
+        self.isolated_tag_prefix, self.isolated_tag_suffix = map(
+            str, isolated_tag.split("#")
+        )
 
         self.automaton = self._create_automaton()
 
     def _create_internal_dictionary(self, tags_dictionary_path):
         dictionary = list()
-        with open(tags_dictionary_path, mode='r', encoding='utf-8') as file:
+        with open(tags_dictionary_path, mode="r", encoding="utf-8") as file:
             pairs = file.readlines()
             for pair in pairs:
-                src_term, tgt_term = map(str, pair.split('\t'))
+                src_term, tgt_term = map(str, pair.split("\t"))
                 dictionary.append((src_term.strip(), tgt_term.strip()))
         return dictionary
 
@@ -57,16 +64,18 @@ class InlineTagger(object):
         automaton.make_automaton()
         return automaton
 
-    def _tagged_src_tgt(self, src_example, tgt_example) -> \
-            tuple[tuple[list[str], list[str]], bool]:
+    def _tagged_src_tgt(
+        self, src_example, tgt_example
+    ) -> tuple[tuple[list[str], list[str]], bool]:
         """Uses the dictionary to find exact source matches with corresponding
         target matches and adds both paired tags and standalone tags."""
 
         maybe_augmented = src_example.split(self.src_delimiter)
         source_only = maybe_augmented[0].strip()
 
-        augmented_part = maybe_augmented[1].strip() \
-            if len(maybe_augmented) > 1 else None
+        augmented_part = (
+            maybe_augmented[1].strip() if len(maybe_augmented) > 1 else None
+        )
 
         tokenized_source_string = source_only.split()
         tokenized_target_string = tgt_example.split()
@@ -82,12 +91,10 @@ class InlineTagger(object):
         # the system will learn to handle a fairly large number of
         # numbered tags (but not an excessively large number)
         paired_tag_start_num = random.choices(
-            range(1, self.max_tags + 1),
-            weights=range(self.max_tags, 0, -1), k=1
+            range(1, self.max_tags + 1), weights=range(self.max_tags, 0, -1), k=1
         )[0]
         single_tag_start_num = random.choices(
-            range(1, self.max_tags + 1),
-            weights=range(self.max_tags, 0, -1), k=1
+            range(1, self.max_tags + 1), weights=range(self.max_tags, 0, -1), k=1
         )[0]
 
         is_match = False
@@ -104,7 +111,7 @@ class InlineTagger(object):
             # Make sure we only search for exact matches (we don't want
             # to match part of words) and perform some bound checking
             if (
-                (pair[1] not in ' '.join(tokenized_target_string))
+                (pair[1] not in " ".join(tokenized_target_string))
                 or (
                     len(source_only) != src_match_end + 1
                     and not (
@@ -135,14 +142,14 @@ class InlineTagger(object):
                     else:
                         target_index += len(w) + 1
 
-                src_term = ' '.join(
+                src_term = " ".join(
                     tokenized_source_string[
-                        source_index: source_index + len(pair[0].split())
+                        source_index : source_index + len(pair[0].split())
                     ]
                 )
-                tgt_term = ' '.join(
+                tgt_term = " ".join(
                     tokenized_target_string[
-                        target_index: target_index + len(pair[1].split())
+                        target_index : target_index + len(pair[1].split())
                     ]
                 )
 
@@ -151,29 +158,29 @@ class InlineTagger(object):
                 # to keep the indices unaltered. This char is replaced with
                 # spaces before we return the augmented examples.
                 src_single_tags = (
-                    f'{source_only[src_offset: src_match_start]}'
-                    f'{self.isolated_tag_prefix}{single_tag_start_num}'
-                    f'{self.isolated_tag_suffix}∥{src_term}∥'
+                    f"{source_only[src_offset: src_match_start]}"
+                    f"{self.isolated_tag_prefix}{single_tag_start_num}"
+                    f"{self.isolated_tag_suffix}∥{src_term}∥"
                 )
                 src_paired_tags = (
-                    f'{source_only[src_offset: src_match_start]}'
-                    f'{self.paired_stag_prefix}{paired_tag_start_num}'
-                    f'{self.paired_stag_suffix}∥{src_term}∥'
-                    f'{self.paired_etag_prefix}{paired_tag_start_num}'
-                    f'{self.paired_etag_suffix}'
+                    f"{source_only[src_offset: src_match_start]}"
+                    f"{self.paired_stag_prefix}{paired_tag_start_num}"
+                    f"{self.paired_stag_suffix}∥{src_term}∥"
+                    f"{self.paired_etag_prefix}{paired_tag_start_num}"
+                    f"{self.paired_etag_suffix}"
                 )
 
                 tgt_single_tags = (
-                    f'{tgt_example[tgt_offset: tgt_match_start]}'
-                    f'{self.isolated_tag_prefix}{single_tag_start_num}'
-                    f'{self.isolated_tag_suffix}∥{tgt_term}∥'
+                    f"{tgt_example[tgt_offset: tgt_match_start]}"
+                    f"{self.isolated_tag_prefix}{single_tag_start_num}"
+                    f"{self.isolated_tag_suffix}∥{tgt_term}∥"
                 )
                 tgt_paired_tags = (
-                    f'{tgt_example[tgt_offset: tgt_match_start]}'
-                    f'{self.paired_stag_prefix}{paired_tag_start_num}'
-                    f'{self.paired_stag_suffix}∥{tgt_term}∥'
-                    f'{self.paired_etag_prefix}{paired_tag_start_num}'
-                    f'{self.paired_etag_suffix}∥'
+                    f"{tgt_example[tgt_offset: tgt_match_start]}"
+                    f"{self.paired_stag_prefix}{paired_tag_start_num}"
+                    f"{self.paired_stag_suffix}∥{tgt_term}∥"
+                    f"{self.paired_etag_prefix}{paired_tag_start_num}"
+                    f"{self.paired_etag_suffix}∥"
                 )
 
                 # Make a weighted choice between paired tags or single tags.
@@ -199,9 +206,7 @@ class InlineTagger(object):
         if is_match:
             if augmented_part is not None:
                 src_with_tags.append(
-                    source_only[src_offset:]
-                    + self.src_delimiter
-                    + augmented_part
+                    source_only[src_offset:] + self.src_delimiter + augmented_part
                 )
             else:
                 src_with_tags.append(source_only[src_offset:])
@@ -209,14 +214,14 @@ class InlineTagger(object):
             tgt_with_tags.append(tgt_example[tgt_offset:])
 
             return (
-                ''.join(src_with_tags).replace('∥', ' ').split(),
-                ''.join(tgt_with_tags).replace('∥', ' ').split(),
+                "".join(src_with_tags).replace("∥", " ").split(),
+                "".join(tgt_with_tags).replace("∥", " ").split(),
             ), is_match
         else:
             return (src_example.split(), tgt_example.split()), is_match
 
 
-@register_transform(name='inlinetags')
+@register_transform(name="inlinetags")
 class InlineTagsTransform(Transform):
     def __init__(self, opts):
         super().__init__(opts)
@@ -226,31 +231,59 @@ class InlineTagsTransform(Transform):
         """Available options for adding inline tags."""
 
         group = parser.add_argument_group("Transform/InlineTags")
-        group.add("--tags_dictionary_path", "-tags_dictionary_path",
-                  type=str, help="Path to a flat term dictionary.")
-        group.add("--tags_corpus_ratio", "-tags_corpus_ratio", type=float,
-                  default=0.1, help="Ratio of corpus to augment with tags.")
-        group.add("--max_tags", "-max_tags", type=int,
-                  default=12,
-                  help="Maximum number of tags that can be added to "
-                  "a single sentence.")
-        group.add("--paired_stag", "-paired_stag",
-                  type=str, default='｟ph_#_beg｠',
-                  help="The format of an opening paired inline tag. "
-                  "Must include the character #.")
-        group.add("--paired_etag", "-paired_etag",
-                  type=str, default='｟ph_#_end｠',
-                  help="The format of a closing paired inline tag. "
-                  "Must include the character #.")
-        group.add("--isolated_tag", "-isolated_tag",
-                  type=str, default='｟ph_#_std｠',
-                  help="The format of an isolated inline tag. "
-                  "Must include the character #.")
-        group.add("--src_delimiter", "-src_delimiter", type=str,
-                  default='｟fuzzy｠',
-                  help="Any special token used for augmented src sentences. "
-                  "The default is the fuzzy token used in the "
-                  "FuzzyMatch transform.")
+        group.add(
+            "--tags_dictionary_path",
+            "-tags_dictionary_path",
+            type=str,
+            help="Path to a flat term dictionary.",
+        )
+        group.add(
+            "--tags_corpus_ratio",
+            "-tags_corpus_ratio",
+            type=float,
+            default=0.1,
+            help="Ratio of corpus to augment with tags.",
+        )
+        group.add(
+            "--max_tags",
+            "-max_tags",
+            type=int,
+            default=12,
+            help="Maximum number of tags that can be added to " "a single sentence.",
+        )
+        group.add(
+            "--paired_stag",
+            "-paired_stag",
+            type=str,
+            default="｟ph_#_beg｠",
+            help="The format of an opening paired inline tag. "
+            "Must include the character #.",
+        )
+        group.add(
+            "--paired_etag",
+            "-paired_etag",
+            type=str,
+            default="｟ph_#_end｠",
+            help="The format of a closing paired inline tag. "
+            "Must include the character #.",
+        )
+        group.add(
+            "--isolated_tag",
+            "-isolated_tag",
+            type=str,
+            default="｟ph_#_std｠",
+            help="The format of an isolated inline tag. "
+            "Must include the character #.",
+        )
+        group.add(
+            "--src_delimiter",
+            "-src_delimiter",
+            type=str,
+            default="｟fuzzy｠",
+            help="Any special token used for augmented src sentences. "
+            "The default is the fuzzy token used in the "
+            "FuzzyMatch transform.",
+        )
 
     def _parse_opts(self):
         self.tags_dictionary_path = self.opts.tags_dictionary_path
@@ -264,27 +297,31 @@ class InlineTagsTransform(Transform):
 
         # Check if the tags include the
         # mandatory "#" number placeholder"
-        if "#" not in opts.paired_stag or \
-           "#" not in opts.paired_etag or \
-           "#" not in opts.isolated_tag:
-            logger.error('Inline tags must include the number '
-                         'placeholder \"#\"')
+        if (
+            "#" not in opts.paired_stag
+            or "#" not in opts.paired_etag
+            or "#" not in opts.isolated_tag
+        ):
+            logger.error("Inline tags must include the number " 'placeholder "#"')
 
         # We split the user-defined tags in the # placeholder
         # in order to number them
-        paired_stag_prefix, paired_stag_suffix = \
-            map(str, opts.paired_stag.split('#'))
-        paired_etag_prefix, paired_etag_suffix = \
-            map(str, opts.paired_etag.split('#'))
-        isolated_tag_prefix, isolated_tag_suffix = \
-            map(str, opts.isolated_tag.split('#'))
+        paired_stag_prefix, paired_stag_suffix = map(str, opts.paired_stag.split("#"))
+        paired_etag_prefix, paired_etag_suffix = map(str, opts.paired_etag.split("#"))
+        isolated_tag_prefix, isolated_tag_suffix = map(
+            str, opts.isolated_tag.split("#")
+        )
 
         src_specials, tgt_specials = list(), list()
         tags = list()
         for i in range(1, opts.max_tags * 2):
-            tags.extend([paired_stag_prefix + str(i) + paired_stag_suffix,
-                         paired_etag_prefix + str(i) + paired_etag_suffix,
-                         isolated_tag_prefix + str(i) + isolated_tag_suffix])
+            tags.extend(
+                [
+                    paired_stag_prefix + str(i) + paired_stag_suffix,
+                    paired_etag_prefix + str(i) + paired_etag_suffix,
+                    isolated_tag_prefix + str(i) + isolated_tag_suffix,
+                ]
+            )
 
         src_specials.extend(tags)
         tgt_specials.extend(tags)
@@ -295,37 +332,36 @@ class InlineTagsTransform(Transform):
         """Create the tagger."""
 
         super().warm_up(None)
-        self.tagger = InlineTagger(self.tags_dictionary_path,
-                                   self.max_tags,
-                                   self.opts.paired_stag,
-                                   self.opts.paired_etag,
-                                   self.opts.isolated_tag,
-                                   self.src_delimiter,
-                                   self.tags_corpus_ratio)
+        self.tagger = InlineTagger(
+            self.tags_dictionary_path,
+            self.max_tags,
+            self.opts.paired_stag,
+            self.opts.paired_etag,
+            self.opts.isolated_tag,
+            self.src_delimiter,
+            self.tags_corpus_ratio,
+        )
 
     def batch_apply(self, batch, is_train=False, stats=None, **kwargs):
         bucket_size = len(batch)
         examples_with_tags = 0
 
         for (ex, _, _) in batch:
-            augmented_example, is_match = self.apply(ex, is_train,
-                                                     stats, **kwargs)
-            if is_match and (examples_with_tags
-                             < bucket_size * self.tags_corpus_ratio):
+            augmented_example, is_match = self.apply(ex, is_train, stats, **kwargs)
+            if is_match and (examples_with_tags < bucket_size * self.tags_corpus_ratio):
                 examples_with_tags += 1
-                ex['src'] = augmented_example['src']
-                ex['tgt'] = augmented_example['tgt']
-        logger.debug(f'Added tags to {examples_with_tags}/{bucket_size} examples')
+                ex["src"] = augmented_example["src"]
+                ex["tgt"] = augmented_example["tgt"]
+        logger.debug(f"Added tags to {examples_with_tags}/{bucket_size} examples")
         return batch
 
-    def apply(self, example, is_train=False, stats=None, **kwargs) \
-            -> tuple[dict, bool]:
+    def apply(self, example, is_train=False, stats=None, **kwargs) -> tuple[dict, bool]:
         """Add tags (placeholders) to source and target segments."""
 
         src_tgt_pair, is_match = self.tagger._tagged_src_tgt(
-            ' '.join(example['src']), ' '.join(example['tgt'])
+            " ".join(example["src"]), " ".join(example["tgt"])
         )
-        example['src'] = src_tgt_pair[0]
-        example['tgt'] = src_tgt_pair[1]
+        example["src"] = src_tgt_pair[0]
+        example["tgt"] = src_tgt_pair[1]
 
         return example, is_match

--- a/onmt/transforms/inlinetags.py
+++ b/onmt/transforms/inlinetags.py
@@ -5,6 +5,7 @@ from .transform import Transform
 import random
 import ahocorasick
 import string
+from typing import Tuple
 
 
 class InlineTagger(object):
@@ -18,43 +19,36 @@ class InlineTagger(object):
     of start and end tags. A dictionary with 20.000-30.000 entries
     should give sufficient number of matches."""
 
-    def __init__(
-        self,
-        tags_dictionary_path,
-        max_tags,
-        paired_start_tag,
-        paired_end_tag,
-        isolated_tag,
-        src_delimiter,
-        tag_corpus_ratio=0.1,
-    ):
+    def __init__(self, tags_dictionary_path, max_tags,
+                 paired_start_tag,
+                 paired_end_tag,
+                 isolated_tag,
+                 src_delimiter,
+                 tag_corpus_ratio=0.1):
         self.max_tags = max_tags
         self.tag_corpus_ratio = tag_corpus_ratio
         self.src_delimiter = src_delimiter
         self.internal_dictionary = self._create_internal_dictionary(
             tags_dictionary_path
         )
-        self.paired_stag_prefix, self.paired_stag_suffix = map(
-            str, paired_start_tag.split("#")
-        )
-        self.paired_etag_prefix, self.paired_etag_suffix = map(
-            str, paired_end_tag.split("#")
-        )
-        self.isolated_tag_prefix, self.isolated_tag_suffix = map(
-            str, isolated_tag.split("#")
-        )
+        self.paired_stag_prefix, self.paired_stag_suffix = \
+            map(str, paired_start_tag.split("#"))
+        self.paired_etag_prefix, self.paired_etag_suffix = \
+            map(str, paired_end_tag.split("#"))
+        self.isolated_tag_prefix, self.isolated_tag_suffix = \
+            map(str, isolated_tag.split("#"))
 
         self.automaton = self._create_automaton()
 
     def _create_internal_dictionary(self, tags_dictionary_path):
-        logger.debug("Creating tag dictionary for tagging transform...")
+        logger.debug('Creating tag dictionary for tagging transform...')
         dictionary = list()
-        with open(tags_dictionary_path, mode="r", encoding="utf-8") as file:
+        with open(tags_dictionary_path, mode='r', encoding='utf-8') as file:
             pairs = file.readlines()
             for pair in pairs:
-                src_term, tgt_term = map(str, pair.split("\t"))
+                src_term, tgt_term = map(str, pair.split('\t'))
                 dictionary.append((src_term.strip(), tgt_term.strip()))
-        logger.debug(f"Created tag dictionary with {len(dictionary)} entries.")
+        logger.debug(f'Created tag dictionary with {len(dictionary)} entries.')
         return dictionary
 
     def _create_automaton(self):
@@ -65,16 +59,16 @@ class InlineTagger(object):
         automaton.make_automaton()
         return automaton
 
-    def _tagged_src_tgt(self, src_example, tgt_example):
+    def _tagged_src_tgt(self, src_example, tgt_example) -> \
+            tuple[tuple[list[str], list[str]], bool]:
         """Uses the dictionary to find exact source matches with corresponding
         target matches and adds both paired tags and standalone tags."""
 
         maybe_augmented = src_example.split(self.src_delimiter)
         source_only = maybe_augmented[0].strip()
 
-        augmented_part = (
-            maybe_augmented[1].strip() if len(maybe_augmented) > 1 else None
-        )
+        augmented_part = maybe_augmented[1].strip() \
+            if len(maybe_augmented) > 1 else None
 
         tokenized_source_string = source_only.split()
         tokenized_target_string = tgt_example.split()
@@ -90,10 +84,12 @@ class InlineTagger(object):
         # the system will learn to handle a fairly large number of
         # numbered tags (but not an excessively large number)
         paired_tag_start_num = random.choices(
-            range(1, self.max_tags + 1), weights=range(self.max_tags, 0, -1), k=1
+            range(1, self.max_tags + 1),
+            weights=range(self.max_tags, 0, -1), k=1
         )[0]
         single_tag_start_num = random.choices(
-            range(1, self.max_tags + 1), weights=range(self.max_tags, 0, -1), k=1
+            range(1, self.max_tags + 1),
+            weights=range(self.max_tags, 0, -1), k=1
         )[0]
 
         is_match = False
@@ -110,7 +106,7 @@ class InlineTagger(object):
             # Make sure we only search for exact matches (we don't want
             # to match part of words) and perform some bound checking
             if (
-                (pair[1] not in " ".join(tokenized_target_string))
+                (pair[1] not in ' '.join(tokenized_target_string))
                 or (
                     len(source_only) != src_match_end + 1
                     and not (
@@ -141,14 +137,14 @@ class InlineTagger(object):
                     else:
                         target_index += len(w) + 1
 
-                src_term = " ".join(
+                src_term = ' '.join(
                     tokenized_source_string[
-                        source_index : source_index + len(pair[0].split())
+                        source_index: source_index + len(pair[0].split())
                     ]
                 )
-                tgt_term = " ".join(
+                tgt_term = ' '.join(
                     tokenized_target_string[
-                        target_index : target_index + len(pair[1].split())
+                        target_index: target_index + len(pair[1].split())
                     ]
                 )
 
@@ -157,29 +153,29 @@ class InlineTagger(object):
                 # to keep the indices unaltered. This char is replaced with
                 # spaces before we return the augmented examples.
                 src_single_tags = (
-                    f"{source_only[src_offset: src_match_start]}"
-                    f"{self.isolated_tag_prefix}{single_tag_start_num}"
-                    f"{self.isolated_tag_suffix}∥{src_term}∥"
+                    f'{source_only[src_offset: src_match_start]}'
+                    f'{self.isolated_tag_prefix}{single_tag_start_num}'
+                    f'{self.isolated_tag_suffix}∥{src_term}∥'
                 )
                 src_paired_tags = (
-                    f"{source_only[src_offset: src_match_start]}"
-                    f"{self.paired_stag_prefix}{paired_tag_start_num}"
-                    f"{self.paired_stag_suffix}∥{src_term}∥"
-                    f"{self.paired_etag_prefix}{paired_tag_start_num}"
-                    f"{self.paired_etag_suffix}"
+                    f'{source_only[src_offset: src_match_start]}'
+                    f'{self.paired_stag_prefix}{paired_tag_start_num}'
+                    f'{self.paired_stag_suffix}∥{src_term}∥'
+                    f'{self.paired_etag_prefix}{paired_tag_start_num}'
+                    f'{self.paired_etag_suffix}'
                 )
 
                 tgt_single_tags = (
-                    f"{tgt_example[tgt_offset: tgt_match_start]}"
-                    f"{self.isolated_tag_prefix}{single_tag_start_num}"
-                    f"{self.isolated_tag_suffix}∥{tgt_term}∥"
+                    f'{tgt_example[tgt_offset: tgt_match_start]}'
+                    f'{self.isolated_tag_prefix}{single_tag_start_num}'
+                    f'{self.isolated_tag_suffix}∥{tgt_term}∥'
                 )
                 tgt_paired_tags = (
-                    f"{tgt_example[tgt_offset: tgt_match_start]}"
-                    f"{self.paired_stag_prefix}{paired_tag_start_num}"
-                    f"{self.paired_stag_suffix}∥{tgt_term}∥"
-                    f"{self.paired_etag_prefix}{paired_tag_start_num}"
-                    f"{self.paired_etag_suffix}"
+                    f'{tgt_example[tgt_offset: tgt_match_start]}'
+                    f'{self.paired_stag_prefix}{paired_tag_start_num}'
+                    f'{self.paired_stag_suffix}∥{tgt_term}∥'
+                    f'{self.paired_etag_prefix}{paired_tag_start_num}'
+                    f'{self.paired_etag_suffix}∥'
                 )
 
                 # Make a weighted choice between paired tags or single tags.
@@ -204,23 +200,23 @@ class InlineTagger(object):
                 is_match = True
         if is_match:
             if augmented_part is not None:
-                src_with_tags.append(
-                    source_only[src_offset:] + self.src_delimiter + augmented_part
-                )
+                src_with_tags.append(source_only[src_offset:] +
+                                     self.src_delimiter +
+                                     augmented_part)
             else:
                 src_with_tags.append(source_only[src_offset:])
 
             tgt_with_tags.append(tgt_example[tgt_offset:])
 
             return (
-                "".join(src_with_tags).replace("∥", " ").split(),
-                "".join(tgt_with_tags).replace("∥", " ").split(),
-            )
+                ''.join(src_with_tags).replace('∥', ' ').split(),
+                ''.join(tgt_with_tags).replace('∥', ' ').split(),
+            ), is_match
         else:
-            return (src_example.split(), tgt_example.split())
+            return (src_example.split(), tgt_example.split()), is_match
 
 
-@register_transform(name="inlinetags")
+@register_transform(name='inlinetags')
 class InlineTagsTransform(Transform):
     def __init__(self, opts):
         super().__init__(opts)
@@ -230,68 +226,40 @@ class InlineTagsTransform(Transform):
         """Available options for adding inline tags."""
 
         group = parser.add_argument_group("Transform/InlineTags")
-        group.add(
-            "--tags_dictionary_path",
-            "-tags_dictionary_path",
-            type=str,
-            help="Path to a flat term dictionary.",
-        )
-        group.add(
-            "--tags_corpus_ratio",
-            "-tags_corpus_ratio",
-            type=float,
-            default=0.1,
-            help="Ratio of corpus to augment with tags.",
-        )
-        group.add(
-            "--max_tags",
-            "-max_tags",
-            type=int,
-            default=12,
-            help="Maximum number of tags that can be added to " "a single sentence.",
-        )
-        group.add(
-            "--paired_stag",
-            "-paired_stag",
-            type=str,
-            default="｟ph_#_beg｠",
-            help="The format of an opening paired inline tag. "
-            "Must include the character #.",
-        )
-        group.add(
-            "--paired_etag",
-            "-paired_etag",
-            type=str,
-            default="｟ph_#_end｠",
-            help="The format of a closing paired inline tag. "
-            "Must include the character #.",
-        )
-        group.add(
-            "--isolated_tag",
-            "-isolated_tag",
-            type=str,
-            default="｟ph_#_std｠",
-            help="The format of an isolated inline tag. "
-            "Must include the character #.",
-        )
-        group.add(
-            "--src_delimiter",
-            "-src_delimiter",
-            type=str,
-            default="｟fuzzy｠",
-            help="Any special token used for augmented src sentences. "
-            "The default is the fuzzy token used in the "
-            "FuzzyMatch transform.",
-        )
+        group.add("--tags_dictionary_path", "-tags_dictionary_path",
+                  type=str, help="Path to a flat term dictionary.")
+        group.add("--tags_corpus_ratio", "-tags_corpus_ratio", type=float,
+                  default=0.1, help="Ratio of corpus to augment with tags.")
+        group.add("--max_tags", "-max_tags", type=int,
+                  default=12,
+                  help="Maximum number of tags that can be added to "
+                  "a single sentence.")
+        group.add("--paired_stag", "-paired_stag",
+                  type=str, default='｟ph_#_beg｠',
+                  help="The format of an opening paired inline tag. "
+                  "Must include the character #.")
+        group.add("--paired_etag", "-paired_etag",
+                  type=str, default='｟ph_#_end｠',
+                  help="The format of a closing paired inline tag. "
+                  "Must include the character #.")
+        group.add("--isolated_tag", "-isolated_tag",
+                  type=str, default='｟ph_#_std｠',
+                  help="The format of an isolated inline tag. "
+                  "Must include the character #.")
+        group.add("--src_delimiter", "-src_delimiter", type=str,
+                  default='｟fuzzy｠',
+                  help="Any special token used for augmented src sentences. "
+                  "The default is the fuzzy token used in the "
+                  "FuzzyMatch transform.")
 
     def _parse_opts(self):
         self.tags_dictionary_path = self.opts.tags_dictionary_path
         self.tags_corpus_ratio = self.opts.tags_corpus_ratio
         self.max_tags = self.opts.max_tags
         self.src_delimiter = self.opts.src_delimiter
-        self.paired_stag = (self.opts.paired_stag,)
-        self.paired_etag = (self.opts.paired_etag,)
-        self.isolated_tag = (self.opts.isolated_tag,)
+        # self.paired_stag = self.opts.paired_stag,
+        # self.paired_etag = self.opts.paired_etag,
+        # self.isolated_tag = self.opts.isolated_tag,
 
     @classmethod
     def get_specials(cls, opts):
@@ -299,31 +267,27 @@ class InlineTagsTransform(Transform):
 
         # Check if the tags include the
         # mandatory "#" number placeholder"
-        if (
-            "#" not in opts.paired_stag
-            or "#" not in opts.paired_etag
-            or "#" not in opts.isolated_tag
-        ):
-            logger.error("Inline tags must include the number " 'placeholder "#"')
+        if "#" not in opts.paired_stag or \
+           "#" not in opts.paired_etag or \
+           "#" not in opts.isolated_tag:
+            logger.error('Inline tags must include the number '
+                         'placeholder \"#\"')
 
         # We split the user-defined tags in the # placeholder
         # in order to number them
-        paired_stag_prefix, paired_stag_suffix = map(str, opts.paired_stag.split("#"))
-        paired_etag_prefix, paired_etag_suffix = map(str, opts.paired_etag.split("#"))
-        isolated_tag_prefix, isolated_tag_suffix = map(
-            str, opts.isolated_tag.split("#")
-        )
+        paired_stag_prefix, paired_stag_suffix = \
+            map(str, opts.paired_stag.split('#'))
+        paired_etag_prefix, paired_etag_suffix = \
+            map(str, opts.paired_etag.split('#'))
+        isolated_tag_prefix, isolated_tag_suffix = \
+            map(str, opts.isolated_tag.split('#'))
 
         src_specials, tgt_specials = list(), list()
         tags = list()
         for i in range(1, opts.max_tags * 2):
-            tags.extend(
-                [
-                    paired_stag_prefix + str(i) + paired_stag_suffix,
-                    paired_etag_prefix + str(i) + paired_etag_suffix,
-                    isolated_tag_prefix + str(i) + isolated_tag_suffix,
-                ]
-            )
+            tags.extend([paired_stag_prefix + str(i) + paired_stag_suffix,
+                         paired_etag_prefix + str(i) + paired_etag_suffix,
+                         isolated_tag_prefix + str(i) + isolated_tag_suffix])
 
         src_specials.extend(tags)
         tgt_specials.extend(tags)
@@ -334,26 +298,40 @@ class InlineTagsTransform(Transform):
         """Create the tagger."""
 
         super().warm_up(None)
-        self.tagger = InlineTagger(
-            self.tags_dictionary_path,
-            self.max_tags,
-            self.paired_stag,
-            self.paired_etag,
-            self.isolated_tag,
-            self.src_delimiter,
-            self.tags_corpus_ratio,
-        )
+        self.tagger = InlineTagger(self.tags_dictionary_path,
+                                   self.max_tags,
+                                   self.opts.paired_stag,
+                                   self.opts.paired_etag,
+                                   self.opts.isolated_tag,
+                                   self.src_delimiter,
+                                   self.tags_corpus_ratio)
+        
+    def batch_apply(self, batch, is_train=False, stats=None, **kwargs):
+        bucket_size = len(batch)
+        logger.info(f'Starting inlinetags transform with '
+                    f'{bucket_size} examples')
+        examples_with_tags = 0
 
-    def apply(self, example, is_train=False, stats=None, **kwargs):
+        for (ex, _, _) in batch:
+            augmented_example, is_match = self.apply(ex, is_train,
+                                                     stats, **kwargs)
+            if is_match and (examples_with_tags <
+                             bucket_size * self.tags_corpus_ratio):
+                examples_with_tags += 1
+                ex['src'] = augmented_example['src']
+                ex['tgt'] = augmented_example['tgt']
+        logger.info(f'Added tags to {examples_with_tags} examples')
+        return batch
+
+    def apply(self, example, is_train=False, stats=None, **kwargs) -> \
+            tuple[dict, bool]:
         """Add tags (placeholders) to source and target segments."""
 
-        if random.random() > self.tags_corpus_ratio:
-            return example
-
-        src_tgt_pair = self.tagger._tagged_src_tgt(
-            " ".join(example["src"]), " ".join(example["tgt"])
+        src_tgt_pair, is_match = self.tagger._tagged_src_tgt(
+            ' '.join(example['src']), ' '.join(example['tgt'])
         )
-        example["src"] = src_tgt_pair[0]
-        example["tgt"] = src_tgt_pair[1]
+        example['src'] = src_tgt_pair[0]
+        example['tgt'] = src_tgt_pair[1]
 
-        return example
+        return example, is_match
+

--- a/onmt/transforms/inlinetags.py
+++ b/onmt/transforms/inlinetags.py
@@ -64,7 +64,7 @@ class InlineTagger(object):
         automaton.make_automaton()
         return automaton
 
-    def _tagged_src_tgt(self, src_example, tgt_example) -> tuple[tuple, bool]:
+    def _tagged_src_tgt(self, src_example, tgt_example) -> tuple:
         """Uses the dictionary to find exact source matches with corresponding
         target matches and adds both paired tags and standalone tags."""
 
@@ -353,7 +353,7 @@ class InlineTagsTransform(Transform):
         logger.debug(f"Added tags to {examples_with_tags}/{bucket_size} examples")
         return batch
 
-    def apply(self, example, is_train=False, stats=None, **kwargs) -> tuple[dict, bool]:
+    def apply(self, example, is_train=False, stats=None, **kwargs) -> tuple:
         """Add tags (placeholders) to source and target segments."""
 
         src_tgt_pair, is_match = self.tagger._tagged_src_tgt(

--- a/onmt/transforms/inlinetags.py
+++ b/onmt/transforms/inlinetags.py
@@ -64,9 +64,7 @@ class InlineTagger(object):
         automaton.make_automaton()
         return automaton
 
-    def _tagged_src_tgt(
-        self, src_example, tgt_example
-    ) -> tuple[tuple[list[str], list[str]], bool]:
+    def _tagged_src_tgt(self, src_example, tgt_example) -> tuple[tuple, bool]:
         """Uses the dictionary to find exact source matches with corresponding
         target matches and adds both paired tags and standalone tags."""
 


### PR DESCRIPTION
Corpus ratio now is finally applied correctly. As it seems, the only way to have an accurate ratio is to pass every single example through the augmentation function and then propagate a boolean with each example that denotes if that example has actually been augmented with tags.