### PR TITLE
Fix checkpointing in tensor parallel mode

### DIFF
--- a/onmt/models/model_saver.py
+++ b/onmt/models/model_saver.py
@@ -237,7 +237,11 @@ class ModelSaver(ModelSaverBase):
         ckpt_path = "%s_step_%d.pt" % (self.base_path, step)
         torch.save(checkpoint, ckpt_path)
         logger.info("Saving safetensors %s_step_%d.pt" % (self.base_path, step))
-        model_path = "%s_device_%d_step_%d.safetensors" % (self.base_path, self.device_id, step)
+        model_path = "%s_device_%d_step_%d.safetensors" % (
+            self.base_path,
+            self.device_id,
+            step,
+        )
         save_file(model_state_dict, model_path)
         return ckpt_path, model_path
 

--- a/onmt/models/model_saver.py
+++ b/onmt/models/model_saver.py
@@ -111,8 +111,9 @@ class ModelSaverBase(object):
             if save_format == "safetensors":
                 self.model_queue = deque([], maxlen=keep_checkpoint)
 
-    def warm_up(self, device_id):
+    def warm_up(self, device_id, parallel_mode):
         self.device_id = device_id
+        self.parallel_mode = parallel_mode
 
     def save(self, step, moving_average=None):
         """Main entry point for model saver
@@ -208,7 +209,10 @@ class ModelSaver(ModelSaverBase):
         }
 
         logger.info("Saving checkpoint %s_step_%d.pt" % (self.base_path, step))
-        ckpt_path = "%s_device_%d_step_%d.pt" % (self.base_path, self.device_id, step)
+        if self.parallel_mode == "tensor_parallel":
+            ckpt_path = "%s_device_%d_step_%d.pt" % (self.base_path, self.device_id, step)
+        else:
+            ckpt_path = "%s_step_%d.pt" % (self.base_path, step)
         torch.save(checkpoint, ckpt_path)
         return ckpt_path, None
 

--- a/onmt/models/model_saver.py
+++ b/onmt/models/model_saver.py
@@ -210,7 +210,11 @@ class ModelSaver(ModelSaverBase):
 
         logger.info("Saving checkpoint %s_step_%d.pt" % (self.base_path, step))
         if self.parallel_mode == "tensor_parallel":
-            ckpt_path = "%s_device_%d_step_%d.pt" % (self.base_path, self.device_id, step)
+            ckpt_path = "%s_device_%d_step_%d.pt" % (
+                self.base_path,
+                self.device_id,
+                step,
+            )
         else:
             ckpt_path = "%s_step_%d.pt" % (self.base_path, step)
         torch.save(checkpoint, ckpt_path)

--- a/onmt/models/model_saver.py
+++ b/onmt/models/model_saver.py
@@ -111,6 +111,9 @@ class ModelSaverBase(object):
             if save_format == "safetensors":
                 self.model_queue = deque([], maxlen=keep_checkpoint)
 
+    def warm_up(self, device_id):
+        self.device_id = device_id
+
     def save(self, step, moving_average=None):
         """Main entry point for model saver
 
@@ -205,7 +208,7 @@ class ModelSaver(ModelSaverBase):
         }
 
         logger.info("Saving checkpoint %s_step_%d.pt" % (self.base_path, step))
-        ckpt_path = "%s_step_%d.pt" % (self.base_path, step)
+        ckpt_path = "%s_device_%d_step_%d.pt" % (self.base_path, self.device_id, step)
         torch.save(checkpoint, ckpt_path)
         return ckpt_path, None
 
@@ -234,7 +237,7 @@ class ModelSaver(ModelSaverBase):
         ckpt_path = "%s_step_%d.pt" % (self.base_path, step)
         torch.save(checkpoint, ckpt_path)
         logger.info("Saving safetensors %s_step_%d.pt" % (self.base_path, step))
-        model_path = "%s_step_%d.safetensors" % (self.base_path, step)
+        model_path = "%s_device_%d_step_%d.safetensors" % (self.base_path, self.device_id, step)
         save_file(model_state_dict, model_path)
         return ckpt_path, model_path
 

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -186,7 +186,7 @@ class Trainer(object):
         self.report_manager = report_manager
         self.with_align = with_align
         self.model_saver = model_saver
-        self.model_saver.warm_up(gpu_rank)
+        self.model_saver.warm_up(gpu_rank, parallel_mode)
         self.average_decay = average_decay
         self.moving_average = None
         self.average_every = average_every

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -86,7 +86,7 @@ def build_trainer(opt, device_id, model, vocabs, optim, model_saver=None):
         parallel_mode,
         report_manager,
         with_align=True if opt.lambda_align > 0 else False,
-        model_saver=model_saver if gpu_rank <= 0 else None,
+        model_saver=model_saver, #if gpu_rank <= 0 else None,
         average_decay=average_decay,
         average_every=average_every,
         model_dtype=opt.model_dtype,
@@ -182,6 +182,7 @@ class Trainer(object):
         self.report_manager = report_manager
         self.with_align = with_align
         self.model_saver = model_saver
+        self.model_saver.warm_up(gpu_rank)
         self.average_decay = average_decay
         self.moving_average = None
         self.average_every = average_every

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -70,6 +70,10 @@ def build_trainer(opt, device_id, model, vocabs, optim, model_saver=None):
     )
 
     report_manager = onmt.utils.build_report_manager(opt, gpu_rank)
+
+    if parallel_mode == "data_parallel" and gpu_rank > 0:
+        model_saver = None
+
     trainer = Trainer(
         model,
         train_loss,
@@ -86,7 +90,7 @@ def build_trainer(opt, device_id, model, vocabs, optim, model_saver=None):
         parallel_mode,
         report_manager,
         with_align=True if opt.lambda_align > 0 else False,
-        model_saver=model_saver,  # if gpu_rank <= 0 else None,
+        model_saver=model_saver,
         average_decay=average_decay,
         average_every=average_every,
         model_dtype=opt.model_dtype,

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -86,7 +86,7 @@ def build_trainer(opt, device_id, model, vocabs, optim, model_saver=None):
         parallel_mode,
         report_manager,
         with_align=True if opt.lambda_align > 0 else False,
-        model_saver=model_saver, #if gpu_rank <= 0 else None,
+        model_saver=model_saver,  # if gpu_rank <= 0 else None,
         average_decay=average_decay,
         average_every=average_every,
         model_dtype=opt.model_dtype,

--- a/tools/lora_weights_tp.py
+++ b/tools/lora_weights_tp.py
@@ -1,0 +1,160 @@
+import argparse
+import torch
+
+from onmt.utils.logging import init_logger, logger
+from onmt.models.model_saver import load_checkpoint
+from onmt.inputters.inputter import dict_to_vocabs, vocabs_to_dict
+from onmt.model_builder import build_base_model
+
+
+"""
+    This script merges or concat LoRa weights from partial checkpoints
+    saved during a finetuning with the tensor parallel mode, into the main model
+    * merge
+        the weights of LoRa are merged and we save the merged model without
+        the optimizer hence in the same format as the original base model.
+    * concat
+        the weights of LoRa are added to the base model in the way the model
+        can be further trained as it was stopped. The Optimizer is also
+        restored from the LoRa checkpoint
+"""
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--format",
+        type=str,
+        choices=["pytorch"],
+        default="pytorch",
+        help="""Format to save the output model""",
+    )
+    parser.add_argument(
+        "--base_model", type=str, required=True, help="""Path to the base model"""
+    )
+    parser.add_argument(
+        "--lora_model",
+        type=str,
+        required=True,
+        help="""Path to the partial lora checkpoints""",
+    )
+    parser.add_argument(
+        "--step",
+        type=int,
+        required=True,
+        help="""step""",
+    )
+    parser.add_argument(
+        "--nb_checkpoints",
+        type=int,
+        required=True,
+        help="""Number of partial checkpoints""",
+    )
+    parser.add_argument(
+        "--action",
+        type=str,
+        required=False,
+        default="merge",
+        choices=["merge", "concat"],
+        help="""Path to the model directory""",
+    )
+    opt = parser.parse_args()
+
+    init_logger()
+
+    finetuned_models = [
+        (f"{opt.lora_model}_device_{device_id}_step_{opt.step}.pt")
+        for device_id in range(opt.nb_checkpoints)
+    ]
+    opt.output = f"{opt.lora_model}_step_{opt.step}_{opt.action}.pt"
+
+
+def main():
+    base_checkpoint = load_checkpoint(opt.base_model)
+    for i in range(opt.nb_checkpoints):
+        device_id = i
+        partial_checkpoint = load_checkpoint(finetuned_models[i])
+        partial_opt = partial_checkpoint["opt"]
+        partial_opt.quant_layers = (
+            []
+        )  # we need to remove any quantization to merge weights
+        partial_opt.world_size = 1
+        partial_opt.gpu_ranks = [0]
+        with open("partial_opt", "w") as w:
+            w.write(str(partial_opt))
+        if i == 0:
+            print("## Loading base model")
+            vocabs = dict_to_vocabs(partial_checkpoint["vocab"])
+            model = build_base_model(partial_opt, vocabs)
+            if "model" in base_checkpoint.keys():
+                model.load_state_dict(
+                    base_checkpoint,
+                    precision=torch.float32,
+                    device=torch.device("cpu"),
+                    strict=False,
+                )
+            else:
+                basepath = (
+                    opt.base_model[:-3]
+                    if opt.base_model[-3:] == ".pt"
+                    else opt.base_model
+                )
+                model.load_safe_state_dict(
+                    basepath,
+                    precision=torch.float32,
+                    device=torch.device("cpu"),
+                    strict=False,
+                )
+            print("done !")
+
+        if "model" in partial_checkpoint.keys():
+            print("## Loading checkpoint ", device_id)
+            model.load_state_dict_tp(
+                partial_checkpoint,
+                precision=torch.float32,
+                device=torch.device("cpu"),
+                strict=False,
+                device_id=device_id,
+            )
+            print("done !")
+
+    if opt.action == "merge":
+        model.eval()  # this merges automatically LoRa weights in main
+        model.half()  # We keep FP16 for all
+        optim = None
+        model_state_dict = model.state_dict()
+        if opt.format == "pytorch":
+            model_state_dict = {
+                k: v
+                for k, v in model_state_dict.items()
+                if "generator" not in k and "lora" not in k
+            }
+        new_opt = base_checkpoint["opt"]
+    elif opt.action == "concat":
+        model.half()  # We keep FP16 for all
+        optim = partial_checkpoint["optim"]
+        model_state_dict = model.state_dict()
+        if opt.format == "pytorch":
+            model_state_dict = {
+                k: v for k, v in model_state_dict.items() if "generator" not in k
+            }
+        new_opt = partial_opt
+    else:
+        raise ValueError("action not supported, please choose merge or concat")
+    if opt.format == "pytorch":
+        generator_state_dict = model.generator.state_dict()
+        new_checkpoint = {
+            "model": model_state_dict,
+            "generator": generator_state_dict,
+            "vocab": vocabs_to_dict(vocabs),
+            "opt": new_opt,
+            "optim": optim,
+        }
+        logger.info("Saving merged model")
+        if opt.output[-3:] == ".pt":
+            torch.save(new_checkpoint, opt.output)
+        else:
+            torch.save(new_checkpoint, opt.output + ".pt")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR fixes a bugin fine-tuning with tensor parallel mode. In this mode, each process needs its own `model_saver`,  as the model weights are distributed across the different devices.
It also provides a tool to gather all the parameters in the same checkpoint.
Example of use:
```shell
python3 OpenNMT-py/tools/lora_weights_tp.py\
    --format pytorch \
    --action merge \
    --base_model llama-2-7B_safetensors.pt \
    --lora_model finetuning/llama-2-7B_finetuned \
    --step 3 \
    --nb_checkpoints 4
  ```
It has been tested in 2 different ways:
- the lama-2-7B score of the  abstract_algebra task is reproduced after 3 steps (0.3000)
- The evaluation score of the gathered checkpoint on the task of interest after 500 steps is satisfying.
