### PR TITLE
Fix alignment generation error

### DIFF
--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -419,7 +419,9 @@ class Inference(object):
                         build_align_pharaoh(align)
                         for align in trans.word_aligns[: self.n_best]
                     ]
-                    n_best_preds_align = [" ".join(align) for align in align_pharaohs]
+                    n_best_preds_align = [
+                        " ".join(align[0]) for align in align_pharaohs
+                    ]
                     n_best_preds = [
                         pred + DefaultTokens.ALIGNMENT_SEPARATOR + align
                         for pred, align in zip(n_best_preds, n_best_preds_align)


### PR DESCRIPTION
This addresses the following error when running translator with `report_align=true`

Traceback 
```
  File "/usr/local/lib64/python3.8/site-packages/onmt/translate/translator.py", line 422, in _translate
    n_best_preds_align = [" ".join(align) for align in align_pharaohs]
  File "/usr/local/lib64/python3.8/site-packages/onmt/translate/translator.py", line 422, in <listcomp>
    n_best_preds_align = [" ".join(align) for align in align_pharaohs]
TypeError: sequence item 0: expected str instance, list found
```

Caused by change to `build_align_pharaoh` where it now returns `return align_pairs, align_scores` versus previous `return align_pairs`