### PR TITLE
New indexing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -169,8 +169,96 @@ jobs:
           -scoring_debug "true" \
           -tensorboard_log_dir /tmp/logs_dynamic-scoring_and_copy \
           -dump_preds /tmp/dump_preds \
+          -position_encoding \
           -copy_attn
         python onmt/tests/test_events.py --logdir /tmp/logs_dynamic-scoring_and_copy -tensorboard_checks valid_metrics 
+    - name : Test Transformer training and validation with dynamic scoring and maxrelative
+      run: |
+        python3 train.py \
+          -config data/data.yaml \
+          -src_vocab /tmp/onmt.vocab.src \
+          -tgt_vocab /tmp/onmt.vocab.tgt \
+          -src_vocab_size 1000 \
+          -tgt_vocab_size 1000 \
+          -encoder_type transformer \
+          -decoder_type transformer \
+          -layers 4 \
+          -word_vec_size 16 \
+          -hidden_size 16 \
+          -num_workers 0 -bucket_size 1024 \
+          -heads 2 \
+          -transformer_ff 64 \
+          -num_workers 0 -bucket_size 1024 \
+          -accum_count 2 4 8 \
+          -accum_steps 0 15000 30000 \
+          -save_model /tmp/onmt.model \
+          -train_steps 10  -valid_steps 5 \
+          -report_every 2 \
+          -valid_metrics "BLEU" "TER" \
+          -tensorboard "true" \
+          -scoring_debug "true" \
+          -tensorboard_log_dir /tmp/logs_dynamic-scoring_and_relative \
+          -dump_preds /tmp/dump_preds \
+          -max_relative_positions 8
+        python onmt/tests/test_events.py --logdir /tmp/logs_dynamic-scoring_and_relative -tensorboard_checks valid_metrics 
+    - name : Test Transformer training and validation with dynamic scoring and rotary
+      run: |
+        python3 train.py \
+          -config data/data.yaml \
+          -src_vocab /tmp/onmt.vocab.src \
+          -tgt_vocab /tmp/onmt.vocab.tgt \
+          -src_vocab_size 1000 \
+          -tgt_vocab_size 1000 \
+          -encoder_type transformer \
+          -decoder_type transformer \
+          -layers 4 \
+          -word_vec_size 16 \
+          -hidden_size 16 \
+          -num_workers 0 -bucket_size 1024 \
+          -heads 2 \
+          -transformer_ff 64 \
+          -num_workers 0 -bucket_size 1024 \
+          -accum_count 2 4 8 \
+          -accum_steps 0 15000 30000 \
+          -save_model /tmp/onmt.model \
+          -train_steps 10  -valid_steps 5 \
+          -report_every 2 \
+          -valid_metrics "BLEU" "TER" \
+          -tensorboard "true" \
+          -scoring_debug "true" \
+          -tensorboard_log_dir /tmp/logs_dynamic-scoring_and_rotary \
+          -dump_preds /tmp/dump_preds \
+          -max_relative_positions -1
+        python onmt/tests/test_events.py --logdir /tmp/logs_dynamic-scoring_and_rotary -tensorboard_checks valid_metrics 
+    - name : Test Transformer training and validation with dynamic scoring and alibi
+      run: |
+        python3 train.py \
+          -config data/data.yaml \
+          -src_vocab /tmp/onmt.vocab.src \
+          -tgt_vocab /tmp/onmt.vocab.tgt \
+          -src_vocab_size 1000 \
+          -tgt_vocab_size 1000 \
+          -encoder_type transformer \
+          -decoder_type transformer \
+          -layers 4 \
+          -word_vec_size 16 \
+          -hidden_size 16 \
+          -num_workers 0 -bucket_size 1024 \
+          -heads 2 \
+          -transformer_ff 64 \
+          -num_workers 0 -bucket_size 1024 \
+          -accum_count 2 4 8 \
+          -accum_steps 0 15000 30000 \
+          -save_model /tmp/onmt.model \
+          -train_steps 10  -valid_steps 5 \
+          -report_every 2 \
+          -valid_metrics "BLEU" "TER" \
+          -tensorboard "true" \
+          -scoring_debug "true" \
+          -tensorboard_log_dir /tmp/logs_dynamic-scoring_and_alibi \
+          -dump_preds /tmp/dump_preds \
+          -max_relative_positions 8
+        python onmt/tests/test_events.py --logdir /tmp/logs_dynamic-scoring_and_alibi -tensorboard_checks valid_metrics 
     - name: Test LM training
       run: |
         python train.py \

--- a/data/data_lm/gen-nucleus-sampling-sol2.txt
+++ b/data/data_lm/gen-nucleus-sampling-sol2.txt
@@ -1,7 +1,7 @@
-like your equipment !
-in your Presidency or registering erratic full detailed table since Waddington , as well handled separately .
-the importance &apos;s future .
-there is survivors , under new public beforehand ?
-bankers sit on the honour and the old , accusations by Cubase for political leadership in the fifth generation of 0.5 , 1 January in serving the old , 1 .
-can do planet what Mr Titley , should like What is really do so done guarantee - ™ your Gore .
-we can restore confidence in Switzerland .
+well ?
+liberty to decide in favor of the Stability tattoo .
+a moment of the top of the importance of the importance &apos;s future .
+I think that received negative perception that it .
+heard from India majority , Romagna .
+We move should do any experiences .
+our website , you invite shop in the year .

--- a/data/data_lm/gen-sampling-beams-sol2.txt
+++ b/data/data_lm/gen-sampling-beams-sol2.txt
@@ -1,7 +1,7 @@
-you ! your staff !
-in German Presidency or rather than Andalusia .
-a moment , one century .
-" s operational from 06: 00 on weekdays , clothes hang thick from the and 00 until about 00 until the sea .
-fine words has underlined the fine vegetarian ...
-service are buying any of my property .
-we are much running behind the facts .
+you ! Next to your luck .
+inspired by the absolut well-beeing-feeling of the Tauern Spa and ...
+the top of the top of the top of the moment , health of the importance of capital , the world .
+" Austrian " sold with &quot; Delta , received from twenty years .
+administered by the usefulness of the interinstitutional coherence of the recorded by the present in the young majority of renewable energies .
+do so would like this subsidy is requested .
+800 m2 can &apos;t be seen on payments .

--- a/onmt/bin/translate.py
+++ b/onmt/bin/translate.py
@@ -9,6 +9,7 @@ import onmt.opts as opts
 from onmt.utils.parse import ArgumentParser
 from onmt.utils.misc import use_gpu, set_random_seed
 from torch.profiler import profile, record_function, ProfilerActivity
+import time
 
 
 def translate(opt):
@@ -52,13 +53,15 @@ def main():
     parser = _get_parser()
     opt = parser.parse_args()
     if opt.profile:
+
         with profile(activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA]) as prof:
             with record_function("Translate"):
                 translate(opt)
-        print(prof.key_averages().table(sort_by="cpu_time_total", row_limit=30))
-
+        print(prof.key_averages().table(sort_by="cpu_time_total", row_limit=40))
     else:
+        init_time = time.time()
         translate(opt)
+        print("Time w/o python interpreter load/terminate: ", time.time() - init_time)
 
 
 if __name__ == "__main__":

--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -581,20 +581,18 @@ class TransformerDecoder(TransformerDecoderBase):
                     {"keys": torch.tensor([]), "values": torch.tensor([])},
                 )
 
-        emb = self.embeddings(tgt, step=step)
-        dec_out = emb
-        assert emb.dim() == 3  # len x batch x embedding_dim
+        dec_out = self.embeddings(tgt, step=step)
 
         pad_idx = self.embeddings.word_padding_idx
-        src_lens = kwargs["src_len"]
+        src_len = kwargs["src_len"]
         src_max_len = self.state["src"].shape[1]
-        src_pad_mask = ~sequence_mask(src_lens, src_max_len)  # [B x slen]
-        src_pad_mask = src_pad_mask.unsqueeze(1)  # [B x 1 x slen]
+        src_pad_mask = sequence_mask(src_len, src_max_len).unsqueeze(
+            1
+        )  # [B x 1 x slen]
         tgt_pad_mask = tgt[:, :, 0].eq(pad_idx).unsqueeze(1)  # [B, 1, T_tgt]
 
         with_align = kwargs.pop("with_align", False)
-        return_attn = kwargs.pop("return_attn", False)
-        return_attn = with_align or self._copy or return_attn
+        return_attn = with_align or self._copy or kwargs.pop("return_attn", False)
 
         attn_aligns = []
 

--- a/onmt/encoders/mean_encoder.py
+++ b/onmt/encoders/mean_encoder.py
@@ -30,7 +30,7 @@ class MeanEncoder(EncoderBase):
 
         if src_len is not None:
             # we avoid padding while mean pooling
-            mask = sequence_mask(src_len).float()
+            mask = (~sequence_mask(src_len)).float()
             mask = mask / src_len.unsqueeze(1).float()
             mean = torch.bmm(mask.unsqueeze(1), emb).squeeze(1)
         else:

--- a/onmt/encoders/transformer.py
+++ b/onmt/encoders/transformer.py
@@ -228,10 +228,9 @@ class TransformerEncoder(EncoderBase):
     def forward(self, src, src_len=None):
         """See :func:`EncoderBase.forward()`"""
         enc_out = self.embeddings(src)
-        mask = ~sequence_mask(src_len).unsqueeze(1)
-        mask = mask.unsqueeze(1)
+        mask = sequence_mask(src_len).unsqueeze(1).unsqueeze(1)
         mask = mask.expand(-1, -1, mask.size(3), -1)
-        # mask is now (batch x 1 x slen x slen)
+        # Padding mask is now (batch x 1 x slen x slen)
         # 1 to be expanded to number of heads in MHA
         # Run the forward pass of every layer of the tranformer.
 

--- a/onmt/inference_engine.py
+++ b/onmt/inference_engine.py
@@ -255,7 +255,7 @@ class InferenceEngineCT2(InferenceEngine):
     def _translate(self, infer_iter):
         scores = []
         preds = []
-        for batch in infer_iter:
+        for batch, bucket_idx in infer_iter:
             _scores, _preds = self.translate_batch(batch, self.opt)
             scores += _scores
             preds += _preds

--- a/onmt/inputters/text_corpus.py
+++ b/onmt/inputters/text_corpus.py
@@ -207,7 +207,8 @@ class ParallelCorpusIterator(object):
         for i, item in enumerate(stream):
             example = item[0]
             line_number = i * self.stride + self.offset
-            example["indices"] = line_number
+            example["cid_line_number"] = line_number
+            example["cid"] = self.cid
             if example["tgt"] is not None:
                 if (
                     len(example["src"]) == 0

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -123,6 +123,7 @@ def load_test_model(opt, device_id=0, model_path=None):
     model_opt.attention_dropout = (
         0.0  # required to force no dropout at inference with flash
     )
+
     model = build_base_model(model_opt, vocabs)
 
     precision = torch.float32
@@ -162,6 +163,7 @@ def load_test_model(opt, device_id=0, model_path=None):
     for name, module in model.named_modules():
         if hasattr(module, "dropout_p"):
             module.dropout_p = 0.0
+
     return vocabs, model, model_opt
 
 

--- a/onmt/modules/copy_generator.py
+++ b/onmt/modules/copy_generator.py
@@ -19,7 +19,7 @@ def collapse_copy_scores(
             src_vocab = batch["src_ex_vocab"][b]
         else:
             batch_id = batch_offset[b] if batch_offset is not None else b
-            index = batch["indices"].data[batch_id]
+            index = batch["ind_in_bucket"].data[batch_id]
             src_vocab = src_vocabs[index]
 
         for i in range(1, len(src_vocab)):
@@ -29,8 +29,8 @@ def collapse_copy_scores(
                 blank.append(offset + i)
                 fill.append(ti)
         if blank:
-            blank = torch.Tensor(blank).type_as(batch["indices"].data)
-            fill = torch.Tensor(fill).type_as(batch["indices"].data)
+            blank = torch.Tensor(blank).type_as(batch["ind_in_bucket"].data)
+            fill = torch.Tensor(fill).type_as(batch["ind_in_bucket"].data)
             score = scores[:, b] if batch_dim == 1 else scores[b]
             score.index_add_(1, fill, score.index_select(1, blank))
             score.index_fill_(1, blank, 1e-10)

--- a/onmt/modules/global_attention.py
+++ b/onmt/modules/global_attention.py
@@ -169,7 +169,7 @@ class GlobalAttention(nn.Module):
         align = self.score(src, enc_out)
 
         if src_len is not None:
-            mask = sequence_mask(src_len, max_len=align.size(-1))
+            mask = ~sequence_mask(src_len, max_len=align.size(-1))
             mask = mask.unsqueeze(1)  # Make it broadcastable.
             align.masked_fill_(~mask, -float("inf"))
 

--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -53,7 +53,7 @@ def relative_matmul(x: Tensor, z: Tensor, transpose: bool) -> Tensor:
     https://arxiv.org/pdf/1803.02155.pdf
     x shape [batch_size x heads x q_len x k_len]
     """
-    batch_size, heads, length = x.size()
+    batch_size, heads, length, _ = x.size()
     x_t = x.permute(2, 0, 1, 3)
     x_t_r = x_t.contiguous().view(length, heads * batch_size, -1)
     if transpose:

--- a/onmt/tests/pull_request_chk.sh
+++ b/onmt/tests/pull_request_chk.sh
@@ -176,8 +176,7 @@ ${PYTHON} onmt/bin/train.py \
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
 
-
-echo -n "  [+] Testing NMT training w/ validation with dynamic scoring and copy ..."
+echo -n "  [+] Testing NMT transformer training w/ validation with dynamic scoring and copy ..."
 ${PYTHON} onmt/bin/train.py \
             -config ${DATA_DIR}/data.yaml \
             -src_vocab $TMP_OUT_DIR/onmt.vocab.src \
@@ -200,6 +199,7 @@ ${PYTHON} onmt/bin/train.py \
             -tensorboard "true" \
             -scoring_debug "true" \
             -copy_attn \
+            -position_encoding \
             -dump_preds $TMP_OUT_DIR/dump_pred \
             -tensorboard_log_dir $TMP_OUT_DIR/logs_dynamic-scoring_and_copy >> ${LOG_FILE} 2>&1
       
@@ -207,6 +207,99 @@ ${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_dynamic-scoring_a
 [ "$?" -eq 0 ] || error_exit
 echo "Succeeded" | tee -a ${LOG_FILE}
 rm -r $TMP_OUT_DIR/logs_dynamic-scoring_and_copy
+
+echo -n "  [+] Testing NMT transformer training w/ validation with dynamic scoring and maxrelative ..."
+${PYTHON} onmt/bin/train.py \
+            -config ${DATA_DIR}/data.yaml \
+            -src_vocab $TMP_OUT_DIR/onmt.vocab.src \
+            -tgt_vocab $TMP_OUT_DIR/onmt.vocab.tgt \
+            -src_vocab_size 1000 \
+            -tgt_vocab_size 1000 \
+            -encoder_type transformer \
+            -decoder_type transformer \
+            -layers 4 \
+            -word_vec_size 16 \
+            -hidden_size 16 \
+            -num_workers 0 -bucket_size 1024 \
+            -heads 2 \
+            -transformer_ff 64 \
+            -bucket_size 1024 \
+            -train_steps 10 \
+            -report_every 2 \
+            -valid_steps 5 \
+            -valid_metrics "BLEU" "TER" \
+            -tensorboard "true" \
+            -scoring_debug "true" \
+            -max_relative_positions 8 \
+            -dump_preds $TMP_OUT_DIR/dump_pred \
+            -tensorboard_log_dir $TMP_OUT_DIR/logs_dynamic-scoring_and_relative >> ${LOG_FILE} 2>&1
+      
+${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_dynamic-scoring_and_relative -tensorboard_checks valid_metrics
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
+rm -r $TMP_OUT_DIR/logs_dynamic-scoring_and_relative
+
+echo -n "  [+] Testing NMT transformer training w/ validation with dynamic scoring and rotary ..."
+${PYTHON} onmt/bin/train.py \
+            -config ${DATA_DIR}/data.yaml \
+            -src_vocab $TMP_OUT_DIR/onmt.vocab.src \
+            -tgt_vocab $TMP_OUT_DIR/onmt.vocab.tgt \
+            -src_vocab_size 1000 \
+            -tgt_vocab_size 1000 \
+            -encoder_type transformer \
+            -decoder_type transformer \
+            -layers 4 \
+            -word_vec_size 16 \
+            -hidden_size 16 \
+            -num_workers 0 -bucket_size 1024 \
+            -heads 2 \
+            -transformer_ff 64 \
+            -bucket_size 1024 \
+            -train_steps 10 \
+            -report_every 2 \
+            -valid_steps 5 \
+            -valid_metrics "BLEU" "TER" \
+            -tensorboard "true" \
+            -scoring_debug "true" \
+            -max_relative_positions -1 \
+            -dump_preds $TMP_OUT_DIR/dump_pred \
+            -tensorboard_log_dir $TMP_OUT_DIR/logs_dynamic-scoring_and_rotary >> ${LOG_FILE} 2>&1
+      
+${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_dynamic-scoring_and_rotary -tensorboard_checks valid_metrics
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
+rm -r $TMP_OUT_DIR/logs_dynamic-scoring_and_rotary
+
+echo -n "  [+] Testing NMT transformer training w/ validation with dynamic scoring and alibi ..."
+${PYTHON} onmt/bin/train.py \
+            -config ${DATA_DIR}/data.yaml \
+            -src_vocab $TMP_OUT_DIR/onmt.vocab.src \
+            -tgt_vocab $TMP_OUT_DIR/onmt.vocab.tgt \
+            -src_vocab_size 1000 \
+            -tgt_vocab_size 1000 \
+            -encoder_type transformer \
+            -decoder_type transformer \
+            -layers 4 \
+            -word_vec_size 16 \
+            -hidden_size 16 \
+            -num_workers 0 -bucket_size 1024 \
+            -heads 2 \
+            -transformer_ff 64 \
+            -bucket_size 1024 \
+            -train_steps 10 \
+            -report_every 2 \
+            -valid_steps 5 \
+            -valid_metrics "BLEU" "TER" \
+            -tensorboard "true" \
+            -scoring_debug "true" \
+            -max_relative_positions -2 \
+            -dump_preds $TMP_OUT_DIR/dump_pred \
+            -tensorboard_log_dir $TMP_OUT_DIR/logs_dynamic-scoring_and_alibi >> ${LOG_FILE} 2>&1
+      
+${PYTHON} onmt/tests/test_events.py --logdir $TMP_OUT_DIR/logs_dynamic-scoring_and_alibi -tensorboard_checks valid_metrics
+[ "$?" -eq 0 ] || error_exit
+echo "Succeeded" | tee -a ${LOG_FILE}
+rm -r $TMP_OUT_DIR/logs_dynamic-scoring_and_alibi
 
 echo -n "  [+] Testing LM training..."
 ${PYTHON} onmt/bin/train.py \

--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -235,7 +235,7 @@ class Trainer(object):
         batches = []
         normalization = 0
         self.accum_count = self._accum_count(self.optim.training_step)
-        for batch in iterator:
+        for batch, bucket_idx in iterator:
             batches.append(batch)
             if self.norm_method == "tokens":
                 num_tokens = (
@@ -388,7 +388,7 @@ class Trainer(object):
         with torch.no_grad():
             stats = onmt.utils.Statistics()
             start = time.time()
-            for batch in valid_iter:
+            for batch, bucket_idx in valid_iter:
                 src = batch["src"]
                 src_len = batch["srclen"]
                 tgt = batch["tgt"]

--- a/onmt/transforms/docify.py
+++ b/onmt/transforms/docify.py
@@ -68,7 +68,9 @@ class DocifyTransform(Transform):
         doc = {}
         doc["src"] = []
         doc["tgt"] = []
-        doc["indices"] = 0
+        doc["ind_in_bucket"] = 0
+        doc["cid"] = ""
+        doc["cid_line_number"] = 0
 
         for ex, _, cid in batch:
             if ex["tgt"] is not None:
@@ -80,7 +82,9 @@ class DocifyTransform(Transform):
                     doc = {}
                     doc["src"] = []
                     doc["tgt"] = []
-                    doc["indices"] = ex["indices"]
+                    doc["ind_in_bucket"] = ex["ind_in_bucket"]
+                    doc["cid"] = ex["cid"]
+                    doc["cid_line_number"] = ex["cid_line_number"]
                 elif cur_len > self.doc_length:
                     if len(doc["src"]) == 0:
                         # case 1st ex is already longer
@@ -106,7 +110,9 @@ class DocifyTransform(Transform):
                             doc = {}
                             doc["src"] = []
                             doc["tgt"] = []
-                            doc["indices"] = ex["indices"]
+                            doc["ind_in_bucket"] = ex["ind_in_bucket"]
+                            doc["cid"] = ex["cid"]
+                            doc["cid_line_number"] = ex["cid_line_number"]
             else:
                 cur_len = len(doc["src"] + ex["src"])
                 doc["tgt"] = None
@@ -132,7 +138,9 @@ class DocifyTransform(Transform):
                             trf_batch.append((doc, self, cid))
                             doc = {}
                             doc["src"] = []
-                            doc["indices"] = ex["indices"]
+                            doc["ind_in_bucket"] = ex["ind_in_bucket"]
+                            doc["cid"] = ex["cid"]
+                            doc["cid_line_number"] = ex["cid_line_number"]
         if len(doc["src"]) > 0:
             trf_batch.append((doc, self, cid))
         return trf_batch

--- a/onmt/transforms/transform.py
+++ b/onmt/transforms/transform.py
@@ -66,8 +66,8 @@ class Transform(object):
             is_train (bool): Indicate if src/tgt is training data;bject.
         """
         transformed_batch = []
-        for example, _, cid in batch:
-            example = self.apply(example, is_train=is_train, **kwargs)
+        for exemple, _, cid in batch:
+            example = self.apply(exemple, is_train=is_train, **kwargs)
             if example is not None:
                 transformed_batch.append((example, self, cid))
         return transformed_batch

--- a/onmt/transforms/transform.py
+++ b/onmt/transforms/transform.py
@@ -66,8 +66,8 @@ class Transform(object):
             is_train (bool): Indicate if src/tgt is training data;bject.
         """
         transformed_batch = []
-        for exemple, _, cid in batch:
-            example = self.apply(exemple, is_train=is_train, **kwargs)
+        for example, _, cid in batch:
+            example = self.apply(example, is_train=is_train, **kwargs)
             if example is not None:
                 transformed_batch.append((example, self, cid))
         return transformed_batch

--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -73,7 +73,7 @@ class TranslationBuilder(object):
             translation_batch["attention"],
             translation_batch["alignment"],
             translation_batch["gold_score"],
-            batch["indices"],
+            batch["ind_in_bucket"],
         )
 
         if not any(align):  # when align is a empty nested list
@@ -159,7 +159,7 @@ class Translation(object):
         "gold_sent",
         "gold_score",
         "word_aligns",
-        "indices",
+        "ind_in_bucket",
     ]
 
     def __init__(
@@ -172,7 +172,7 @@ class Translation(object):
         tgt_sent,
         gold_score,
         word_aligns,
-        indices,
+        ind_in_bucket,
     ):
         self.src = src
         self.srclen = srclen
@@ -182,7 +182,7 @@ class Translation(object):
         self.gold_sent = tgt_sent
         self.gold_score = gold_score
         self.word_aligns = word_aligns
-        self.indices = indices
+        self.ind_in_bucket = ind_in_bucket
 
     def log(self, sent_number, src_raw=""):
         """

--- a/onmt/translate/translation.py
+++ b/onmt/translate/translation.py
@@ -40,7 +40,7 @@ class TranslationBuilder(object):
                 voc[tok]
                 if tok < len(voc)
                 else dyn_voc.ids_to_tokens[tok - len(self.vocabs["src"].ids_to_tokens)]
-                for tok in pred
+                for tok in pred.tolist()
             ]
         if tokens[-1] == DefaultTokens.EOS:
             tokens = tokens[:-1]

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -406,7 +406,7 @@ class Inference(object):
             bucket_translations = sorted(
                 bucket_translations, key=lambda x: x.ind_in_bucket
             )
-            for j, trans in enumerate(bucket_translations):
+            for trans in bucket_translations:
                 bucket_scores += [trans.pred_scores[: self.n_best]]
                 bucket_score += trans.pred_scores[0]
                 bucket_words += len(trans.pred_sents[0])
@@ -416,10 +416,6 @@ class Inference(object):
 
                 n_best_preds = [
                     " ".join(pred) for pred in trans.pred_sents[: self.n_best]
-                ]
-
-                n_best_scores = [
-                    score.item() for score in trans.pred_scores[: self.n_best]
                 ]
 
                 if self.report_align:
@@ -440,12 +436,14 @@ class Inference(object):
 
                 bucket_predictions += [n_best_preds]
 
-                out_all = [
-                    pred + "\t" + str(score)
-                    for (pred, score) in zip(n_best_preds, n_best_scores)
-                ]
-
                 if self.with_score:
+                    n_best_scores = [
+                        score.item() for score in trans.pred_scores[: self.n_best]
+                    ]
+                    out_all = [
+                        pred + "\t" + str(score)
+                        for (pred, score) in zip(n_best_preds, n_best_scores)
+                    ]
                     self.out_file.write("\n".join(out_all) + "\n")
                 else:
                     self.out_file.write("\n".join(n_best_preds) + "\n")
@@ -506,6 +504,7 @@ class Inference(object):
         prev_idx = 0
 
         for batch, bucket_idx in infer_iter:
+
             batch_data = self.translate_batch(batch, attn_debug)
 
             translations = xlation_builder.from_batch(batch_data)

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -346,7 +346,7 @@ class Inference(object):
         def _maybe_retranslate(translations, batch):
             """Here we handle the cases of mismatch in number of segments
             between source and target. We re-translate seg by seg."""
-            inds, perm = torch.sort(batch["indices"])
+            inds, perm = torch.sort(batch["ind_in_bucket"])
             trans_copy = deepcopy(translations)
             inserted_so_far = 0
             for j, trans in enumerate(translations):
@@ -382,7 +382,7 @@ class Inference(object):
                     t_sub_batch = {
                         "src": t_sub_src.to(device),
                         "srclen": t_sub_src_len.to(device),
-                        "indices": t_sub_src_ind.to(device),
+                        "ind_in_bucket": t_sub_src_ind.to(device),
                     }
                     # new sub-batch ready to be translated
                     sub_data = self.translate_batch(t_sub_batch, attn_debug)
@@ -395,27 +395,24 @@ class Inference(object):
                     inserted_so_far += len(sub_src) - 1
             return trans_copy
 
-        for batch in infer_iter:
-            batch_data = self.translate_batch(batch, attn_debug)
-
-            translations = xlation_builder.from_batch(batch_data)
-            if (
-                not isinstance(self, GeneratorLM)
-                and self._tgt_sep_idx != self._tgt_unk_idx
-                and (batch["src"] == self._tgt_sep_idx).any().item()
-            ):
-                # For seq2seq when we need to force doc to spit the same number of sents
-                translations = _maybe_retranslate(translations, batch)
-
+        def _process_bucket(bucket_translations):
+            bucket_scores = []
+            bucket_predictions = []
+            bucket_score = 0
+            bucket_words = 0
+            bucket_gold_score = 0
+            bucket_gold_words = 0
             voc_src = self.vocabs["src"].ids_to_tokens
-
-            for j, trans in enumerate(translations):
-                all_scores += [trans.pred_scores[: self.n_best]]
-                pred_score_total += trans.pred_scores[0]
-                pred_words_total += len(trans.pred_sents[0])
+            bucket_translations = sorted(
+                bucket_translations, key=lambda x: x.ind_in_bucket
+            )
+            for j, trans in enumerate(bucket_translations):
+                bucket_scores += [trans.pred_scores[: self.n_best]]
+                bucket_score += trans.pred_scores[0]
+                bucket_words += len(trans.pred_sents[0])
                 if "tgt" in batch.keys():
-                    gold_score_total += trans.gold_score
-                    gold_words_total += len(trans.gold_sent) + 1
+                    bucket_gold_score += trans.gold_score
+                    bucket_gold_words += len(trans.gold_sent) + 1
 
                 n_best_preds = [
                     " ".join(pred) for pred in trans.pred_sents[: self.n_best]
@@ -441,7 +438,7 @@ class Inference(object):
                 if transform_pipe is not None:
                     n_best_preds = transform_pipe.batch_apply_reverse(n_best_preds)
 
-                all_predictions += [n_best_preds]
+                bucket_predictions += [n_best_preds]
 
                 out_all = [
                     pred + "\t" + str(score)
@@ -496,6 +493,71 @@ class Inference(object):
                         self.logger.info(output)
                     else:
                         os.write(1, output.encode("utf-8"))
+            return (
+                bucket_scores,
+                bucket_predictions,
+                bucket_score,
+                bucket_words,
+                bucket_gold_score,
+                bucket_gold_words,
+            )
+
+        bucket_translations = []
+        prev_idx = 0
+
+        for batch, bucket_idx in infer_iter:
+            batch_data = self.translate_batch(batch, attn_debug)
+
+            translations = xlation_builder.from_batch(batch_data)
+            if (
+                not isinstance(self, GeneratorLM)
+                and self._tgt_sep_idx != self._tgt_unk_idx
+                and (batch["src"] == self._tgt_sep_idx).any().item()
+            ):
+                # For seq2seq when we need to force doc to spit the same number of sents
+                translations = _maybe_retranslate(translations, batch)
+
+            bucket_translations += translations
+
+            if (
+                not isinstance(infer_iter, list)
+                and len(bucket_translations) >= infer_iter.bucket_size
+            ):
+                bucket_idx += 1
+
+            if bucket_idx != prev_idx:
+                prev_idx = bucket_idx
+                (
+                    bucket_scores,
+                    bucket_predictions,
+                    bucket_score,
+                    bucket_words,
+                    bucket_gold_score,
+                    bucket_gold_words,
+                ) = _process_bucket(bucket_translations)
+                all_scores += bucket_scores
+                all_predictions += bucket_predictions
+                pred_score_total += bucket_score
+                pred_words_total += bucket_words
+                gold_score_total += bucket_gold_score
+                gold_words_total += bucket_gold_words
+                bucket_translations = []
+
+        if len(bucket_translations) > 0:
+            (
+                bucket_scores,
+                bucket_predictions,
+                bucket_score,
+                bucket_words,
+                bucket_gold_score,
+                bucket_gold_words,
+            ) = _process_bucket(bucket_translations)
+            all_scores += bucket_scores
+            all_predictions += bucket_predictions
+            pred_score_total += bucket_score
+            pred_words_total += bucket_words
+            gold_score_total += bucket_gold_score
+            gold_words_total += bucket_gold_words
 
         end_time = time.time()
 

--- a/onmt/utils/misc.py
+++ b/onmt/utils/misc.py
@@ -54,14 +54,8 @@ def sequence_mask(lengths, max_len=None):
     """
     Creates a boolean mask from sequence lengths.
     """
-    batch_size = lengths.numel()
     max_len = max_len or lengths.max()
-    return (
-        torch.arange(0, max_len, device=lengths.device)
-        .type_as(lengths)
-        .repeat(batch_size, 1)
-        .lt(lengths.unsqueeze(1))
-    )
+    return torch.arange(0, max_len, device=lengths.device) >= lengths.unsqueeze(1)
 
 
 def tile(x, count, dim=0):

--- a/tools/LM_scoring.py
+++ b/tools/LM_scoring.py
@@ -102,7 +102,7 @@ def main():
         cumul_length += batch["tgt"][:, 1:, 0].ne(padding_idx).sum().cpu()
         # Now we need to rearrange the batch of ppl
         # in the original order with indices
-        sent_ppl_orig = ppl.gather(0, batch["indices"].argsort(0))
+        sent_ppl_orig = ppl.gather(0, batch["cid_line_number"].argsort(0))
         for j in range(batch_size):
             ppl_file.write(str(sent_ppl_orig[j].item()) + "\n")
     logger.info(


### PR DESCRIPTION
This PR has the following purposes:

- get rid of the old batch["indices"] key which was not actually used.
- introduce the following keys
batch["cid"]: identify the corpus id of the example
batch["cid_line_number"]: identify the corpus id line number
these two keys will be helpful to retrieve the lines where a training stopped and resume training at those lines
one other key:
batch["ind_in_bucket"] de facto replaces the "indices" but represents the index in the current bucket

This PR hence will sort buckets ALSO at inference (was doing it at training) which will speed up the inference and then after translation we reorder the translations from these "ind_in_bucket".

