### PR TITLE
Skipinit Generator and Embeddings

### DIFF
--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -341,7 +341,11 @@ def build_base_model(model_opt, vocabs):
 
     # Build Generator.
     if not model_opt.copy_attn:
-        generator = skip_init(nn.Linear, in_features=model_opt.dec_hid_size, out_features=len(vocabs["tgt"]))
+        generator = skip_init(
+            nn.Linear,
+            in_features=model_opt.dec_hid_size,
+            out_features=len(vocabs["tgt"]),
+        )
         if model_opt.share_decoder_embeddings:
             generator.weight = model.decoder.embeddings.word_lut.weight
     else:

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -4,6 +4,7 @@ and creates each encoder and decoder accordingly.
 """
 import torch
 import torch.nn as nn
+from torch.nn.utils import skip_init
 from torch.nn.init import xavier_uniform_, zeros_, uniform_
 import onmt.modules
 from onmt.encoders import str2enc
@@ -340,7 +341,7 @@ def build_base_model(model_opt, vocabs):
 
     # Build Generator.
     if not model_opt.copy_attn:
-        generator = nn.Linear(model_opt.dec_hid_size, len(vocabs["tgt"]))
+        generator = skip_init(nn.Linear, in_features=model_opt.dec_hid_size, out_features=len(vocabs["tgt"]))
         if model_opt.share_decoder_embeddings:
             generator.weight = model.decoder.embeddings.word_lut.weight
     else:

--- a/onmt/modules/embeddings.py
+++ b/onmt/modules/embeddings.py
@@ -4,6 +4,7 @@ import warnings
 
 import torch
 import torch.nn as nn
+from torch.nn.utils import skip_init
 
 from onmt.modules.util_class import Elementwise
 from onmt.utils.logging import logger
@@ -171,7 +172,7 @@ class Embeddings(nn.Module):
         # is for words. Subsequent ones are for features, if any exist.
         emb_params = zip(vocab_sizes, emb_dims, pad_indices)
         embeddings = [
-            nn.Embedding(vocab, dim, padding_idx=pad, sparse=sparse)
+            skip_init(nn.Embedding, num_embeddings=vocab, embedding_dim=dim, padding_idx=pad, sparse=sparse)
             for vocab, dim, pad in emb_params
         ]
         emb_luts = Elementwise(feat_merge, embeddings)

--- a/onmt/modules/embeddings.py
+++ b/onmt/modules/embeddings.py
@@ -172,7 +172,13 @@ class Embeddings(nn.Module):
         # is for words. Subsequent ones are for features, if any exist.
         emb_params = zip(vocab_sizes, emb_dims, pad_indices)
         embeddings = [
-            skip_init(nn.Embedding, num_embeddings=vocab, embedding_dim=dim, padding_idx=pad, sparse=sparse)
+            skip_init(
+                nn.Embedding,
+                num_embeddings=vocab,
+                embedding_dim=dim,
+                padding_idx=pad,
+                sparse=sparse,
+            )
             for vocab, dim, pad in emb_params
         ]
         emb_luts = Elementwise(feat_merge, embeddings)

--- a/onmt/tests/test_embeddings.py
+++ b/onmt/tests/test_embeddings.py
@@ -5,7 +5,7 @@ import itertools
 from copy import deepcopy
 
 import torch
-
+from torch.nn.init import xavier_uniform_
 from onmt.tests.utils_for_tests import product_dict
 
 
@@ -141,6 +141,9 @@ class TestEmbeddings(unittest.TestCase):
                 n: p for n, p in emb.named_parameters() if p.requires_grad
             }
             if len(trainable_params) > 0:
+                for n, p in emb.named_parameters():
+                    if n == "weight" and p.dim() > 1:
+                        xavier_uniform_(p)
                 old_weights = deepcopy(trainable_params)
                 dummy_in = self.dummy_inputs(params, init_case)
                 res = emb(dummy_in)


### PR DESCRIPTION
This should have been done while we did it for all other layers.

It makes LLM loading faster (1.5 sec less for a 7B model)

At training this will change slightly because by default:
nn.Linear uses uniform_
nn.Embedding uses normal_
for both it will now be the same as others xavier_uniform_
I tested, impact is almost nil.