### PR TITLE
Check if input tensor is empty before reducing and rescaling

### DIFF
--- a/onmt/utils/distributed.py
+++ b/onmt/utils/distributed.py
@@ -47,9 +47,10 @@ def all_reduce_and_rescale_tensors(tensors, rescale_denom, buffer_size=104857600
         buffer_size: all-reduce chunk size in bytes
     """
     # buffer size in bytes, determine equiv. # of elements based on data type
-    buffer_t = (
-        tensors[0].new(math.ceil(buffer_size / tensors[0].element_size())).zero_()
-    )
+    if len(tensors) > 0:
+        buffer_t = (
+            tensors[0].new(math.ceil(buffer_size / tensors[0].element_size())).zero_()
+        )
     buffer = []
 
     def all_reduce_buffer():


### PR DESCRIPTION
The goal of this PR is to solve the following error when the parameter `tensors` of the function `all_reduce_and_rescale_tensors` is empty:
```bash
Traceback (most recent call last):
  File "/opt/conda/bin/onmt_train", line 8, in <module>
    sys.exit(main())
  File "/opt/conda/lib/python3.10/site-packages/onmt/bin/train.py", line 67, in main
    train(opt)
  File "/opt/conda/lib/python3.10/site-packages/onmt/bin/train.py", line 49, in train
    p.join()
  File "/opt/conda/lib/python3.10/multiprocessing/process.py", line 149, in join
    res = self._popen.wait(timeout)
  File "/opt/conda/lib/python3.10/multiprocessing/popen_fork.py", line 43, in wait
    return self.poll(os.WNOHANG if timeout == 0.0 else 0)
  File "/opt/conda/lib/python3.10/multiprocessing/popen_fork.py", line 27, in poll
    pid, sts = os.waitpid(self.pid, flag)
  File "/opt/conda/lib/python3.10/site-packages/onmt/utils/distributed.py", line 165, in signal_handler
    raise Exception(msg)
Exception: 

-- Tracebacks above this line can probably
                 be ignored --


Traceback (most recent call last):
  File "/opt/conda/lib/python3.10/site-packages/onmt/utils/distributed.py", line 177, in spawned_train
    process_fn(opt, device_id=device_id)
  File "/opt/conda/lib/python3.10/site-packages/onmt/train_single.py", line 237, in main
    trainer.train(
  File "/opt/conda/lib/python3.10/site-packages/onmt/trainer.py", line 319, in train
    self._gradient_accumulation(
  File "/opt/conda/lib/python3.10/site-packages/onmt/trainer.py", line 546, in _gradient_accumulation
    onmt.utils.distributed.all_reduce_and_rescale_tensors(
  File "/opt/conda/lib/python3.10/site-packages/onmt/utils/distributed.py", line 51, in all_reduce_and_rescale_tensors
    tensors[0].new(math.ceil(buffer_size / tensors[0].element_size())).zero_()
IndexError: list index out of range
```