### PR TITLE
use flash_attn_with_kvcache for faster inference

### DIFF
--- a/onmt/decoders/transformer.py
+++ b/onmt/decoders/transformer.py
@@ -40,6 +40,7 @@ class TransformerDecoderLayerBase(nn.Module):
         parallel_gpu=1,
         sliding_window=0,
         rotary_interleave=True,
+        rotary_theta=1e4,
         num_experts=0,
         num_experts_per_tok=2,
     ):
@@ -85,6 +86,7 @@ class TransformerDecoderLayerBase(nn.Module):
             sliding_window (int): Width of the band mask and KV cache (cf Mistral Model)
             rotary_interleave (bool): Interleave the head dimensions when rotary
                 embeddings are applied
+            rotary_theta (int): rotary base theta
         """
         super(TransformerDecoderLayerBase, self).__init__()
 
@@ -96,6 +98,7 @@ class TransformerDecoderLayerBase(nn.Module):
                 max_relative_positions=max_relative_positions,
                 relative_positions_buckets=relative_positions_buckets,
                 rotary_interleave=rotary_interleave,
+                rotary_theta=rotary_theta,
                 attn_type="self",
                 self_attn_type=self_attn_type,
                 add_qkvbias=add_qkvbias,
@@ -276,6 +279,7 @@ class TransformerDecoderLayer(TransformerDecoderLayerBase):
         parallel_gpu=1,
         sliding_window=0,
         rotary_interleave=True,
+        rotary_theta=1e4,
         num_experts=0,
         num_experts_per_tok=2,
     ):
@@ -307,6 +311,7 @@ class TransformerDecoderLayer(TransformerDecoderLayerBase):
             parallel_gpu=parallel_gpu,
             sliding_window=sliding_window,
             rotary_interleave=rotary_interleave,
+            rotary_theta=rotary_theta,
             num_experts=num_experts,
             num_experts_per_tok=num_experts_per_tok,
         )
@@ -469,6 +474,7 @@ class TransformerDecoderBase(DecoderBase):
             else 1,
             sliding_window=opt.sliding_window,
             rotary_interleave=opt.rotary_interleave,
+            rotary_theta=opt.rotary_theta,
             num_experts=opt.num_experts,
             num_experts_per_tok=opt.num_experts_per_tok,
         )
@@ -559,6 +565,7 @@ class TransformerDecoder(TransformerDecoderBase):
         parallel_gpu (int): Number of gpu for tensor parallelism
         sliding_window (int): Width of the band mask and KV cache (cf Mistral Model)
         rotary_interleave (bool): Interleave the head dimensions when rotary embeddings are applied
+        rotary_theta (int): rotary base theta
     """
 
     def __init__(
@@ -590,6 +597,7 @@ class TransformerDecoder(TransformerDecoderBase):
         parallel_gpu=1,
         sliding_window=0,
         rotary_interleave=True,
+        rotary_theta=1e4,
         num_experts=0,
         num_experts_per_tok=2,
     ):
@@ -623,6 +631,7 @@ class TransformerDecoder(TransformerDecoderBase):
                     parallel_gpu=parallel_gpu,
                     sliding_window=sliding_window,
                     rotary_interleave=rotary_interleave,
+                    rotary_theta=rotary_theta,
                     num_experts=num_experts,
                     num_experts_per_tok=num_experts_per_tok,
                 )
@@ -830,6 +839,7 @@ class TransformerLMDecoder(TransformerDecoderBase):
         parallel_gpu (int): Number of gpu for tensor parallelism
         sliding_window (int): Width of the band mask and KV cache (cf Mistral Model)
         rotary_interleave (bool): Interleave the head dimensions when rotary embeddings are applied
+        rotary_theta (int): rotary base theta
     """
 
     def __init__(
@@ -861,6 +871,7 @@ class TransformerLMDecoder(TransformerDecoderBase):
         parallel_gpu=1,
         sliding_window=0,
         rotary_interleave=True,
+        rotary_theta=1e4,
         num_experts=0,
         num_experts_per_tok=2,
     ):
@@ -893,6 +904,7 @@ class TransformerLMDecoder(TransformerDecoderBase):
                     parallel_gpu=parallel_gpu,
                     sliding_window=sliding_window,
                     rotary_interleave=rotary_interleave,
+                    rotary_theta=rotary_theta,
                     num_experts=num_experts,
                     num_experts_per_tok=num_experts_per_tok,
                 )

--- a/onmt/encoders/transformer.py
+++ b/onmt/encoders/transformer.py
@@ -40,6 +40,7 @@ class TransformerEncoderLayer(nn.Module):
         parallel_gpu (int): Number of gpu for tensor parallelism
         rotary_interleave (bool): Interleave the head dimensions when rotary
             embeddings are applied
+        rotary_theta (int): rotary base theta
     """
 
     def __init__(
@@ -61,6 +62,7 @@ class TransformerEncoderLayer(nn.Module):
         use_ckpting=[],
         parallel_gpu=1,
         rotary_interleave=True,
+        rotary_theta=1e4,
     ):
         super(TransformerEncoderLayer, self).__init__()
 
@@ -72,6 +74,7 @@ class TransformerEncoderLayer(nn.Module):
             max_relative_positions=max_relative_positions,
             relative_positions_buckets=relative_positions_buckets,
             rotary_interleave=rotary_interleave,
+            rotary_theta=rotary_theta,
             attn_type="self",
             add_qkvbias=add_qkvbias,
             num_kv=num_kv,
@@ -177,6 +180,7 @@ class TransformerEncoder(EncoderBase):
         use_ckpting=[],
         parallel_gpu=1,
         rotary_interleave=True,
+        rotary_theta=1e4,
     ):
         super(TransformerEncoder, self).__init__()
 
@@ -201,6 +205,7 @@ class TransformerEncoder(EncoderBase):
                     use_ckpting=use_ckpting,
                     parallel_gpu=parallel_gpu,
                     rotary_interleave=rotary_interleave,
+                    rotary_theta=rotary_theta,
                 )
                 for i in range(num_layers)
             ]
@@ -239,6 +244,7 @@ class TransformerEncoder(EncoderBase):
             if opt.parallel_mode == "tensor_parallel"
             else 1,
             rotary_interleave=opt.rotary_interleave,
+            rotary_theta=opt.rotary_theta,
         )
 
     def forward(self, src, src_len=None):

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -145,6 +145,7 @@ def load_test_model(opt, device_id=0, model_path=None):
         0.0  # required to force no dropout at inference with flash
     )
 
+    model_opt.max_length = opt.max_length
     model = build_base_model(model_opt, vocabs)
 
     precision = torch.float32

--- a/onmt/model_builder.py
+++ b/onmt/model_builder.py
@@ -148,7 +148,6 @@ def load_test_model(opt, device_id=0, model_path=None):
         0.0  # required to force no dropout at inference with flash
     )
 
-    model_opt.max_length = opt.max_length
     model = build_base_model(model_opt, vocabs)
 
     precision = torch.float32

--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -514,6 +514,8 @@ class MultiHeadedAttention(torch.nn.Module):
                         rotary_interleaved=self.rotary_interleave,
                     ).transpose(1, 2)
                     attn_output = self.final_linear(unshape(context))
+                    if self.parallel_gpu > 1:
+                        all_reduce(attn_output)
                     return attn_output, None
 
             elif self.attn_type == "context":

--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -439,6 +439,7 @@ class MultiHeadedAttention(torch.nn.Module):
                     or not self.flash2
                     or self.max_relative_positions not in [0, -1]
                     or query.size(0) > 8
+                    or query.dtype != torch.float16
                 ):
                     if self.max_relative_positions == -1:  # Rotary Embeddings
                         if seqlen > self.rope.size(0):

--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -509,8 +509,12 @@ class MultiHeadedAttention(torch.nn.Module):
                             dim=-2,
                         )
                     if sliding_window > 0 and key.size(2) > sliding_window:
-                        self.layer_cache[1]["keys"] = self.layer_cache[1]["keys"][:, :, 1:, :]
-                        self.layer_cache[1]["values"] = self.layer_cache[1]["values"][:, :, 1:, :]
+                        self.layer_cache[1]["keys"] = self.layer_cache[1]["keys"][
+                            :, :, 1:, :
+                        ]
+                        self.layer_cache[1]["values"] = self.layer_cache[1]["values"][
+                            :, :, 1:, :
+                        ]
                     context = self.flash_attn_with_kvcache(
                         query.transpose(1, 2),
                         self.layer_cache[1]["keys"].transpose(1, 2),

--- a/onmt/modules/position_ffn.py
+++ b/onmt/modules/position_ffn.py
@@ -5,9 +5,14 @@ import torch.nn.functional as F
 from torch.utils.checkpoint import checkpoint
 
 try:
-    from apex.normalization import FusedRMSNorm as RMSNorm
-except ImportError:
+    import awq_inference_engine
     from onmt.modules.rmsnorm import RMSNorm
+except ImportError:
+    try:
+        from apex.normalization import FusedRMSNorm as RMSNorm
+    except ImportError:
+        from onmt.modules.rmsnorm import RMSNorm
+
 from torch.nn.utils import skip_init
 from torch.distributed import all_reduce
 

--- a/onmt/modules/position_ffn.py
+++ b/onmt/modules/position_ffn.py
@@ -3,16 +3,7 @@
 import torch.nn as nn
 import torch.nn.functional as F
 from torch.utils.checkpoint import checkpoint
-
-try:
-    import awq_inference_engine
-    from onmt.modules.rmsnorm import RMSNorm
-except ImportError:
-    try:
-        from apex.normalization import FusedRMSNorm as RMSNorm
-    except ImportError:
-        from onmt.modules.rmsnorm import RMSNorm
-
+from onmt.modules.rmsnorm import RMSNorm
 from torch.nn.utils import skip_init
 from torch.distributed import all_reduce
 

--- a/onmt/modules/rmsnorm.py
+++ b/onmt/modules/rmsnorm.py
@@ -26,12 +26,12 @@ class RMSNorm(torch.nn.Module):
     def forward(self, hidden_states):
         if AWQ_INFERENCE_ENGINE:
             output = torch.empty_like(hidden_states)
-            if hidden_states.dim() == 2: # patch for multi experts
+            if hidden_states.dim() == 2:  # patch for multi experts
                 hidden_states = hidden_states.unsqueeze(0)
             awq_inference_engine.layernorm_forward_cuda(
                 hidden_states, self.weight, output, self.eps
             )
-            if hidden_states.dim() == 2: # patch for multi experts
+            if hidden_states.dim() == 2:  # patch for multi experts
                 output = output.unsqueeze(0)
             return output
         else:

--- a/onmt/modules/rmsnorm.py
+++ b/onmt/modules/rmsnorm.py
@@ -3,11 +3,19 @@
 import torch
 import torch.nn as nn
 
+try:
+    import awq_inference_engine
+
+    AWQ_INFERENCE_ENGINE = True
+except:
+    AWQ_INFERENCE_ENGINE = False
+
 
 class RMSNorm(torch.nn.Module):
     """RMSNorm: https://arxiv.org/abs/1910.07467
     Args:
-        hidden_size (int): layer hidden_sizeension.
+        hidden_size (int): layer hidden_size dimension.
+        eps: variance epsilon.
     """
 
     def __init__(self, hidden_size: int, eps: float = 1e-6):
@@ -16,8 +24,15 @@ class RMSNorm(torch.nn.Module):
         self.weight = nn.Parameter(torch.ones(hidden_size))
 
     def forward(self, hidden_states):
-        hidden_states = hidden_states.to(torch.float32)
-        variance = hidden_states.pow(2).mean(-1, keepdim=True)
-        hidden_states = hidden_states * torch.rsqrt(variance + self.eps)
-        hidden_states = hidden_states.to(self.weight.dtype)
-        return hidden_states * self.weight
+        if AWQ_INFERENCE_ENGINE:
+            output = torch.empty_like(hidden_states)
+            awq_inference_engine.layernorm_forward_cuda(
+                hidden_states, self.weight, output, self.eps
+            )
+            return output
+        else:
+            hidden_states = hidden_states.to(torch.float32)
+            variance = hidden_states.pow(2).mean(-1, keepdim=True)
+            hidden_states = hidden_states * torch.rsqrt(variance + self.eps)
+            hidden_states = hidden_states.to(self.weight.dtype)
+            return hidden_states * self.weight

--- a/onmt/modules/rmsnorm.py
+++ b/onmt/modules/rmsnorm.py
@@ -6,8 +6,8 @@ import torch.nn as nn
 try:
     import awq_inference_engine
 
-    AWQ_INFERENCE_ENGINE = True
-except:
+    AWQ_INFERENCE_ENGINE = False
+except ImportError:
     AWQ_INFERENCE_ENGINE = False
 
 

--- a/onmt/modules/rmsnorm.py
+++ b/onmt/modules/rmsnorm.py
@@ -6,7 +6,7 @@ import torch.nn as nn
 try:
     import awq_inference_engine
 
-    AWQ_INFERENCE_ENGINE = False
+    AWQ_INFERENCE_ENGINE = True
 except ImportError:
     AWQ_INFERENCE_ENGINE = False
 

--- a/onmt/modules/rmsnorm.py
+++ b/onmt/modules/rmsnorm.py
@@ -26,9 +26,13 @@ class RMSNorm(torch.nn.Module):
     def forward(self, hidden_states):
         if AWQ_INFERENCE_ENGINE:
             output = torch.empty_like(hidden_states)
+            if hidden_states.dim() == 2: # patch for multi experts
+                hidden_states = hidden_states.unsqueeze(0)
             awq_inference_engine.layernorm_forward_cuda(
                 hidden_states, self.weight, output, self.eps
             )
+            if hidden_states.dim() == 2: # patch for multi experts
+                output = output.unsqueeze(0)
             return output
         else:
             hidden_states = hidden_states.to(torch.float32)

--- a/onmt/opts.py
+++ b/onmt/opts.py
@@ -881,6 +881,13 @@ def model_opts(parser):
         "False = used by all Hugging face models",
     )
     group.add(
+        "--rotary_theta",
+        "-rotary_theta",
+        type=int,
+        default=10000,
+        help="Rotary theta base length" "1e4 for Llama2.Mistral" "1e6 for Mixtral",
+    )
+    group.add(
         "--heads",
         "-heads",
         type=int,

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -1113,7 +1113,7 @@ class GeneratorLM(Inference):
                 batch,
                 src_len=decode_strategy.src_len,
                 src_map=src_map,
-                step=step if step == 0 else step + max(src_len.tolist()) - 1,
+                step=step if step == 0 else step + max(src_len.tolist()),
                 batch_offset=decode_strategy.batch_offset,
             )
 

--- a/onmt/translate/translator.py
+++ b/onmt/translate/translator.py
@@ -1102,6 +1102,7 @@ class GeneratorLM(Inference):
         )
 
         # (4) Begin decoding step by step:
+        beg_time = time()
         for step in range(decode_strategy.max_length):
             decoder_input = (
                 src if step == 0 else decode_strategy.current_predictions.view(-1, 1, 1)
@@ -1139,6 +1140,8 @@ class GeneratorLM(Inference):
             if parallel_paths > 1 or any_finished:
                 # select indexes in model state/cache
                 self.model.decoder.map_state(lambda state, dim: state[select_indices])
+            if step == 0:
+                print("step0 time: ", time() - beg_time)
 
         return self.report_results(
             gold_score,

--- a/onmt/utils/distributed.py
+++ b/onmt/utils/distributed.py
@@ -212,7 +212,7 @@ def spawned_infer(opt, device_id, error_queue, queue_instruct, queue_result):
                     device_id=device_id,
                 )
                 scores, preds = translator._translate(
-                    infer_iter, infer_iter.transform, opt.attn_debug, opt.align_debug
+                    infer_iter, infer_iter.transforms, opt.attn_debug, opt.align_debug
                 )
                 queue_result.put(scores)
                 queue_result.put(preds)

--- a/tools/convert_HF_llamalike.py
+++ b/tools/convert_HF_llamalike.py
@@ -223,8 +223,14 @@ if __name__ == "__main__":
         norm_eps = config["layer_norm_epsilon"]
     else:
         norm_eps = 1e-6
+    if "rope_theta" in config.keys():
+        rope_theta = config["rope_theta"]
+    else:
+        rope_theta = 1e4
     if "sliding_window" in config.keys():
         sliding_window = config["sliding_window"]
+        if sliding_window is None:
+            sliding_window = 4096
     else:
         sliding_window = 0
 
@@ -633,6 +639,7 @@ if __name__ == "__main__":
         self_attn_type="scaled-dot",
         max_relative_positions=-1,
         rotary_interleave=False,
+        rotary_theta=rope_theta,
         heads=heads,
         sliding_window=sliding_window,
         transformer_ff=transformer_ff,


### PR DESCRIPTION
This PR does:
1) switch apex RMSNorm to awq_inference_engine RMSNorm which is much faster
2) add rotary_theta as an option (llama/mistral used to use 1e4 while Mixtral and mistralv0.2 use 1e6)
3) use flash2 flash_attn_with_kvcache instead of regular flash_attn_func for step > 0 (much faster to increment cache in place in certain cases)