### PR TITLE
Allow multiple response patterns in the insert_mask_before_placeholder transform

### DIFF
--- a/onmt/tests/test_transform.py
+++ b/onmt/tests/test_transform.py
@@ -788,7 +788,7 @@ class TestInsertMaskBeforePlaceholder(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.base_opts = {
-            "response_pattern": "Response : ｟newline｠",
+            "response_patterns": ["Response : ｟newline｠"],
         }
 
     def test_insert_mask_before_placeholder(self):


### PR DESCRIPTION
This PR enables multiple "response patterns" in LLM-like training examples (with prompt and response) for  multi-task finetuning.