### PR TITLE
Fix valid stats when we zero-out the prompt-loss

### DIFF
--- a/onmt/trainer.py
+++ b/onmt/trainer.py
@@ -401,6 +401,8 @@ class Trainer(object):
                     )
 
                     # Compute loss.
+                    if self.zero_out_prompt_loss:
+                        batch = self.valid_loss.ignore_prompt(batch)
                     _, batch_stats = self.valid_loss(batch, model_out, attns)
 
                     stats.update(batch_stats)


### PR DESCRIPTION
This PR applies the same logic to valid batches as to train batches when the zero-out-prompt-loss mechanism is activated.