### PR TITLE
Reset rotary embeddings for chained inference

### DIFF
--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -464,6 +464,12 @@ class MultiHeadedAttention(torch.nn.Module):
                     or query.dtype != torch.float16
                 ):
                     if self.max_relative_positions == -1:  # Rotary Embeddings
+                        if step == 0:
+                            self.rope, self.cos, self.sin = rotaryembeddings(
+                                self.rotary_dim,
+                                base=self.rotary_theta,
+                                device=self.rope.device,
+                            )
                         if seqlen + start_pos > self.rope.size(0):
                             # Resize rotary embeddings.
                             self.rope, self.cos, self.sin = rotaryembeddings(


### PR DESCRIPTION
This fix is necessary if we use multiple calls to inference methods of inference engines.