### PR TITLE
fixed masked flash attention

### DIFF
--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -487,7 +487,7 @@ class MultiHeadedAttention(torch.nn.Module):
                         x = key_pad_mask
                         x = x.expand(-1, self.head_count // self.parallel_gpu, -1)
                         x = x.unsqueeze(3)
-                        x = x.expand(-1, -1, -1, 128)
+                        x = x.expand(-1, -1, -1, value.size(3))
                         value = value.masked_fill(x, 0)
 
                     self.layer_cache[1]["keys"] = key

--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -483,6 +483,12 @@ class MultiHeadedAttention(torch.nn.Module):
                         if sliding_window > 0 and key.size(2) > sliding_window:
                             key = key[:, :, 1:, :]
                             value = value[:, :, 1:, :]
+                    if key_pad_mask is not None and step == 0:
+                        x = key_pad_mask
+                        x = x.expand(-1, self.head_count // self.parallel_gpu, -1)
+                        x = x.unsqueeze(3)
+                        x = x.expand(-1, -1, -1, 128)
+                        value = value.masked_fill(x, 0)
 
                     self.layer_cache[1]["keys"] = key
                     self.layer_cache[1]["values"] = value

--- a/onmt/modules/multi_headed_attn.py
+++ b/onmt/modules/multi_headed_attn.py
@@ -733,10 +733,6 @@ class MultiHeadedAttention(torch.nn.Module):
                 attn_output.add_(relative_matmul(drop_attn, relations_values, False))
 
         context = unshape(attn_output)
-        if key_pad_mask is not None:
-            if key_pad_mask.size(0) > 1 and context.size(1) > 1:
-                x = key_pad_mask.squeeze(1).unsqueeze(2).expand(-1, -1, context.size(2))
-                context = context.masked_fill(x, 0)
 
         if self.layer_cache[0]:
             attn_output = self.final_linear(context)


### PR DESCRIPTION
This PR proposes a fix for the flash attention path in the multi-head attention module.
The flash attention block doesn't support the left padding mask, so we apply it upstream.
https://github.com/Dao-AILab/flash-attention/issues/649

We apply  the `key_pad_mask` to the values contained in the KV-cache at the first step only, for all scenari (standard, flash, sdpa mechanisms).